### PR TITLE
🌈 Look up all the references in the current tree

### DIFF
--- a/.changeset/silent-chefs-melt.md
+++ b/.changeset/silent-chefs-melt.md
@@ -1,0 +1,5 @@
+---
+'curvenote': patch
+---
+
+Look up all bibtex files on the current tree

--- a/apps/cli/src/store/local/actions.ts
+++ b/apps/cli/src/store/local/actions.ts
@@ -40,7 +40,7 @@ import {
 import { loadProjectFromDisk } from '../../toc';
 import { copyActionResource, copyLogo, getSiteManifest } from '../../toc/manifest';
 import { LocalProject, LocalProjectPage } from '../../toc/types';
-import { writeFileToFolder, serverPath, tic } from '../../utils';
+import { writeFileToFolder, serverPath, tic, addWarningForFile } from '../../utils';
 import { selectors } from '..';
 import { processNotebook } from './notebook';
 import { watch } from './reducers';
@@ -96,7 +96,7 @@ function combineRenderers(cache: ISessionWithCache, ...files: string[]) {
     const renderer = cache.$citationRenderers[file];
     Object.keys(renderer).forEach((key) => {
       if (combined[key]) {
-        cache.log.warn(`Duplicate citations in ${file} with id: ${key}`);
+        addWarningForFile(cache, file, `Duplicate citation with id: ${key}`);
       }
       combined[key] = renderer[key];
     });

--- a/apps/cli/src/toc/fromPath.ts
+++ b/apps/cli/src/toc/fromPath.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { extname, join } from 'path';
 import { CURVENOTE_YML } from '../config/types';
 import { ISession } from '../session/types';
-import { BUILD_FOLDER } from '../utils';
+import { shouldIgnoreFile } from '../utils';
 import { pagesFromToc } from './fromToc';
 import { PageLevels, LocalProjectFolder, LocalProjectPage, LocalProject } from './types';
 import {
@@ -16,11 +16,6 @@ import {
 } from './utils';
 
 const DEFAULT_INDEX_FILENAMES = ['index', 'readme', 'main'];
-
-function alwaysIgnore(file: string) {
-  const ignore = ['node_modules', BUILD_FOLDER];
-  return file.startsWith('.') || ignore.includes(file);
-}
 
 type Options = {
   ignore?: string[];
@@ -40,7 +35,7 @@ function projectPagesFromPath(
   const { ignore, suppressWarnings } = opts || {};
   const contents = fs
     .readdirSync(path)
-    .filter((file) => !alwaysIgnore(file))
+    .filter((file) => !shouldIgnoreFile(file))
     .map((file) => join(path, file))
     .filter((file) => !ignore || !ignore.includes(file))
     .sort();

--- a/apps/cli/src/toc/utils.ts
+++ b/apps/cli/src/toc/utils.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { extname, join, parse } from 'path';
+import { extname, join, parse, basename } from 'path';
 import { title2name as createSlug } from '@curvenote/blocks';
 import { loadConfigOrThrow } from '../config';
 import { CURVENOTE_YML } from '../config/types';
@@ -77,14 +77,30 @@ export function fileInfo(file: string, pageSlugs: PageSlugs): { slug: string; ti
   return { slug, title };
 }
 
-export function getCitationPaths(session: ISession, path: string): string[] {
-  // TODO: traverse to find all bibs, and or read from toc/config
-  const ref = join(path, 'references.bib');
-  if (!fs.existsSync(ref)) {
-    session.log.debug(`Expected citations at "${ref}"`);
-    return [];
-  }
-  return [ref];
+const BIBTEX_IGNORE_DIRECTORIES = ['_build', 'node_modules', '_static', '.git'];
+
+export function getCitationPaths(session: ISession, path: string) {
+  let bibFiles: string[] = [];
+  const content = fs.readdirSync(path);
+  content
+    .map((dir) => join(path, dir))
+    .filter((file) => {
+      const isDir = isDirectory(file);
+      if (!isDir && extname(file) === '.bib') {
+        // Push the bibtex file to a list!
+        bibFiles.push(file);
+      }
+      // If it is in a list or is hidden
+      if (basename(file).startsWith('.') || BIBTEX_IGNORE_DIRECTORIES.includes(basename(file))) {
+        return false;
+      }
+      return isDir;
+    })
+    .forEach((dir) => {
+      // Now recurse into each directory
+      bibFiles = bibFiles.concat(getCitationPaths(session, dir));
+    });
+  return bibFiles;
 }
 
 export function findProjectsOnPath(session: ISession, path: string) {

--- a/apps/cli/src/toc/utils.ts
+++ b/apps/cli/src/toc/utils.ts
@@ -6,6 +6,7 @@ import { CURVENOTE_YML } from '../config/types';
 import { ISession } from '../session';
 import { selectors } from '../store';
 import { PageLevels } from './types';
+import { shouldIgnoreFile } from '../utils';
 
 export const VALID_FILE_EXTENSIONS = ['.md', '.ipynb'];
 
@@ -77,8 +78,6 @@ export function fileInfo(file: string, pageSlugs: PageSlugs): { slug: string; ti
   return { slug, title };
 }
 
-const BIBTEX_IGNORE_DIRECTORIES = ['_build', 'node_modules', '_static', '.git'];
-
 export function getCitationPaths(session: ISession, path: string) {
   let bibFiles: string[] = [];
   const content = fs.readdirSync(path);
@@ -91,7 +90,7 @@ export function getCitationPaths(session: ISession, path: string) {
         bibFiles.push(file);
       }
       // If it is in a list or is hidden
-      if (basename(file).startsWith('.') || BIBTEX_IGNORE_DIRECTORIES.includes(basename(file))) {
+      if (shouldIgnoreFile(basename(file))) {
         return false;
       }
       return isDir;

--- a/apps/cli/src/utils/utils.ts
+++ b/apps/cli/src/utils/utils.ts
@@ -12,6 +12,11 @@ import { WarningKind, warnings } from '../store/build';
 export const BUILD_FOLDER = '_build';
 export const THUMBNAILS_FOLDER = 'thumbnails';
 
+export function shouldIgnoreFile(file: string) {
+  const ignore = ['node_modules', BUILD_FOLDER];
+  return file.startsWith('.') || ignore.includes(file);
+}
+
 export function resolvePath(optionalPath: string | undefined, filename: string) {
   if (optionalPath) return path.join(optionalPath, filename);
   if (path.isAbsolute(filename)) return filename;


### PR DESCRIPTION
Previously we would only load `references.bib` this now loads all references on the path.

