### PR TITLE
❎ Do not process.exit(1) outside cli wrapper

### DIFF
--- a/.changeset/olive-moons-bow.md
+++ b/.changeset/olive-moons-bow.md
@@ -1,0 +1,5 @@
+---
+'curvenote': patch
+---
+
+Replace a process.exit(1) with error in exported function outside CLI

--- a/apps/cli/src/sync/clone.ts
+++ b/apps/cli/src/sync/clone.ts
@@ -26,7 +26,7 @@ export async function interactiveCloneQuestions(
   let project: Project | undefined;
   if (opts?.remote) {
     project = await validateLinkIsAProject(session, opts.remote);
-    if (!project) process.exit(1);
+    if (!project) throw new Error(`Invalid remote address: "${opts.remote}"`);
   } else {
     while (!project) {
       const { projectLink } = await inquirer.prompt([questions.projectLink()]);


### PR DESCRIPTION
The CLI should nicely `process.exit(1)` on failure, but exported functions should just throw an error.

This fixes a hang up when the launchpad `publish` action receives an invalid project. Without this, the process will just exit before the `failed` status is updated.