### PR TITLE
🐛  Frontmatter is deleted if it is the only node

### DIFF
--- a/.changeset/sharp-baboons-film.md
+++ b/.changeset/sharp-baboons-film.md
@@ -1,0 +1,5 @@
+---
+'curvenote': patch
+---
+
+If frontmatter is the only block, it will now be removed


### PR DESCRIPTION
If the content is only a frontmatter block, then the `remove` tries to delete the root node, which is not allowed. This follows through with removing that content.

Content:
![image](https://user-images.githubusercontent.com/913249/185984376-bea86fe3-e0ee-4e55-93a2-24e88dae089b.png)

This is the bug:
![image](https://user-images.githubusercontent.com/913249/185984481-e27c6bae-03c9-40cd-8679-1231054adab0.png)

After the content is properly deleted and a blank article is shown.