### PR TITLE
Enable builds via xelatex or pdflatex

### DIFF
--- a/apps/cli/src/cli/export.ts
+++ b/apps/cli/src/cli/export.ts
@@ -21,6 +21,13 @@ function makeTemplateOption() {
   return new Option('-t, --template <name>', 'Specify a template to apply during export');
 }
 
+function makePdfCommandOption() {
+  return new Option(
+    '-c, --command <name>',
+    'Specify a TeX build command to use during pdf creation (xelatex|pdflatex)',
+  ).default('xelatex');
+}
+
 function makeTemplateOptionsOption() {
   return new Option(
     '-o, --options <name>',
@@ -86,6 +93,7 @@ function makePdfBuildCLI(program: Command) {
   const command = new Command('pdf:build')
     .description('Build a pdf given a tex file')
     .argument('[output]', 'A path to the tex file to build')
+    .addOption(makePdfCommandOption())
     .action(clirun(buildPdfOnly, { program }));
   return command;
 }

--- a/apps/cli/src/export/pdf/build.ts
+++ b/apps/cli/src/export/pdf/build.ts
@@ -1,6 +1,7 @@
 import type { ISession } from '../../session/types';
+import type { TexExportOptions } from '../tex/types';
 import { createPdfGivenTexFile } from './create';
 
-export async function buildPdfOnly(session: ISession, filename: string) {
-  await createPdfGivenTexFile(session.log, filename, false);
+export async function buildPdfOnly(session: ISession, filename: string, opts: TexExportOptions) {
+  await createPdfGivenTexFile(session.log, filename, opts.command, false);
 }

--- a/apps/cli/src/export/pdf/create.ts
+++ b/apps/cli/src/export/pdf/create.ts
@@ -3,11 +3,17 @@ import path from 'path';
 import util from 'util';
 import type { Logger } from '../../logging';
 import { BUILD_FOLDER } from '../../utils';
+import type { PdfBuildCommand } from '../tex/types';
 import { exec } from '../utils';
 
 const copyFile = util.promisify(fs.copyFile);
 
-export async function createPdfGivenTexFile(log: Logger, filename: string, useBuildFolder = true) {
+export async function createPdfGivenTexFile(
+  log: Logger,
+  filename: string,
+  command: PdfBuildCommand = 'xelatex',
+  useBuildFolder = true,
+) {
   const basename = path.basename(filename, path.extname(filename));
   const tex_filename = `${basename}.tex`;
   const pdf_filename = `${basename}.pdf`;
@@ -18,7 +24,9 @@ export async function createPdfGivenTexFile(log: Logger, filename: string, useBu
   const outputLogFile = path.join(outputPath, log_filename);
 
   const buildPath = path.resolve(useBuildFolder ? path.join(outputPath, BUILD_FOLDER) : outputPath);
-  const CMD = `latexmk -f -xelatex -synctex=1 -interaction=batchmode -file-line-error -latexoption="-shell-escape" ${tex_filename} &> ${tex_log_filename}`;
+  const CMD = `latexmk -f ${
+    command === 'pdflatex' ? '-pdf -bibtex' : '-xelatex'
+  } -synctex=1 -interaction=batchmode -file-line-error -latexoption="-shell-escape" ${tex_filename} &> ${tex_log_filename}`;
   try {
     log.debug(`Building LaTeX: logging output to ${tex_log_filename}`);
     await exec(CMD, { cwd: buildPath });

--- a/apps/cli/src/export/pdf/single.ts
+++ b/apps/cli/src/export/pdf/single.ts
@@ -23,7 +23,10 @@ export async function singleArticleToPdf(
     texIsIntermediate: true,
   });
 
-  await createPdfGivenTexFile(session.log, targetTexFilename);
+  // TODO: jtex currently downloads the template for use, but we pre-load the template configuration file/spec in
+  // ifTemplateFetchTaggedBlocks() called in singleArticleToTex. If we can do that prefetch earlier, then we could
+  // test for a flag in the template.yml schema, and set the opts.command here to xelatex or pdflatex appropriately
+  await createPdfGivenTexFile(session.log, targetTexFilename, opts.command);
 
   return article;
 }

--- a/apps/cli/src/export/tex/types.ts
+++ b/apps/cli/src/export/tex/types.ts
@@ -1,5 +1,8 @@
+export type PdfBuildCommand = 'xelatex' | 'pdflatex';
+
 export interface TexExportOptions {
   filename: string;
+  command?: PdfBuildCommand;
   multiple?: boolean;
   images?: string;
   template?: string;


### PR DESCRIPTION
This PR adds an additional option on `export pdf:build` enabling `pdflatex` to be used.





