### PR TITLE
Tabs and MyST Demo support

### DIFF
--- a/.changeset/four-islands-attend.md
+++ b/.changeset/four-islands-attend.md
@@ -1,0 +1,10 @@
+---
+'curvenote': patch
+'@curvespace/default': patch
+'myst-util-to-react': patch
+'@curvenote/site': patch
+'@curvenote/ui-providers': patch
+---
+
+- `include` added as a directive
+- `tab-set` and `tab-item` added as directives

--- a/.changeset/long-eyes-compete.md
+++ b/.changeset/long-eyes-compete.md
@@ -1,0 +1,5 @@
+---
+'myst-util-to-react': patch
+---
+
+Node `abbr` is actually `abbreviation`, this was updated

--- a/.changeset/short-islands-speak.md
+++ b/.changeset/short-islands-speak.md
@@ -1,0 +1,7 @@
+---
+'curvenote': patch
+'@curvespace/default': patch
+'myst-util-to-react': patch
+---
+
+Added a MyST Demo Component

--- a/apps/cli/src/myst/directives.ts
+++ b/apps/cli/src/myst/directives.ts
@@ -385,6 +385,42 @@ const TabItem: IDirective = {
   hast: (h, node) => h(node, 'div', { class: 'margin' }),
 };
 
+const MystDemo: IDirective = {
+  myst: class MystDemo extends Directive {
+    public required_arguments = 0;
+
+    public optional_arguments = 0;
+
+    public final_argument_whitespace = false;
+
+    public has_content = true;
+
+    public option_spec = {};
+
+    run(data: IDirectiveData<keyof MystDemo['option_spec']>) {
+      const newTokens: Token[] = [];
+      const adToken = this.createToken('myst', 'div', 1, {
+        map: data.map,
+        block: true,
+        meta: { value: data.body },
+      });
+      newTokens.push(adToken);
+      return newTokens;
+    }
+  },
+  mdast: {
+    type: 'myst',
+    getAttrs(t) {
+      return {
+        value: t.meta.value,
+      };
+    },
+    noCloseToken: true,
+    isLeaf: true,
+  },
+  hast: (h, node) => h(node, 'div', { class: 'margin' }),
+};
+
 export const directives = {
   'r:var': RVar,
   mdast: Mdast,
@@ -399,4 +435,5 @@ export const directives = {
   tabSet: TabSet,
   'tab-item': TabItem,
   tabItem: TabItem,
+  myst: MystDemo,
 };

--- a/apps/cli/src/transforms/include.ts
+++ b/apps/cli/src/transforms/include.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import type { GenericNode } from 'mystjs';
+import { parseMyst, Root } from '../myst';
+import { selectAll } from 'mystjs';
+import { join, dirname } from 'path';
+import { ISession } from '../session';
+
+/**
+ * This is the {include} directive, that loads from disk.
+ *
+ * RST documentation:
+ *  - https://docutils.sourceforge.io/docs/ref/rst/directives.html#including-an-external-document-fragment
+ */
+export function includeFilesDirective(session: ISession, filename: string, mdast: Root) {
+  const includeNodes = selectAll('include', mdast) as GenericNode[];
+  const dir = dirname(filename);
+  includeNodes.forEach((node) => {
+    const file = join(dir, node.file);
+    if (!fs.existsSync(file)) {
+      session.log.error(`Include Directive: Could not find "${file}" in "${filename}"`);
+    }
+    const content = fs.readFileSync(file).toString();
+    const children = parseMyst(content).children as GenericNode[];
+    node.children = children;
+  });
+}

--- a/apps/cli/src/transforms/index.ts
+++ b/apps/cli/src/transforms/index.ts
@@ -1,3 +1,5 @@
+export { importMdastFromJson } from './mdast';
+export { includeFilesDirective } from './include';
 export { ensureBlockNesting } from './blocks';
 export { transformCitations } from './citations';
 export { transformLinkedDOIs } from './dois';

--- a/apps/cli/src/transforms/mdast.ts
+++ b/apps/cli/src/transforms/mdast.ts
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import type { GenericNode } from 'mystjs';
+import type { Root } from '../myst';
+import { selectAll } from 'mystjs';
+import { join, dirname } from 'path';
+import { ISession } from '../session';
+
+/**
+ * This is the {mdast} directive, that loads from disk
+ * For example, tables that can't be represented in markdown.
+ */
+export function importMdastFromJson(session: ISession, filename: string, mdast: Root) {
+  const mdastNodes = selectAll('mdast', mdast) as GenericNode[];
+  const loadedData: Record<string, GenericNode> = {};
+  const dir = dirname(filename);
+  mdastNodes.forEach((node) => {
+    const [mdastFilename, id] = node.id.split('#');
+    let data = loadedData[mdastFilename];
+    if (!data) {
+      data = JSON.parse(fs.readFileSync(join(dir, mdastFilename)).toString());
+      loadedData[mdastFilename] = data;
+    }
+    if (!data[id]) {
+      session.log.error(`Mdast Node import: Could not find ${id} in ${mdastFilename}`);
+      return;
+    }
+    // Clear the current object
+    Object.keys(node).forEach((k) => {
+      delete node[k];
+    });
+    // Replace with the import
+    Object.assign(node, data[id]);
+  });
+}

--- a/apps/web/app/config.json
+++ b/apps/web/app/config.json
@@ -30,7 +30,8 @@
         { "title": "Examples", "slug": "examples", "level": 2 },
         { "title": "Tables", "slug": "tables", "level": 2 },
         { "title": "Links", "slug": "links", "level": 2 },
-        { "title": "Math & Tabs", "slug": "math", "level": 2 }
+        { "title": "Math & Tabs", "slug": "math", "level": 2 },
+        { "title": "Commonmark", "slug": "commonmark", "level": 2 }
       ]
     }
   ]

--- a/apps/web/app/config.json
+++ b/apps/web/app/config.json
@@ -29,7 +29,8 @@
         { "title": "Juptyer Outputs", "slug": "outputs", "level": 2 },
         { "title": "Examples", "slug": "examples", "level": 2 },
         { "title": "Tables", "slug": "tables", "level": 2 },
-        { "title": "Links", "slug": "links", "level": 2 }
+        { "title": "Links", "slug": "links", "level": 2 },
+        { "title": "Math & Tabs", "slug": "math", "level": 2 }
       ]
     }
   ]

--- a/apps/web/app/content/demo/commonmark.json
+++ b/apps/web/app/content/demo/commonmark.json
@@ -1,0 +1,671 @@
+{
+  "kind": "Article",
+  "file": "features/commonmark.md",
+  "sha256": "6fc88b0dc8e965a509dd46ebcb3b686fc201414f0fc9b89614bb6bb582eb23de",
+  "slug": "commonmark",
+  "frontmatter": { "title": "CommonMark" },
+  "mdast": {
+    "type": "root",
+    "children": [
+      {
+        "type": "block",
+        "children": [
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "This page provides an overview of the types of block and inline markup features supported by CommonMark and MyST, with pointers to additional content of interest. For full details on all the nuance of these features, please look at the ",
+                "key": "AjRKlXIsgV"
+              },
+              {
+                "type": "link",
+                "url": "https://spec.commonmark.org/",
+                "children": [
+                  { "type": "text", "value": "CommonMark Spec documentation", "key": "ZD663WI15R" }
+                ],
+                "key": "e1F9qdHvGt"
+              },
+              { "type": "text", "value": ".", "key": "vi9ijRYThW" }
+            ],
+            "key": "Ex6KOjHHsk"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "MyST (Markedly Structured Text) was designed to make it easier to create publishable computational documents written with Markdown notation. It is a superset of ",
+                "key": "F0LkQ1Xv4j"
+              },
+              {
+                "type": "link",
+                "url": "https://commonmark.org/",
+                "children": [
+                  { "type": "text", "value": "CommonMark Markdown", "key": "kfs4U4yWZH" }
+                ],
+                "key": "BlN3eW3pA8"
+              },
+              {
+                "type": "text",
+                "value": " and draws heavy inspiration from ",
+                "key": "gAnr027STh"
+              },
+              {
+                "type": "link",
+                "url": "https://rmarkdown.rstudio.com/",
+                "children": [{ "type": "text", "value": "RMarkdown", "key": "IrIRsrCOjt" }],
+                "key": "yqJse7Q974"
+              },
+              {
+                "type": "text",
+                "value": " syntax. In addition to CommonMark, MyST also implements and extends ",
+                "key": "pNjLtKfV1B"
+              },
+              {
+                "type": "link",
+                "url": "https://github.com/syntax-tree/mdast",
+                "children": [{ "type": "text", "value": "mdast", "key": "zKsC1vGdLM" }],
+                "key": "xPGQTDs877"
+              },
+              {
+                "type": "text",
+                "value": ", which is a standard abstract syntax tree for Markdown. ",
+                "key": "J2kcR9FJrW"
+              },
+              { "type": "inlineCode", "value": "mdast", "key": "tNfhOboSvP" },
+              { "type": "text", "value": " is part of the ", "key": "S5J7efkK8V" },
+              {
+                "type": "link",
+                "url": "https://unifiedjs.com",
+                "children": [{ "type": "text", "value": "unifiedjs", "key": "qCJRCgCrZq" }],
+                "key": "rHrquVbbZb"
+              },
+              { "type": "text", "value": " community and has ", "key": "SkPXg9cjd3" },
+              {
+                "type": "link",
+                "url": "https://unifiedjs.com/explore/keyword/mdast/",
+                "children": [{ "type": "text", "value": "many utilities", "key": "Wk5VzfZF57" }],
+                "key": "Nou5YXuVGZ"
+              },
+              {
+                "type": "text",
+                "value": " for exporting and transforming your content.",
+                "key": "Hh9vfBAGD1"
+              }
+            ],
+            "key": "cmG6yF9cbG"
+          },
+          {
+            "type": "heading",
+            "depth": 2,
+            "children": [{ "type": "text", "value": "Block Markup", "key": "OjE2JJOzaY" }],
+            "enumerate": false,
+            "key": "Aqa9IdLlEb"
+          },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Headings", "key": "irZr2ejX5p" }],
+            "enumerate": false,
+            "key": "SgSaofj7p6"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "Markdown syntax denotes headers starting with between 1 to 6 ",
+                "key": "fF5g09jh3R"
+              },
+              { "type": "inlineCode", "value": "#", "key": "dSqqo8n3ka" },
+              {
+                "type": "text",
+                "value": ".\nFor example, a level 3 header looks like:",
+                "key": "qNaq084LfP"
+              }
+            ],
+            "key": "LE7ix6xT22"
+          },
+          {
+            "type": "myst",
+            "value": "### Heading Level 3\n\nTry changing the number of `#`s to change the `depth`.\n",
+            "key": "wYnYHxaU5x"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "An alternative syntax (called setext) is also supported for level 1 and 2 headers,\nby underlining using multiple ",
+                "key": "gSKnlq4d6T"
+              },
+              { "type": "inlineCode", "value": "===", "key": "HhBHT98f0G" },
+              { "type": "text", "value": " or ", "key": "wlMQNQFwll" },
+              { "type": "inlineCode", "value": "---", "key": "jmWEYshpRv" },
+              { "type": "text", "value": ". For example:", "key": "oMIwgikwmw" }
+            ],
+            "key": "kZeBabsd5M"
+          },
+          {
+            "type": "myst",
+            "value": "Heading 1\n=========\n\nHeading 2\n---------\n",
+            "key": "V5wPcLU8X2"
+          },
+          {
+            "type": "admonition",
+            "kind": "seealso",
+            "children": [
+              {
+                "type": "admonitionTitle",
+                "children": [{ "type": "text", "value": "See Also", "key": "a3c5lhiyvQ" }],
+                "key": "qLduVLws8t"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "Reference headings by preceding headers with a ",
+                    "key": "LbvAxaoFgB"
+                  },
+                  { "type": "inlineCode", "value": "(label)=", "key": "njoxqbTCfH" },
+                  { "type": "text", "value": ". See ", "key": "qjc8w3I1P1" },
+                  {
+                    "type": "link",
+                    "url": "/docs/references",
+                    "children": [],
+                    "key": "Oh6C6qXBaw",
+                    "urlSource": "./references.md",
+                    "internal": true
+                  },
+                  { "type": "text", "value": "!", "key": "hbne0gCCEa" }
+                ],
+                "key": "hZGLdVVXSk"
+              }
+            ],
+            "key": "u1hMxvu1dx"
+          },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Lists", "key": "q6xEfaJhVE" }],
+            "enumerate": false,
+            "key": "ZjO7dCOOIb"
+          },
+          {
+            "type": "paragraph",
+            "children": [{ "type": "text", "value": "Bullet points:", "key": "SOz1zJEwOW" }],
+            "key": "XtRwRlrTfo"
+          },
+          {
+            "type": "myst",
+            "value": "- headings\n- lists\n  - bullets\n  - numbers\n- code blocks\n",
+            "key": "KoGXBwGVHF"
+          },
+          {
+            "type": "paragraph",
+            "children": [{ "type": "text", "value": "Numbered items:", "key": "W0gA6zr6Ng" }],
+            "key": "ykW7DH5IUA"
+          },
+          { "type": "myst", "value": "1. quotes\n2. breaks\n3. links\n", "key": "kCiq03neWU" },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Code", "key": "kMmlodsijZ" }],
+            "enumerate": false,
+            "key": "qXCI3CCQJ4"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "Code blocks are enclosed in 3 or more ",
+                "key": "Zgk2oUZd9f"
+              },
+              { "type": "inlineCode", "value": "`", "key": "vsQiJYc71i" },
+              { "type": "text", "value": " or ", "key": "rtYBJrPvRZ" },
+              { "type": "inlineCode", "value": "~", "key": "jIqLDsc1Ff" },
+              { "type": "text", "value": " with an optional language name.", "key": "DpARYz23FD" }
+            ],
+            "key": "AGvFwWATpu"
+          },
+          {
+            "type": "myst",
+            "value": "```python\nprint('this is python')\n```\n",
+            "key": "CrM3fWEAc3"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "Indented paragraphs are also treated as literal text. This may be used for code or other preformatted text.",
+                "key": "JZRF2hM8uQ"
+              }
+            ],
+            "key": "ZrWgyR0dDg"
+          },
+          {
+            "type": "myst",
+            "value": "Some JSON:\n\n    {\n      'literal': '*text*'\n    }\n",
+            "key": "dVXf6Ys2OC"
+          },
+          {
+            "type": "admonition",
+            "kind": "seealso",
+            "children": [
+              {
+                "type": "admonitionTitle",
+                "children": [{ "type": "text", "value": "See Also", "key": "hZTlL4ctdn" }],
+                "key": "dKi4MQBaz4"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "Create code-blocks with additional highlighting using the ",
+                    "key": "FdM0LRpYPo"
+                  },
+                  { "type": "inlineCode", "value": "code-block", "key": "vH2mGy0toy" },
+                  { "type": "text", "value": " directive. See more here!", "key": "yz5CEvFrzP" }
+                ],
+                "key": "xq9B0DEYGd"
+              }
+            ],
+            "key": "RxyViwCKyG"
+          },
+          {
+            "type": "mystComment",
+            "value": "TODO: provide a link!\n TODO: myst: implement code-block",
+            "key": "zUOrOVcmCB"
+          },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Quotes", "key": "HNiXzSx8bJ" }],
+            "enumerate": false,
+            "key": "AK8WAy1Kiv"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              { "type": "text", "value": "Quote blocks are prepended with ", "key": "HAwW9xPHyg" },
+              { "type": "inlineCode", "value": ">", "key": "tHuaLYlHbg" },
+              { "type": "text", "value": ":", "key": "E9d3IFwZVe" }
+            ],
+            "key": "JwW9eJBlok"
+          },
+          { "type": "myst", "value": "> Super profound quote\n", "key": "bP0uKZBG5R" },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Thematic Break", "key": "AfkZyZn8W0" }],
+            "enumerate": false,
+            "key": "MapiGagcx1"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "Create a horizontal line in the output",
+                "key": "hhMwKVgDbk"
+              }
+            ],
+            "key": "JSAlnWiTmn"
+          },
+          { "type": "myst", "value": "Section 1\n\n---\n\nSection 2\n", "key": "MMwKosb5k4" },
+          {
+            "type": "admonition",
+            "kind": "seealso",
+            "children": [
+              {
+                "type": "admonitionTitle",
+                "children": [{ "type": "text", "value": "See Also", "key": "DGIcO1ij3T" }],
+                "key": "yecvZmGd38"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "Thematic breaks should not be confused with MyST ",
+                    "key": "hvFi2NfZUm"
+                  },
+                  {
+                    "type": "link",
+                    "url": "/docs/blocks",
+                    "children": [{ "type": "text", "value": "block syntax", "key": "mLePfOocdp" }],
+                    "key": "JjwzamOqyc",
+                    "urlSource": "./blocks.md",
+                    "internal": true
+                  },
+                  {
+                    "type": "text",
+                    "value": ",\nwhich is used to structurally seperate content.",
+                    "key": "GGHxFaKQwZ"
+                  }
+                ],
+                "key": "f6ynRBz3Eu"
+              }
+            ],
+            "key": "bPqjON174u"
+          },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Link Definitions", "key": "zQNqtWeWif" }],
+            "enumerate": false,
+            "key": "IK0IyNU60a"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "Links may be defined outside of text with a reference target (no spaces) and an optional title.",
+                "key": "A7oTXfkC9b"
+              }
+            ],
+            "key": "aJwkyCjuOR"
+          },
+          {
+            "type": "myst",
+            "value": "[This is a link defined elsewhere!][key]\n\n[key]: https://www.google.com 'a title'\n",
+            "key": "H1SVlP8kzt"
+          },
+          {
+            "type": "admonition",
+            "kind": "seealso",
+            "children": [
+              {
+                "type": "admonitionTitle",
+                "children": [{ "type": "text", "value": "See Also", "key": "gXf2qeQO49" }],
+                "key": "oOsT5cwuGa"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  { "type": "text", "value": "These can be used in ", "key": "shVQ9tNRxh" },
+                  {
+                    "type": "crossReference",
+                    "children": [{ "type": "text", "value": "Inline links", "key": "kLwawHGo7I" }],
+                    "kind": "ref",
+                    "identifier": "inline-links",
+                    "label": "inline-links",
+                    "resolved": true,
+                    "key": "Yyz27jMFkx"
+                  },
+                  { "type": "text", "value": " and are similar to ", "key": "TBYCqcPXKH" },
+                  {
+                    "type": "link",
+                    "url": "/docs/references",
+                    "children": [],
+                    "key": "faTYrCdbWS",
+                    "urlSource": "./references.md",
+                    "internal": true
+                  },
+                  {
+                    "type": "text",
+                    "value": " in MyST.\nThis syntax is also similar to ",
+                    "key": "dYLXLLiTHB"
+                  },
+                  {
+                    "type": "link",
+                    "url": "/docs/footnotes",
+                    "children": [],
+                    "key": "sUP68BPnz5",
+                    "urlSource": "./footnotes.md",
+                    "internal": true
+                  },
+                  { "type": "text", "value": ".", "key": "D5Uxh2iAEG" }
+                ],
+                "key": "pUZQCFtq2X"
+              }
+            ],
+            "key": "wH3lKTzi6F"
+          },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Paragraph", "key": "RBlD1aGQpg" }],
+            "enumerate": false,
+            "key": "GIVLM2Gypn"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "Any text that does not belong to another block is simply a paragraph:",
+                "key": "jZEtJAKKZl"
+              }
+            ],
+            "key": "amBgJycKmD"
+          },
+          { "type": "myst", "value": "any _text_\n", "key": "WujeHslZc8" },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Valid HTML", "key": "eTnWbiryrq" }],
+            "enumerate": false,
+            "key": "StKxh6lqhE"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "Any valid HTML may also be included in a MyST document and rendered to HTML. However, you must set the option ",
+                "key": "u6AREmcqVl"
+              },
+              { "type": "inlineCode", "value": "allowDangerousHtml: true", "key": "wQNk099Af0" },
+              { "type": "text", "value": " in the MyST parser.", "key": "EFIJ6rhmNv" }
+            ],
+            "key": "BTXB1oPqCf"
+          },
+          {
+            "type": "heading",
+            "depth": 2,
+            "children": [{ "type": "text", "value": "Inline Markup", "key": "Qxq8wbXMPC" }],
+            "enumerate": false,
+            "key": "n6qklYRq6Y"
+          },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Inline links", "key": "xj6Dw2mj0T" }],
+            "identifier": "inline-links",
+            "label": "inline-links",
+            "enumerate": false,
+            "key": "siwQ1D1sAZ"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "Auto-link where link itself is shown in final output:",
+                "key": "uIyL0iQTLe"
+              }
+            ],
+            "key": "yzhAkvgIkv"
+          },
+          {
+            "type": "myst",
+            "value": "Search engine: <https://www.google.com>\n",
+            "key": "zFaEaKjaS5"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "Link with alternative text and optional title:",
+                "key": "iFLAwUh2JK"
+              }
+            ],
+            "key": "bSAR9KvqGr"
+          },
+          {
+            "type": "myst",
+            "value": "[search engine](https://www.google.com \"Google\")\n",
+            "key": "DUx4mfwfho"
+          },
+          {
+            "type": "admonition",
+            "kind": "seealso",
+            "children": [
+              {
+                "type": "admonitionTitle",
+                "children": [{ "type": "text", "value": "See Also", "key": "D5Ak62DzUY" }],
+                "key": "BVGWF2EEg5"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "link",
+                    "url": "/docs/references",
+                    "children": [],
+                    "key": "jrYYMaEwXC",
+                    "urlSource": "./references.md",
+                    "internal": true
+                  },
+                  {
+                    "type": "text",
+                    "value": " provides other ways to reference inline content.",
+                    "key": "uAjVMtwwmP"
+                  }
+                ],
+                "key": "cJMnJP5MO4"
+              }
+            ],
+            "key": "rAiSeGe3uN"
+          },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Inline images", "key": "xDr0IOljdj" }],
+            "enumerate": false,
+            "key": "t1V9qXD5Dz"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "Link to an image can be done similar to other inline links, or you may use HTML syntax to include image size, etc.",
+                "key": "sSKKjg8EuU"
+              }
+            ],
+            "key": "UuIwYrW6Rv"
+          },
+          {
+            "type": "myst",
+            "value": "![alt](https://source.unsplash.com/random/500x200/?fruit \"title\")\n",
+            "key": "yQ0pCL757B"
+          },
+          {
+            "type": "admonition",
+            "kind": "seealso",
+            "children": [
+              {
+                "type": "admonitionTitle",
+                "children": [{ "type": "text", "value": "See Also", "key": "gaAJLMDpvN" }],
+                "key": "mOMR3e9r8C"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "link",
+                    "url": "/docs/figures",
+                    "children": [],
+                    "key": "Bfvi6AY1yh",
+                    "urlSource": "./figures.md",
+                    "internal": true
+                  },
+                  {
+                    "type": "text",
+                    "value": " provides other ways to size, label, and caption images.",
+                    "key": "eda8OfxjBs"
+                  }
+                ],
+                "key": "DbD79ZeOcO"
+              }
+            ],
+            "key": "KlyNFnn4x1"
+          },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Text formatting", "key": "x9NFJsUbmp" }],
+            "enumerate": false,
+            "key": "E2FinQSp20"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "Standard inline formatting including bold, italic, code, as well as escaped symbols and line breaks:",
+                "key": "fkqZFAkteV"
+              }
+            ],
+            "key": "RQpwLwbVjJ"
+          },
+          {
+            "type": "myst",
+            "value": "**strong**, _emphasis_, `literal text`, \\*escaped symbols\\*, a hard\\\nbreak\n",
+            "key": "OzjR3pQvOb"
+          },
+          {
+            "type": "admonition",
+            "kind": "seealso",
+            "children": [
+              {
+                "type": "admonitionTitle",
+                "children": [{ "type": "text", "value": "See Also", "key": "VLI8pkJydY" }],
+                "key": "mWuKpirsVP"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "link",
+                    "url": "/docs/basic",
+                    "children": [],
+                    "key": "qrh6FWOvLo",
+                    "urlSource": "./basic.md",
+                    "internal": true
+                  },
+                  {
+                    "type": "text",
+                    "value": " provides other roles for subscript, superscript, abbeviations, and other text formating.",
+                    "key": "DmfcH1YrTM"
+                  }
+                ],
+                "key": "lZETqhoo4G"
+              }
+            ],
+            "key": "tpzzSb9vYm"
+          }
+        ],
+        "key": "cDpiJ4PVnt"
+      }
+    ],
+    "key": "iNmf0bazYN"
+  },
+  "references": { "cite": { "order": [], "data": {} }, "footnotes": {} },
+  "footer": {
+    "navigation": {
+      "prev": { "title": "Overview", "url": "/docs/overview", "group": "MyST Spec" },
+      "next": { "title": "Admonitions", "url": "/docs/admonitions", "group": "MyST Spec" }
+    }
+  },
+  "domain": "http://localhost:3000"
+}

--- a/apps/web/app/content/demo/math.json
+++ b/apps/web/app/content/demo/math.json
@@ -1,0 +1,569 @@
+{
+  "kind": "Article",
+  "file": "features/math.md",
+  "sha256": "74ebe5e88cc1ff8b4df49f2431a6e9b33cb5eaba2105ed009726f679e8bfe182",
+  "slug": "math",
+  "frontmatter": { "title": "Math & Equations" },
+  "mdast": {
+    "type": "root",
+    "children": [
+      {
+        "type": "block",
+        "children": [
+          {
+            "type": "heading",
+            "depth": 2,
+            "children": [{ "type": "text", "value": "Math Node", "key": "GJmipBgtp7" }],
+            "enumerate": false,
+            "key": "iGOJJkR7LI"
+          },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Specification", "key": "yXG3YISs2H" }],
+            "enumerate": false,
+            "key": "PGU5TzSmbu"
+          },
+          {
+            "type": "include",
+            "file": "../nodes/math.md",
+            "children": [
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "Math node for presenting numbered equations",
+                    "key": "RGd3NEHfql"
+                  }
+                ],
+                "key": "CcxPVg5lZu"
+              },
+              {
+                "type": "list",
+                "ordered": false,
+                "spread": false,
+                "children": [
+                  {
+                    "type": "listItem",
+                    "spread": true,
+                    "children": [
+                      {
+                        "type": "strong",
+                        "children": [{ "type": "text", "value": "type*", "key": "BNdPmNpaZP" }],
+                        "key": "gIQ3ei3TL9"
+                      },
+                      { "type": "text", "value": ": ", "key": "wDhHU1SJJd" },
+                      {
+                        "type": "emphasis",
+                        "children": [{ "type": "text", "value": "string", "key": "Z75LANEB9m" }],
+                        "key": "RMH8klHnNw"
+                      },
+                      { "type": "text", "value": " (\"math\") - See ", "key": "z83nVhl0A3" },
+                      {
+                        "type": "crossReference",
+                        "kind": "ref",
+                        "identifier": "node",
+                        "label": "node",
+                        "key": "qAvoUBR1bX"
+                      }
+                    ],
+                    "key": "iWCuszXXHy"
+                  },
+                  {
+                    "type": "listItem",
+                    "spread": true,
+                    "children": [
+                      {
+                        "type": "strong",
+                        "children": [
+                          { "type": "text", "value": "enumerated", "key": "L9CSFHVPl5" }
+                        ],
+                        "key": "KoWUPjiqkh"
+                      },
+                      { "type": "text", "value": ": ", "key": "MxJy0WIOYM" },
+                      {
+                        "type": "emphasis",
+                        "children": [{ "type": "text", "value": "boolean", "key": "KZriYqXZM3" }],
+                        "key": "D7HNkuukSz"
+                      },
+                      {
+                        "type": "text",
+                        "value": " - count this math block for numbering based on kind, e.g. See equation (1a)",
+                        "key": "IYa1AaLZdh"
+                      }
+                    ],
+                    "key": "Rc75x356PB"
+                  },
+                  {
+                    "type": "listItem",
+                    "spread": true,
+                    "children": [
+                      {
+                        "type": "strong",
+                        "children": [
+                          { "type": "text", "value": "enumerator", "key": "eDwBKByurj" }
+                        ],
+                        "key": "II9tbo2abN"
+                      },
+                      { "type": "text", "value": ": ", "key": "RLsri3YS5b" },
+                      {
+                        "type": "emphasis",
+                        "children": [{ "type": "text", "value": "string", "key": "bcTIuPn1n7" }],
+                        "key": "OWVvHs1b9H"
+                      },
+                      {
+                        "type": "text",
+                        "value": " - resolved enumerated value for this math block",
+                        "key": "puYhYG3wKV"
+                      }
+                    ],
+                    "key": "tVSrA2pKSF"
+                  },
+                  {
+                    "type": "listItem",
+                    "spread": true,
+                    "children": [
+                      {
+                        "type": "strong",
+                        "children": [
+                          { "type": "text", "value": "identifier", "key": "upJTu5f0L8" }
+                        ],
+                        "key": "rlk0guECpo"
+                      },
+                      { "type": "text", "value": ": ", "key": "ssIgs92Ibz" },
+                      {
+                        "type": "emphasis",
+                        "children": [{ "type": "text", "value": "string", "key": "RnpP4ObvmI" }],
+                        "key": "N4TqAbPlvT"
+                      },
+                      { "type": "text", "value": " - See ", "key": "gz542oGOG2" },
+                      {
+                        "type": "crossReference",
+                        "kind": "ref",
+                        "identifier": "optionalassociation",
+                        "label": "optionalassociation",
+                        "key": "uu9N3DLfVm"
+                      }
+                    ],
+                    "key": "t66iNl4bhF"
+                  },
+                  {
+                    "type": "listItem",
+                    "spread": true,
+                    "children": [
+                      {
+                        "type": "strong",
+                        "children": [{ "type": "text", "value": "label", "key": "pUp1xxCTPB" }],
+                        "key": "LtMwuwhuCc"
+                      },
+                      { "type": "text", "value": ": ", "key": "d7mH9tyEK3" },
+                      {
+                        "type": "emphasis",
+                        "children": [{ "type": "text", "value": "string", "key": "Wcv9E1tw0b" }],
+                        "key": "XQB3HrwGtm"
+                      },
+                      { "type": "text", "value": " - See ", "key": "ciEzdBbI6R" },
+                      {
+                        "type": "crossReference",
+                        "kind": "ref",
+                        "identifier": "optionalassociation",
+                        "label": "optionalassociation",
+                        "key": "AmxEvyvKO4"
+                      }
+                    ],
+                    "key": "p9PvY1leYc"
+                  },
+                  {
+                    "type": "listItem",
+                    "spread": true,
+                    "children": [
+                      {
+                        "type": "strong",
+                        "children": [{ "type": "text", "value": "value*", "key": "ntTUDtQgmP" }],
+                        "key": "RfnG2iU3EP"
+                      },
+                      { "type": "text", "value": ": ", "key": "Fu8m1t8ilz" },
+                      {
+                        "type": "emphasis",
+                        "children": [{ "type": "text", "value": "string", "key": "s3IK79fMi9" }],
+                        "key": "Ga10lwsXPW"
+                      },
+                      { "type": "text", "value": " - See ", "key": "L5qPROfV8U" },
+                      {
+                        "type": "crossReference",
+                        "kind": "ref",
+                        "identifier": "literal",
+                        "label": "literal",
+                        "key": "xJPGwKt37f"
+                      }
+                    ],
+                    "key": "kXetHGgbrn"
+                  },
+                  {
+                    "type": "listItem",
+                    "spread": true,
+                    "children": [
+                      {
+                        "type": "strong",
+                        "children": [{ "type": "text", "value": "position", "key": "IwdgMMa6HR" }],
+                        "key": "NCsNMWvCxC"
+                      },
+                      { "type": "text", "value": ": ", "key": "JjrswPrj4N" },
+                      {
+                        "type": "emphasis",
+                        "children": [{ "type": "text", "value": "object", "key": "E9AUe5sW7x" }],
+                        "key": "SxWLodnYyW"
+                      },
+                      { "type": "text", "value": " (", "key": "XcEMccmGKn" },
+                      {
+                        "type": "crossReference",
+                        "kind": "ref",
+                        "identifier": "position",
+                        "label": "position",
+                        "key": "cx1QtPkFyd"
+                      },
+                      { "type": "text", "value": ") - See ", "key": "tJQHYcoAtH" },
+                      {
+                        "type": "crossReference",
+                        "kind": "ref",
+                        "identifier": "node",
+                        "label": "node",
+                        "key": "jrWL30Z0WU"
+                      }
+                    ],
+                    "key": "xlYJ6FNcFA"
+                  },
+                  {
+                    "type": "listItem",
+                    "spread": true,
+                    "children": [
+                      {
+                        "type": "strong",
+                        "children": [{ "type": "text", "value": "data", "key": "p4UO0lHFPo" }],
+                        "key": "F2MCqqXhDW"
+                      },
+                      { "type": "text", "value": ": ", "key": "wSFMCigYsY" },
+                      {
+                        "type": "emphasis",
+                        "children": [{ "type": "text", "value": "object", "key": "RpWC5E3Sgl" }],
+                        "key": "lkxvhsvJxY"
+                      },
+                      { "type": "text", "value": " - See ", "key": "fG7Aw6dKeO" },
+                      {
+                        "type": "crossReference",
+                        "kind": "ref",
+                        "identifier": "node",
+                        "label": "node",
+                        "key": "HBe15Ky4jq"
+                      }
+                    ],
+                    "key": "dqaKohb59L"
+                  }
+                ],
+                "key": "TCDUWLrYOU"
+              }
+            ],
+            "key": "Bibyvil9sR"
+          },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Example", "key": "F8XWH973Ky" }],
+            "enumerate": false,
+            "key": "cQvcmIQVlY"
+          },
+          {
+            "type": "include",
+            "file": "../examples/math.md",
+            "children": [
+              {
+                "type": "tabSet",
+                "children": [
+                  {
+                    "type": "tabItem",
+                    "title": "Markup",
+                    "sync": "myst",
+                    "children": [
+                      {
+                        "type": "code",
+                        "lang": "",
+                        "value": "```{math}\n:label: matrix\nAx = b\n```",
+                        "key": "LtTNXxizL4"
+                      }
+                    ],
+                    "key": "KFSYwJkqG6"
+                  },
+                  {
+                    "type": "tabItem",
+                    "title": "AST",
+                    "sync": "ast",
+                    "children": [
+                      {
+                        "type": "code",
+                        "lang": "yaml",
+                        "value": "type: root\nchildren:\n  - type: mystDirective\n    name: math\n    options:\n      label: matrix\n    value: Ax = b\n    children:\n      - type: math\n        identifier: matrix\n        label: matrix\n        value: Ax = b\n",
+                        "key": "SJ6dcPEuNI"
+                      }
+                    ],
+                    "key": "iWqzjw7zLy"
+                  },
+                  {
+                    "type": "tabItem",
+                    "title": "Render",
+                    "sync": "render",
+                    "children": [
+                      {
+                        "type": "math",
+                        "identifier": "matrix",
+                        "label": "matrix",
+                        "value": "Ax = b",
+                        "enumerator": "1",
+                        "html": "<span class=\"katex-display\"><span class=\"katex\"><span class=\"katex-mathml\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\"><semantics><mrow><mi>A</mi><mi>x</mi><mo>=</mo><mi>b</mi></mrow><annotation encoding=\"application/x-tex\">Ax = b</annotation></semantics></math></span><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:0.6833em;\"></span><span class=\"mord mathnormal\">A</span><span class=\"mord mathnormal\">x</span><span class=\"mspace\" style=\"margin-right:0.2778em;\"></span><span class=\"mrel\">=</span><span class=\"mspace\" style=\"margin-right:0.2778em;\"></span></span><span class=\"base\"><span class=\"strut\" style=\"height:0.6944em;\"></span><span class=\"mord mathnormal\">b</span></span></span></span></span>",
+                        "key": "VSaN1F1ZCn"
+                      }
+                    ],
+                    "key": "OCpphOeafe"
+                  }
+                ],
+                "key": "zMYhZB5tk2"
+              }
+            ],
+            "key": "pxAZYxAluu"
+          },
+          {
+            "type": "heading",
+            "depth": 2,
+            "children": [{ "type": "text", "value": "Inline Math Node", "key": "qgWCW6df2v" }],
+            "enumerate": false,
+            "key": "CjJrwXhsiF"
+          },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Specification", "key": "e73IZ5jMHt" }],
+            "enumerate": false,
+            "key": "kDNd1x0nhk"
+          },
+          {
+            "type": "include",
+            "file": "../nodes/inlinemath.md",
+            "children": [
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "Fragment of math, similar to InlineCode, using role {math}",
+                    "key": "aIyAts5mXO"
+                  }
+                ],
+                "key": "HOjn6aEP3q"
+              },
+              {
+                "type": "list",
+                "ordered": false,
+                "spread": false,
+                "children": [
+                  {
+                    "type": "listItem",
+                    "spread": true,
+                    "children": [
+                      {
+                        "type": "strong",
+                        "children": [{ "type": "text", "value": "type*", "key": "IOctk8pbog" }],
+                        "key": "BircbJCYvQ"
+                      },
+                      { "type": "text", "value": ": ", "key": "Q48ZQ7YQ4x" },
+                      {
+                        "type": "emphasis",
+                        "children": [{ "type": "text", "value": "string", "key": "JFTyYjJ5kX" }],
+                        "key": "bm7JIgK6fN"
+                      },
+                      { "type": "text", "value": " (\"inlineMath\") - See ", "key": "EGilcvymsU" },
+                      {
+                        "type": "crossReference",
+                        "kind": "ref",
+                        "identifier": "node",
+                        "label": "node",
+                        "key": "RBdK7BqSOq"
+                      }
+                    ],
+                    "key": "IVdbI1bVSp"
+                  },
+                  {
+                    "type": "listItem",
+                    "spread": true,
+                    "children": [
+                      {
+                        "type": "strong",
+                        "children": [{ "type": "text", "value": "value*", "key": "rAGBR7v5rQ" }],
+                        "key": "lA441ziTaH"
+                      },
+                      { "type": "text", "value": ": ", "key": "JcP5V03lmM" },
+                      {
+                        "type": "emphasis",
+                        "children": [{ "type": "text", "value": "string", "key": "yLLITopgkn" }],
+                        "key": "kbHhxSTwaf"
+                      },
+                      { "type": "text", "value": " - See ", "key": "dOpJjjaw2M" },
+                      {
+                        "type": "crossReference",
+                        "kind": "ref",
+                        "identifier": "literal",
+                        "label": "literal",
+                        "key": "qRryMsx9lk"
+                      }
+                    ],
+                    "key": "a5YnClY6Uw"
+                  },
+                  {
+                    "type": "listItem",
+                    "spread": true,
+                    "children": [
+                      {
+                        "type": "strong",
+                        "children": [{ "type": "text", "value": "position", "key": "gAFS6K9k5Z" }],
+                        "key": "tjNIdG2bfv"
+                      },
+                      { "type": "text", "value": ": ", "key": "BJ3K2A6hiV" },
+                      {
+                        "type": "emphasis",
+                        "children": [{ "type": "text", "value": "object", "key": "LfpKY17YZp" }],
+                        "key": "C1E69daJHu"
+                      },
+                      { "type": "text", "value": " (", "key": "Y7wURE7tJs" },
+                      {
+                        "type": "crossReference",
+                        "kind": "ref",
+                        "identifier": "position",
+                        "label": "position",
+                        "key": "wC5ftdmLP7"
+                      },
+                      { "type": "text", "value": ") - See ", "key": "hKTcOR8tJq" },
+                      {
+                        "type": "crossReference",
+                        "kind": "ref",
+                        "identifier": "node",
+                        "label": "node",
+                        "key": "QI67ywmjz4"
+                      }
+                    ],
+                    "key": "A0pLhjzcjW"
+                  },
+                  {
+                    "type": "listItem",
+                    "spread": true,
+                    "children": [
+                      {
+                        "type": "strong",
+                        "children": [{ "type": "text", "value": "data", "key": "SL6I7fksr4" }],
+                        "key": "wpotYPzyYD"
+                      },
+                      { "type": "text", "value": ": ", "key": "TuFoE3zPGa" },
+                      {
+                        "type": "emphasis",
+                        "children": [{ "type": "text", "value": "object", "key": "oJMd7AbEdo" }],
+                        "key": "nz8BgmF5sZ"
+                      },
+                      { "type": "text", "value": " - See ", "key": "maA7yI0vmV" },
+                      {
+                        "type": "crossReference",
+                        "kind": "ref",
+                        "identifier": "node",
+                        "label": "node",
+                        "key": "WY1w2fYDsF"
+                      }
+                    ],
+                    "key": "YoQqVNdq6K"
+                  }
+                ],
+                "key": "oUILQO47bL"
+              }
+            ],
+            "key": "fZ3c2WUmPp"
+          },
+          {
+            "type": "heading",
+            "depth": 3,
+            "children": [{ "type": "text", "value": "Example", "key": "ez89Ih4Dg8" }],
+            "enumerate": false,
+            "key": "MIkPE8AkXw"
+          },
+          {
+            "type": "include",
+            "file": "../examples/inlinemath.md",
+            "children": [
+              {
+                "type": "tabSet",
+                "children": [
+                  {
+                    "type": "tabItem",
+                    "title": "Markup",
+                    "sync": "myst",
+                    "children": [
+                      {
+                        "type": "code",
+                        "lang": "",
+                        "value": "This is genius {math}`e=mc^2`",
+                        "key": "jXLsH58nig"
+                      }
+                    ],
+                    "key": "Pm3KLOElvn"
+                  },
+                  {
+                    "type": "tabItem",
+                    "title": "AST",
+                    "sync": "ast",
+                    "children": [
+                      {
+                        "type": "code",
+                        "lang": "yaml",
+                        "value": "type: root\nchildren:\n  - type: paragraph\n    children:\n      - type: text\n        value: 'This is genius '\n      - type: mystRole\n        name: math\n        value: e=mc^2\n        children:\n          - type: inlineMath\n            value: e=mc^2\n",
+                        "key": "t9EGBMwu95"
+                      }
+                    ],
+                    "key": "SjXMJLmWNB"
+                  },
+                  {
+                    "type": "tabItem",
+                    "title": "Render",
+                    "sync": "render",
+                    "children": [
+                      {
+                        "type": "paragraph",
+                        "children": [
+                          { "type": "text", "value": "This is genius ", "key": "bnnShD1mUZ" },
+                          {
+                            "type": "inlineMath",
+                            "value": "e=mc^2",
+                            "html": "<span class=\"katex\"><span class=\"katex-mathml\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\"><semantics><mrow><mi>e</mi><mo>=</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding=\"application/x-tex\">e=mc^2</annotation></semantics></math></span><span class=\"katex-html\" aria-hidden=\"true\"><span class=\"base\"><span class=\"strut\" style=\"height:0.4306em;\"></span><span class=\"mord mathnormal\">e</span><span class=\"mspace\" style=\"margin-right:0.2778em;\"></span><span class=\"mrel\">=</span><span class=\"mspace\" style=\"margin-right:0.2778em;\"></span></span><span class=\"base\"><span class=\"strut\" style=\"height:0.8141em;\"></span><span class=\"mord mathnormal\">m</span><span class=\"mord\"><span class=\"mord mathnormal\">c</span><span class=\"msupsub\"><span class=\"vlist-t\"><span class=\"vlist-r\"><span class=\"vlist\" style=\"height:0.8141em;\"><span style=\"top:-3.063em;margin-right:0.05em;\"><span class=\"pstrut\" style=\"height:2.7em;\"></span><span class=\"sizing reset-size6 size3 mtight\"><span class=\"mord mtight\">2</span></span></span></span></span></span></span></span></span></span></span>",
+                            "key": "Twfv9zpjl7"
+                          }
+                        ],
+                        "key": "B9xn4AR2vN"
+                      }
+                    ],
+                    "key": "Kevcd3V8TA"
+                  }
+                ],
+                "key": "WZUeDEjUL7"
+              }
+            ],
+            "key": "g3Zs32ycNK"
+          }
+        ],
+        "key": "eiUWjwjE0J"
+      }
+    ],
+    "key": "HTtH9u6W3X"
+  },
+  "references": { "cite": { "order": [], "data": {} }, "footnotes": {} },
+  "footer": {
+    "navigation": {
+      "prev": { "title": "Tables", "url": "/docs/tables", "group": "MyST Spec" },
+      "next": { "title": "References & Links", "url": "/docs/references", "group": "MyST Spec" }
+    }
+  },
+  "domain": "http://localhost:3000"
+}

--- a/apps/web/styles/app.css
+++ b/apps/web/styles/app.css
@@ -18,6 +18,12 @@
   .prose table tr:hover td {
     @apply bg-slate-50 dark:bg-stone-800;
   }
+  .prose dt {
+    @apply font-bold text-blue-900 dark:text-blue-100;
+  }
+  .prose dd {
+    @apply ml-8;
+  }
   article.content {
     min-height: calc(100vh);
   }

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -14,6 +14,7 @@ module.exports = {
       colors: {
         primary: colors.blue,
         success: colors.green[500],
+        'curvenote-blue': '#225f9c',
       },
       // See https://github.com/tailwindlabs/tailwindcss-typography/blob/master/src/styles.js
       typography: (theme) => ({

--- a/packages/myst-util-to-react/src/CopyIcon.tsx
+++ b/packages/myst-util-to-react/src/CopyIcon.tsx
@@ -1,0 +1,40 @@
+import DuplicateIcon from '@heroicons/react/outline/DuplicateIcon';
+import CheckIcon from '@heroicons/react/outline/CheckIcon';
+import { useState } from 'react';
+import classNames from 'classnames';
+
+export function CopyIcon({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  if (typeof document === 'undefined' || !navigator.clipboard) {
+    return null;
+  }
+  const onClick = () => {
+    if (copied) return;
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 3000);
+    });
+  };
+  return (
+    <button
+      title={copied ? 'Copied!!' : 'Copy to Clipboard'}
+      className={classNames(
+        'inline-flex items-center opacity-60 hover:opacity-100 active:opacity-40 cursor-pointer ml-2',
+        'transition-color duration-200 ease-in-out',
+        {
+          'text-primary-500 border-primary-500': !copied,
+          'text-success border-success ': copied,
+        },
+      )}
+      onClick={onClick}
+      aria-pressed={copied ? 'true' : 'false'}
+      aria-label="Copy code to clipboard"
+    >
+      {copied ? (
+        <CheckIcon className="w-[24px] h-[24px] text-success" />
+      ) : (
+        <DuplicateIcon className="w-[24px] h-[24px]" />
+      )}
+    </button>
+  );
+}

--- a/packages/myst-util-to-react/src/basic.tsx
+++ b/packages/myst-util-to-react/src/basic.tsx
@@ -45,7 +45,7 @@ type BasicNodeRenderers = {
   thematicBreak: NodeRenderer<spec.ThematicBreak>;
   subscript: NodeRenderer<spec.Subscript>;
   superscript: NodeRenderer<spec.Superscript>;
-  abbr: NodeRenderer<spec.Abbreviation>;
+  abbreviation: NodeRenderer<spec.Abbreviation>;
   // Tables
   table: NodeRenderer<spec.Table>;
   tableRow: NodeRenderer<spec.TableRow>;
@@ -162,7 +162,7 @@ const BASIC_RENDERERS: BasicNodeRenderers = {
   superscript(node, children) {
     return <sup key={node.key}>{children}</sup>;
   },
-  abbr(node, children) {
+  abbreviation(node, children) {
     return (
       <abbr key={node.key} title={node.title}>
         {children}

--- a/packages/myst-util-to-react/src/basic.tsx
+++ b/packages/myst-util-to-react/src/basic.tsx
@@ -29,6 +29,18 @@ type SmallCaps = {
   type: 'smallcaps';
 };
 
+type DefinitionList = {
+  type: 'definitionList';
+};
+
+type DefinitionTerm = {
+  type: 'definitionTerm';
+};
+
+type DefinitionDescription = {
+  type: 'definitionDescription';
+};
+
 type BasicNodeRenderers = {
   strong: NodeRenderer<spec.Strong>;
   emphasis: NodeRenderer<spec.Emphasis>;
@@ -58,6 +70,10 @@ type BasicNodeRenderers = {
   strike: NodeRenderer<Strike>;
   underline: NodeRenderer<Underline>;
   smallcaps: NodeRenderer<SmallCaps>;
+  // definitions
+  definitionList: NodeRenderer<DefinitionList>;
+  definitionTerm: NodeRenderer<DefinitionTerm>;
+  definitionDescription: NodeRenderer<DefinitionDescription>;
 };
 
 const BASIC_RENDERERS: BasicNodeRenderers = {
@@ -174,6 +190,15 @@ const BASIC_RENDERERS: BasicNodeRenderers = {
   },
   comment() {
     return null;
+  },
+  definitionList(node, children) {
+    return <dl key={node.key}>{children}</dl>;
+  },
+  definitionTerm(node, children) {
+    return <dt key={node.key}>{children}</dt>;
+  },
+  definitionDescription(node, children) {
+    return <dd key={node.key}>{children}</dd>;
   },
 };
 

--- a/packages/myst-util-to-react/src/code.tsx
+++ b/packages/myst-util-to-react/src/code.tsx
@@ -4,27 +4,13 @@ import { useTheme } from '@curvenote/ui-providers';
 import { LightAsync as SyntaxHighlighter } from 'react-syntax-highlighter';
 import light from 'react-syntax-highlighter/dist/cjs/styles/hljs/xcode';
 import dark from 'react-syntax-highlighter/dist/cjs/styles/hljs/vs2015';
-import { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
-import { CheckIcon } from '@heroicons/react/outline';
-import { DuplicateIcon } from '@heroicons/react/solid';
-
-function copyTextToClipboard(text: string) {
-  return new Promise<void>((res, rej) => {
-    navigator.clipboard.writeText(text).then(
-      () => {
-        res();
-      },
-      (err) => {
-        rej(err);
-      },
-    );
-  });
-}
+import { CopyIcon } from './CopyIcon';
 
 type Props = {
   value: string;
   lang?: string;
+  showCopy?: boolean;
   showLineNumbers?: boolean;
   emphasizeLines?: number[];
   className?: string;
@@ -32,16 +18,8 @@ type Props = {
 
 export function CodeBlock(props: Props) {
   const { isLight } = useTheme();
-  const { value, lang, emphasizeLines, showLineNumbers, className } = props;
+  const { value, lang, emphasizeLines, showLineNumbers, className, showCopy = true } = props;
   const highlightLines = new Set(emphasizeLines);
-  const [showCopied, setShowCopied] = useState<boolean>(false);
-  const timeoutRef = useRef<NodeJS.Timeout>();
-
-  useEffect(() => {
-    if (!showCopied) return;
-    if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    timeoutRef.current = setTimeout(() => setShowCopied(false), 1500);
-  }, [showCopied]);
 
   return (
     <div className={classNames('relative group not-prose overflow-auto', className)}>
@@ -73,24 +51,11 @@ export function CodeBlock(props: Props) {
       >
         {value}
       </SyntaxHighlighter>
-      <div className="absolute hidden top-1 right-1 group-hover:block">
-        <button
-          className={classNames('p-1 cursor-pointer transition-color duration-200 ease-in-out', {
-            'text-primary-500 border-primary-500': !showCopied,
-            'text-success border-success ': showCopied,
-          })}
-          title={showCopied ? 'Copied' : 'Copy to clipboard'}
-          onClick={() => {
-            copyTextToClipboard(value)
-              .then(() => setShowCopied(true))
-              .catch(() => {
-                console.error('Failed to copy');
-              });
-          }}
-        >
-          {showCopied ? <CheckIcon className="w-5 h-5" /> : <DuplicateIcon className="w-5 h-5" />}
-        </button>
-      </div>
+      {showCopy && (
+        <div className="absolute hidden top-1 right-1 group-hover:block">
+          <CopyIcon text={value} />
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/myst-util-to-react/src/index.tsx
+++ b/packages/myst-util-to-react/src/index.tsx
@@ -15,6 +15,7 @@ import OUTPUT_RENDERERS from './output';
 import HEADING_RENDERERS from './heading';
 import CROSS_REFERENCE_RENDERERS from './crossReference';
 import RRID_RENDERERS from './rrid';
+import TAB_RENDERERS from './tabs';
 
 export type { NodeRenderer } from './types';
 export { Bibliography } from './cite';
@@ -27,6 +28,7 @@ export const DEFAULT_RENDERERS: Record<string, NodeRenderer> = {
   ...MATH_RENDERERS,
   ...CITE_RENDERERS,
   ...RRID_RENDERERS,
+  ...TAB_RENDERERS,
   ...IFRAME_RENDERERS,
   ...FOOTNOTE_RENDERERS,
   ...ADMONITION_RENDERERS,

--- a/packages/myst-util-to-react/src/index.tsx
+++ b/packages/myst-util-to-react/src/index.tsx
@@ -16,6 +16,7 @@ import HEADING_RENDERERS from './heading';
 import CROSS_REFERENCE_RENDERERS from './crossReference';
 import RRID_RENDERERS from './rrid';
 import TAB_RENDERERS from './tabs';
+import MYST_RENDERERS from './myst';
 
 export type { NodeRenderer } from './types';
 export { Bibliography } from './cite';
@@ -36,6 +37,7 @@ export const DEFAULT_RENDERERS: Record<string, NodeRenderer> = {
   ...OUTPUT_RENDERERS,
   ...HEADING_RENDERERS,
   ...CROSS_REFERENCE_RENDERERS,
+  ...MYST_RENDERERS,
 };
 
 export function useParse(

--- a/packages/myst-util-to-react/src/myst.tsx
+++ b/packages/myst-util-to-react/src/myst.tsx
@@ -53,18 +53,19 @@ export const MySTRenderer: NodeRenderer = (node) => {
           <textarea
             ref={area}
             value={text}
-            className="block p-6 shadow-inner resize-none w-full font-mono bg-slate-50 outline-none"
+            className="block p-6 shadow-inner resize-none w-full font-mono bg-slate-50 dark:bg-slate-800 outline-none"
             onChange={(e) => setText(e.target.value)}
           ></textarea>
         </label>
       </div>
-      <div className="relative min-h-1 pt-[50px] px-6 pb-6">
-        <div className="absolute cursor-pointer top-0 left-0 border">
+      <div className="relative min-h-1 pt-[50px] px-6 pb-6 dark:bg-slate-900">
+        <div className="absolute cursor-pointer top-0 left-0 border dark:border-slate-600">
           {['Demo', 'AST', 'HTML'].map((show) => (
             <button
               key={show}
               className={classnames('px-2 uppercase', {
-                'bg-white hover:bg-slate-200': previewType !== show,
+                'bg-white hover:bg-slate-200 dark:bg-slate-500 dark:hover:bg-slate-700':
+                  previewType !== show,
                 'bg-curvenote-blue text-white': previewType === show,
               })}
               title={`Show the ${show}`}

--- a/packages/myst-util-to-react/src/myst.tsx
+++ b/packages/myst-util-to-react/src/myst.tsx
@@ -17,7 +17,7 @@ async function parse(text: string) {
 
 export const MySTRenderer: NodeRenderer = (node) => {
   const area = useRef<HTMLTextAreaElement | null>(null);
-  const [text, setText] = useState<string>(node.value);
+  const [text, setText] = useState<string>(node.value.trim());
   const [mdast, setMdast] = useState<string>('Loading...');
   const [html, setHtml] = useState<string>('Loading...');
   const [content, setContent] = useState<React.ReactNode>(<p>{node.value}</p>);
@@ -43,7 +43,7 @@ export const MySTRenderer: NodeRenderer = (node) => {
   }, [text]);
 
   return (
-    <figure className="relative shadow-lg rounded overflow-hidden">
+    <figure key={node.key} className="relative shadow-lg rounded overflow-hidden">
       <div className="absolute right-0 p-1">
         <CopyIcon text={text} />
       </div>

--- a/packages/myst-util-to-react/src/myst.tsx
+++ b/packages/myst-util-to-react/src/myst.tsx
@@ -58,7 +58,8 @@ export const MySTRenderer: NodeRenderer = (node) => {
           ></textarea>
         </label>
       </div>
-      <div className="relative min-h-1 pt-[50px] px-6 pb-6 dark:bg-slate-900">
+      {/* The `exclude-from-outline` class is excluded from the document outline */}
+      <div className="exclude-from-outline relative min-h-1 pt-[50px] px-6 pb-6 dark:bg-slate-900">
         <div className="absolute cursor-pointer top-0 left-0 border dark:border-slate-600">
           {['Demo', 'AST', 'HTML'].map((show) => (
             <button

--- a/packages/myst-util-to-react/src/myst.tsx
+++ b/packages/myst-util-to-react/src/myst.tsx
@@ -62,6 +62,7 @@ export const MySTRenderer: NodeRenderer = (node) => {
         <div className="absolute cursor-pointer top-0 left-0 border">
           {['Demo', 'AST', 'HTML'].map((show) => (
             <button
+              key={show}
               className={classnames('px-2 uppercase', {
                 'bg-white hover:bg-slate-200': previewType !== show,
                 'bg-curvenote-blue text-white': previewType === show,

--- a/packages/myst-util-to-react/src/myst.tsx
+++ b/packages/myst-util-to-react/src/myst.tsx
@@ -1,0 +1,90 @@
+import { useParse } from 'myst-util-to-react';
+import yaml from 'js-yaml';
+import type { NodeRenderer } from 'myst-util-to-react';
+import React, { useEffect, useRef, useState } from 'react';
+import classnames from 'classnames';
+import { CopyIcon } from './CopyIcon';
+import { CodeBlock } from './code';
+
+async function parse(text: string) {
+  const { MyST } = await import('mystjs');
+  const myst = new MyST();
+  const mdast = myst.parse(text);
+  const html = myst.renderMdast(mdast);
+  const content = useParse(mdast as any);
+  return { mdast: yaml.dump(mdast), html, content };
+}
+
+export const MySTRenderer: NodeRenderer = (node) => {
+  const area = useRef<HTMLTextAreaElement | null>(null);
+  const [text, setText] = useState<string>(node.value);
+  const [mdast, setMdast] = useState<string>('Loading...');
+  const [html, setHtml] = useState<string>('Loading...');
+  const [content, setContent] = useState<React.ReactNode>(<p>{node.value}</p>);
+  const [previewType, setPreviewType] = useState('Demo');
+
+  useEffect(() => {
+    const ref = { current: true };
+    parse(text).then((result) => {
+      if (!ref.current) return;
+      setMdast(result.mdast);
+      setHtml(result.html);
+      setContent(result.content);
+    });
+    return () => {
+      ref.current = false;
+    };
+  }, [text]);
+
+  useEffect(() => {
+    if (!area.current) return;
+    area.current.style.height = 'auto'; // for the scroll area in the next step!
+    area.current.style.height = `${area.current.scrollHeight}px`;
+  }, [text]);
+
+  return (
+    <figure className="relative shadow-lg rounded overflow-hidden">
+      <div className="absolute right-0 p-1">
+        <CopyIcon text={text} />
+      </div>
+      <div className="myst">
+        <label>
+          <span className="sr-only">Edit the MyST text</span>
+          <textarea
+            ref={area}
+            value={text}
+            className="block p-6 shadow-inner resize-none w-full font-mono bg-slate-50 outline-none"
+            onChange={(e) => setText(e.target.value)}
+          ></textarea>
+        </label>
+      </div>
+      <div className="relative min-h-1 pt-[50px] px-6 pb-6">
+        <div className="absolute cursor-pointer top-0 left-0 border">
+          {['Demo', 'AST', 'HTML'].map((show) => (
+            <button
+              className={classnames('px-2 uppercase', {
+                'bg-white hover:bg-slate-200': previewType !== show,
+                'bg-curvenote-blue text-white': previewType === show,
+              })}
+              title={`Show the ${show}`}
+              aria-label={`Show the ${show}`}
+              aria-pressed={previewType === show ? 'true' : 'false'}
+              onClick={() => setPreviewType(show)}
+            >
+              {show}
+            </button>
+          ))}
+        </div>
+        {previewType === 'Demo' && content}
+        {previewType === 'AST' && <CodeBlock lang="yaml" value={mdast} showCopy={false} />}
+        {previewType === 'HTML' && <CodeBlock lang="xml" value={html} showCopy={false} />}
+      </div>
+    </figure>
+  );
+};
+
+const MYST_RENDERERS = {
+  myst: MySTRenderer,
+};
+
+export default MYST_RENDERERS;

--- a/packages/myst-util-to-react/src/tabs.tsx
+++ b/packages/myst-util-to-react/src/tabs.tsx
@@ -1,0 +1,56 @@
+import { useIsTabOpen, useTabSet } from '@curvenote/ui-providers';
+import classNames from 'classnames';
+import type { GenericNode } from 'mystjs';
+import { useEffect } from 'react';
+import { selectAll } from 'unist-util-select';
+import { NodeRenderer } from './types';
+
+interface TabItem extends GenericNode {
+  key: string;
+  title: string;
+  sync?: string;
+}
+
+export const TabSetRenderer: NodeRenderer = (node, children) => {
+  const items = selectAll('tabItem', node) as TabItem[];
+  const keys = items.map((item) => item.sync || item.key);
+  const { onClick, active } = useTabSet(keys);
+  useEffect(() => {
+    onClick(items[0]?.sync || items[0]?.key);
+  }, []);
+  return (
+    <div className="">
+      <div className="flex flex-row border-b border-b-gray-100">
+        {items.map((item) => {
+          const key = item.sync || item.key;
+          return (
+            <div
+              className={classNames('flex-none px-3 py-1 font-semibold cursor-pointer', {
+                'text-blue-600 border-b-2 border-b-blue-600': active[key],
+                'text-gray-500': !active[key],
+              })}
+              onClick={() => onClick(key)}
+            >
+              {item.title}
+            </div>
+          );
+        })}
+      </div>
+      <div className="shadow flex">
+        <div className="w-full px-6">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export const TabItemRenderer: NodeRenderer<TabItem> = (node, children) => {
+  const open = useIsTabOpen(node.sync || node.key);
+  return <div className={classNames({ hidden: !open })}>{children}</div>;
+};
+
+const TAB_RENDERERS: Record<string, NodeRenderer> = {
+  tabSet: TabSetRenderer,
+  tabItem: TabItemRenderer,
+};
+
+export default TAB_RENDERERS;

--- a/packages/myst-util-to-react/src/tabs.tsx
+++ b/packages/myst-util-to-react/src/tabs.tsx
@@ -26,8 +26,10 @@ export const TabSetRenderer: NodeRenderer = (node, children) => {
           return (
             <div
               className={classNames('flex-none px-3 py-1 font-semibold cursor-pointer', {
-                'text-blue-600 border-b-2 border-b-blue-600': active[key],
-                'text-gray-500': !active[key],
+                'text-blue-600 border-b-2 border-b-blue-600 dark:border-b-white dark:text-white':
+                  active[key],
+                'text-gray-500 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-100':
+                  !active[key],
               })}
               onClick={() => onClick(key)}
             >

--- a/packages/site/src/components/DocumentOutline.tsx
+++ b/packages/site/src/components/DocumentOutline.tsx
@@ -64,7 +64,8 @@ const Headings = ({ headings, activeId, highlight }: Props) => (
 
 function getHeaders(): HTMLHeadingElement[] {
   const headers = Array.from(document.querySelectorAll(SELECTOR)).filter((e) => {
-    return !e.classList.contains('title');
+    const parent = e.closest('.exclude-from-outline');
+    return !(e.classList.contains('title') || parent);
   });
   return headers as HTMLHeadingElement[];
 }

--- a/packages/site/src/pages/Root.tsx
+++ b/packages/site/src/pages/Root.tsx
@@ -1,5 +1,11 @@
 import { DocumentLoader, SiteManifest } from '@curvenote/site-common';
-import { SiteProvider, Theme, ThemeProvider, UiStateProvider } from '@curvenote/ui-providers';
+import {
+  SiteProvider,
+  TabStateProvider,
+  Theme,
+  ThemeProvider,
+  UiStateProvider,
+} from '@curvenote/ui-providers';
 import {
   Links,
   LiveReload,
@@ -40,18 +46,20 @@ export function Document({
         <Analytics analytics={config?.analytics} />
       </head>
       <body className="m-0 transition-colors duration-500 bg-white dark:bg-stone-900">
-        <UiStateProvider>
-          <ThemeProvider theme={theme}>
-            <SiteProvider config={config}>
-              <Navigation top={top} height={height}>
-                <TopNav />
-              </Navigation>
-              <article ref={ref} className="content">
-                {children}
-              </article>
-            </SiteProvider>
-          </ThemeProvider>
-        </UiStateProvider>
+        <TabStateProvider>
+          <UiStateProvider>
+            <ThemeProvider theme={theme}>
+              <SiteProvider config={config}>
+                <Navigation top={top} height={height}>
+                  <TopNav />
+                </Navigation>
+                <article ref={ref} className="content">
+                  {children}
+                </article>
+              </SiteProvider>
+            </ThemeProvider>
+          </UiStateProvider>
+        </TabStateProvider>
         <ScrollRestoration />
         <Scripts />
         {process.env.NODE_ENV === 'development' && <LiveReload />}

--- a/packages/ui-providers/src/index.tsx
+++ b/packages/ui-providers/src/index.tsx
@@ -3,3 +3,4 @@ export * from './theme';
 export * from './references';
 export * from './ui';
 export * from './site';
+export * from './tabs';

--- a/packages/ui-providers/src/tabs.tsx
+++ b/packages/ui-providers/src/tabs.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface TabState {
+  openTabs: string[];
+}
+
+type TabContextType = [TabState, (state: TabState) => void];
+
+const TabContext = createContext<TabContextType | undefined>(undefined);
+
+// Create a provider for components to consume and subscribe to changes
+export function TabStateProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState({ openTabs: [] as string[] });
+  return <TabContext.Provider value={[state, setState]}>{children}</TabContext.Provider>;
+}
+
+export function useIsTabOpen(key: string): boolean {
+  const [state] = useContext(TabContext) ?? [];
+  return state?.openTabs.includes(key) ?? false;
+}
+
+export function useTabSet(keys: string[]): {
+  onClick: (key: string) => void;
+  active: Record<string, boolean>;
+} {
+  const [state, setState] = useContext(TabContext) ?? [];
+  const onClick = (tab: string) => {
+    const newState = [...(state?.openTabs ?? [])].filter((key) => !keys.includes(key));
+    newState.push(tab);
+    setState?.({ openTabs: newState });
+  };
+  const active = Object.fromEntries(
+    keys.map((key) => [key, state?.openTabs.includes(key) ?? false]),
+  );
+  return { onClick, active };
+}


### PR DESCRIPTION
Supporting things that are needed for nice MyST documentation:
* Tabs
* MyST renderer demo component
* `include` directive

This supports most of the things that are required for the current myst-spec and mystjs documentation.

![myst-demo](https://user-images.githubusercontent.com/913249/179809983-51db4f67-79a5-4650-a211-21d340734f84.gif)
![tabs-dark](https://user-images.githubusercontent.com/913249/179810614-d03a946f-5c3d-424c-9b6a-6fab9be4839a.gif)
![image](https://user-images.githubusercontent.com/913249/179810693-1d876813-f962-476b-b914-eddfe5ab98ab.png)

cc @choldgraf - I am working my way back to the myst documentation and site.