### PR TITLE
⚠️  Warn on HOST being set incorrectly

### DIFF
--- a/.changeset/twelve-penguins-sip.md
+++ b/.changeset/twelve-penguins-sip.md
@@ -1,0 +1,5 @@
+---
+'curvenote': patch
+---
+
+Add a `--keep-host` option for curvenote serve and by default use localhost for the value of the HOST environment variable.

--- a/apps/cli/src/cli/options.ts
+++ b/apps/cli/src/cli/options.ts
@@ -23,6 +23,14 @@ export function makeCleanOption() {
 export function makeForceOption() {
   return new Option('-f, --force', 'Remove the build directory and re-install').default(false);
 }
+
+export function makeKeepHostOption() {
+  return new Option(
+    '--keep-host',
+    'The HOST environment variable is changed to "localhost" by default. This flag uses the original environment variable.',
+  ).default(false);
+}
+
 export function makeCIOption() {
   return new Option(
     '-ci, --ci', // Must have both!

--- a/apps/cli/src/cli/web.ts
+++ b/apps/cli/src/cli/web.ts
@@ -10,6 +10,7 @@ import {
   makeWriteTocOption,
   makeStrictOption,
   makeCheckLinksOption,
+  makeKeepHostOption,
 } from './options';
 
 function makeCurvenoteCleanCLI(program: Command) {
@@ -40,6 +41,7 @@ function makeCurvenoteStartCLI(program: Command) {
     .addOption(makeCleanOption())
     .addOption(makeForceOption())
     .addOption(makeBranchOption())
+    .addOption(makeKeepHostOption())
     .action(clirun(web.startServer, { program, requireSiteConfig: true }));
   return command;
 }

--- a/apps/cli/src/export/jupyter-book/index.ts
+++ b/apps/cli/src/export/jupyter-book/index.ts
@@ -25,7 +25,7 @@ export async function projectToJupyterBook(session: ISession, projectId: Project
   ]);
   if (!nav) {
     session.log.error(
-      `Unable to load project "${project.data.name}" - do you need to save a draft?`,
+      `Unable to load project navigation "${project.data.name}" - please save any article in your project?`,
     );
     return;
   }

--- a/apps/cli/src/utils/utils.ts
+++ b/apps/cli/src/utils/utils.ts
@@ -81,6 +81,21 @@ export function warnOnUnrecognizedKeys(
   log.warn(`${start} Did not recognize key${plural}: "${extraKeys.join('", "')}".`);
 }
 
+export function warnOnHostEnvironmentVariable(session: ISession, opts?: { keepHost?: boolean }) {
+  if (process.env.HOST && process.env.HOST !== 'localhost') {
+    if (opts?.keepHost) {
+      session.log.warn(
+        `\nThe HOST environment variable is set to "${process.env.HOST}", this may cause issues for the web server.\n`,
+      );
+    } else {
+      session.log.warn(
+        `\nThe HOST environment variable is set to "${process.env.HOST}", we are overwriting this to "localhost".\nTo keep this value use the \`--keep-host\` flag.\n`,
+      );
+      process.env.HOST = 'localhost';
+    }
+  }
+}
+
 export function addWarningForFile(
   session: ISession,
   file: string | undefined | null,

--- a/apps/cli/src/web/index.ts
+++ b/apps/cli/src/web/index.ts
@@ -12,6 +12,7 @@ import {
   repoPath,
   serverPath,
   blocksJsonPath,
+  warnOnHostEnvironmentVariable,
 } from '../utils';
 import { deployContentToCdn, promoteContent } from './deploy';
 import type { Options } from './prepare';
@@ -94,6 +95,7 @@ export async function build(
 }
 
 export async function startServer(session: ISession, opts: Options): Promise<void> {
+  warnOnHostEnvironmentVariable(session, opts);
   await build(session, opts, false);
   sparkles(session, 'Starting Curvenote');
   watchContent(session);

--- a/apps/cli/src/web/prepare.ts
+++ b/apps/cli/src/web/prepare.ts
@@ -13,6 +13,7 @@ export type Options = {
   ci?: boolean;
   yes?: boolean;
   writeToc?: boolean;
+  keepHost?: boolean;
 };
 
 export function cleanBuiltFiles(session: ISession, info = true): void {


### PR DESCRIPTION
By default overwrite the `HOST` environment variable to `localhost.

![image](https://user-images.githubusercontent.com/913249/183488941-3f18e6f2-8350-44b8-9d29-db5f9348a4de.png)

Adds the `--keep-host` flag, which can lead to an error:
![image](https://user-images.githubusercontent.com/913249/183489065-b13fc98f-19e9-46c2-965e-59650b65b197.png)

See #302