### PR TITLE
🍽  Allow table of contents to be relative

### DIFF
--- a/.changeset/polite-apricots-decide.md
+++ b/.changeset/polite-apricots-decide.md
@@ -1,0 +1,5 @@
+---
+'curvenote': patch
+---
+
+Relative links in `--write-toc` option

--- a/apps/cli/src/cli/web.ts
+++ b/apps/cli/src/cli/web.ts
@@ -51,6 +51,7 @@ function makeBuildCLI(program: Command) {
     .addOption(makeCleanOption())
     .addOption(makeForceOption())
     .addOption(makeBranchOption())
+    .addOption(makeWriteTocOption())
     .addOption(makeCIOption())
     .addOption(makeStrictOption())
     .addOption(makeCheckLinksOption())

--- a/apps/cli/src/toc/index.ts
+++ b/apps/cli/src/toc/index.ts
@@ -42,7 +42,9 @@ export function loadProjectFromDisk(
   }
   if (writeToc) {
     try {
-      session.log.info(`📓 Writing '_toc.yml' file to ${path}`);
+      session.log.info(
+        `📓 Writing '_toc.yml' file to ${path === '.' ? 'the current directory' : path}`,
+      );
       writeTocFromProject(newProject, path);
       // Re-load from TOC just in case there are subtle differences with resulting project
       newProject = projectFromToc(session, path);

--- a/apps/cli/src/toc/index.ts
+++ b/apps/cli/src/toc/index.ts
@@ -12,7 +12,7 @@ import { LocalProject } from './types';
  *
  * @param session
  * @param path - root directory of project, relative to current directory; default is '.'
- * @param index - index file, including path relative to current directory; default is 'index.md'
+ * @param opts - `index`, including path relative to current directory; default is 'index.md'
  *     or 'readme.md' in 'path' directory
  *
  * If jupyterbook '_toc.yml' exists in path, project structure will be derived from that.

--- a/apps/cli/src/toc/toToc.ts
+++ b/apps/cli/src/toc/toToc.ts
@@ -1,12 +1,16 @@
 import fs from 'fs';
 import yaml from 'js-yaml';
-import { join } from 'path';
+import { join, relative } from 'path';
 import { JupyterBookChapter, TOC } from '../export/jupyter-book/toc';
 import { PageLevels, LocalProjectFolder, LocalProjectPage, LocalProject } from './types';
 import { removeExtension } from './utils';
 
-const GENERATED_TOC_HEADER = `
-# Table of Contents
+function getRelativeDocumentLink(file: string, path: string) {
+  if (path === '.') return removeExtension(file);
+  return removeExtension(relative(path, file));
+}
+
+const GENERATED_TOC_HEADER = `# Table of Contents
 #
 # Curvenote will respect:
 # 1. New pages
@@ -25,7 +29,7 @@ const GENERATED_TOC_HEADER = `
 
 `;
 
-function chaptersFromPages(pages: (LocalProjectFolder | LocalProjectPage)[]) {
+function chaptersFromPages(pages: (LocalProjectFolder | LocalProjectPage)[], path: string) {
   const levels = pages.map((page) => page.level);
   const currentLevel = Math.min(...levels) as PageLevels;
   const currentLevelIndices = levels.reduce((inds: number[], val: PageLevels, i: number) => {
@@ -44,13 +48,13 @@ function chaptersFromPages(pages: (LocalProjectFolder | LocalProjectPage)[]) {
     const chapter: JupyterBookChapter = {};
     if ('file' in pages[index]) {
       const page = pages[index] as LocalProjectPage;
-      chapter.file = removeExtension(page.file);
+      chapter.file = getRelativeDocumentLink(page.file, path);
     } else if ('title' in pages[index]) {
       const page = pages[index] as LocalProjectFolder;
       chapter.title = page.title;
     }
     if (nextPages.length) {
-      chapter.sections = chaptersFromPages(nextPages);
+      chapter.sections = chaptersFromPages(nextPages, path);
     }
     return chapter;
   });
@@ -62,20 +66,20 @@ function chaptersFromPages(pages: (LocalProjectFolder | LocalProjectPage)[]) {
  *
  * Output consists of a top-level chapter with files/sections
  * based on project structure. Sections headings may be either
- * associated with a `file` (results in clickable curvespace page)
- * or just a `title` (results in unclickable curvespace heading)
+ * associated with a `file` (results in clickable in page)
+ * or just a `title` (results in unclickable in heading)
  */
-export function tocFromProject(project: LocalProject) {
+export function tocFromProject(project: LocalProject, path: string) {
   const toc: TOC = {
     format: 'jb-book',
-    root: removeExtension(project.file),
-    chapters: chaptersFromPages(project.pages),
+    root: getRelativeDocumentLink(project.file, path),
+    chapters: chaptersFromPages(project.pages, path),
   };
   return toc;
 }
 
 export function writeTocFromProject(project: LocalProject, path: string) {
   const filename = join(path, '_toc.yml');
-  const content = `${GENERATED_TOC_HEADER}${yaml.dump(tocFromProject(project))}`;
+  const content = `${GENERATED_TOC_HEADER}${yaml.dump(tocFromProject(project, path))}`;
   fs.writeFileSync(filename, content);
 }

--- a/apps/cli/src/toc/toToc.ts
+++ b/apps/cli/src/toc/toToc.ts
@@ -69,7 +69,7 @@ function chaptersFromPages(pages: (LocalProjectFolder | LocalProjectPage)[], pat
  * associated with a `file` (results in clickable in page)
  * or just a `title` (results in unclickable in heading)
  */
-export function tocFromProject(project: LocalProject, path: string) {
+export function tocFromProject(project: LocalProject, path = '.') {
   const toc: TOC = {
     format: 'jb-book',
     root: getRelativeDocumentLink(project.file, path),

--- a/apps/cli/src/toc/toc.spec.ts
+++ b/apps/cli/src/toc/toc.spec.ts
@@ -430,6 +430,34 @@ describe('tocFromProject', () => {
       ],
     });
   });
+  it('root page with relative path', async () => {
+    expect(
+      tocFromProject(
+        {
+          file: 'path/readme.md',
+          path: '.',
+          index: 'readme',
+          citations: [],
+          pages: [
+            {
+              file: 'path/a.md',
+              slug: 'a',
+              level: 1,
+            },
+          ],
+        },
+        'path', // This is the relative path we are calling this from!
+      ),
+    ).toEqual({
+      format: 'jb-book',
+      root: 'readme',
+      chapters: [
+        {
+          file: 'a',
+        },
+      ],
+    });
+  });
   it('root and folder and page', async () => {
     expect(
       tocFromProject({


### PR DESCRIPTION
Previously the path would always be from the command location, so a _toc.yml in a nested directory would fail.