### PR TITLE
📍 Local PDF export using local tex export

### DIFF
--- a/apps/cli/src/cli/export.ts
+++ b/apps/cli/src/cli/export.ts
@@ -9,6 +9,7 @@ import {
   oxaLinkToPdf,
   pathToWord,
 } from '../export';
+import { makeCleanOption } from './options';
 import { clirun } from './utils';
 
 function makeImageOption() {
@@ -80,6 +81,7 @@ function makeTexExportCLI(program: Command) {
     .addOption(makeDisableTemplateOption())
     .addOption(makeTemplateOption())
     .addOption(makeTemplatePathOption())
+    .addOption(makeCleanOption())
     .addOption(makeTemplateOptionsOption())
     .addOption(makeConverterOption())
     .action(clirun(oxaLinkToArticleTex, { program }));
@@ -97,6 +99,7 @@ function makePdfExportCLI(program: Command) {
     .addOption(makeDisableTemplateOption())
     .addOption(makeTemplateOption())
     .addOption(makeTemplatePathOption())
+    .addOption(makeCleanOption())
     .addOption(makeTemplateOptionsOption())
     .addOption(makeConverterOption())
     .action(clirun(oxaLinkToPdf, { program }));

--- a/apps/cli/src/cli/export.ts
+++ b/apps/cli/src/cli/export.ts
@@ -70,8 +70,11 @@ function makeMarkdownExportCLI(program: Command) {
 function makeTexExportCLI(program: Command) {
   const command = new Command('latex')
     .alias('tex')
-    .description('Export a tex file from a Curvenote link')
-    .argument('<article>', 'A link to the Curvenote article (e.g. OXA Link or API link)')
+    .description('Export a tex file from a local markdown/notebook file or a Curvenote link')
+    .argument(
+      '<article>',
+      'A local file or link to the Curvenote article (e.g. OXA Link or API link)',
+    )
     .argument('[output]', 'The document filename to export to', '')
     .addOption(makeImageOption())
     .addOption(makeDisableTemplateOption())
@@ -85,10 +88,15 @@ function makeTexExportCLI(program: Command) {
 
 function makePdfExportCLI(program: Command) {
   const command = new Command('pdf')
-    .description('Export a pdf file from a Curvenote link')
-    .argument('<article>', 'A link to the Curvenote article (e.g. OXA Link or API link)')
-    .argument('[output]', 'The document filename to export to', 'main.pdf')
+    .description('Export a pdf file from a local markdown/notebook file or a Curvenote link')
+    .argument(
+      '<article>',
+      'A local file or link to the Curvenote article (e.g. OXA Link or API link)',
+    )
+    .argument('[output]', 'The document filename to export to', '')
+    .addOption(makeDisableTemplateOption())
     .addOption(makeTemplateOption())
+    .addOption(makeTemplatePathOption())
     .addOption(makeTemplateOptionsOption())
     .addOption(makeConverterOption())
     .action(clirun(oxaLinkToPdf, { program }));

--- a/apps/cli/src/config/index.ts
+++ b/apps/cli/src/config/index.ts
@@ -25,11 +25,11 @@ function configFile(path: string) {
   return join(path, CURVENOTE_YML);
 }
 
-function configFileExists(path: string) {
+export function configFileExists(path: string) {
   return fs.existsSync(configFile(path));
 }
 
-function readConfig(session: PartialSession, path: string) {
+export function readConfig(session: PartialSession, path: string) {
   if (!configFileExists(path)) throw Error(`Cannot find ${CURVENOTE_YML} in ${path}`);
   const file = configFile(path);
   const opts: ValidationOptions = {

--- a/apps/cli/src/config/index.ts
+++ b/apps/cli/src/config/index.ts
@@ -74,7 +74,7 @@ export function readConfig(session: PartialSession, path: string) {
     conf.project = { ...frontmatter, ...rest };
   }
   if (conf.site?.logoText) {
-    session.log.warn(`logoText is deprecated, please use logo_text in "${file}#site"`, opts);
+    session.log.warn(`logoText is deprecated, please use logo_text in "${file}#site"`);
     const { logoText, ...rest } = conf.site;
     conf.site = { logo_text: logoText, ...rest };
   }

--- a/apps/cli/src/config/index.ts
+++ b/apps/cli/src/config/index.ts
@@ -37,10 +37,10 @@ function readConfig(session: PartialSession, path: string) {
     property: 'config',
     messages: {},
     errorLogFn: (message: string) => {
-      session.log.error(`Validation error: "${message}`);
+      session.log.error(`Validation error: ${message}`);
     },
     warningLogFn: (message: string) => {
-      session.log.warn(`Validation: "${message}`);
+      session.log.warn(`Validation: ${message}`);
     },
   };
   const conf = validateObject(yaml.load(fs.readFileSync(file, 'utf-8')), opts);
@@ -91,10 +91,10 @@ function validateSiteConfigAndSave(
     property: 'site',
     messages: {},
     errorLogFn: (message: string) => {
-      session.log.error(`Validation error: "${message}`);
+      session.log.error(`Validation error: ${message}`);
     },
     warningLogFn: (message: string) => {
-      session.log.warn(`Validation: "${message}`);
+      session.log.warn(`Validation: ${message}`);
     },
   });
   if (!siteConfig) {
@@ -115,10 +115,10 @@ function validateProjectConfigAndSave(
     property: 'project',
     messages: {},
     errorLogFn: (message: string) => {
-      session.log.error(`Validation error: "${message}`);
+      session.log.error(`Validation error: ${message}`);
     },
     warningLogFn: (message: string) => {
-      session.log.warn(`Validation: "${message}`);
+      session.log.warn(`Validation: ${message}`);
     },
   });
   if (!projectConfig) {

--- a/apps/cli/src/export/jupyter-book/toc.ts
+++ b/apps/cli/src/export/jupyter-book/toc.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { join } from 'path';
+import { join, parse } from 'path';
 import YAML from 'js-yaml';
 import type { Blocks } from '@curvenote/blocks';
 import { NavListItemKindEnum } from '@curvenote/blocks';
@@ -246,9 +246,10 @@ export function readTOC(log: Logger, opts?: Options): TOC {
 
 export function validateTOC(session: ISession, path: string): boolean {
   const filename = tocFile(path);
+  const { dir, base } = parse(filename);
   if (!fs.existsSync(filename)) return false;
   try {
-    readTOC(silentLogger(), { filename });
+    readTOC(silentLogger(), { filename: base, path: dir });
     return true;
   } catch (error) {
     const { message } = error as unknown as Error;

--- a/apps/cli/src/export/pdf/create.ts
+++ b/apps/cli/src/export/pdf/create.ts
@@ -88,8 +88,8 @@ export async function createPdfGivenTexExport(
   const logBuild = path.join(buildPath, logFile);
   const texLogBuild = path.join(buildPath, texLogFile);
   // Log file location saved alongside pdf
-  const logOutput = path.join(path.dirname(pdfOutput), logFile);
-  const texLogOutput = path.join(path.dirname(pdfOutput), texLogFile);
+  const logOutput = path.join(path.dirname(pdfOutput), 'logs', logFile);
+  const texLogOutput = path.join(path.dirname(pdfOutput), 'logs', texLogFile);
 
   let buildCommand: string;
   if (!template && !templatePath) {
@@ -111,11 +111,12 @@ export async function createPdfGivenTexExport(
   const logBuildExists = fs.existsSync(logBuild);
   const texLogBuildExists = fs.existsSync(texLogBuild);
 
-  if (
-    (pdfBuildExists || logBuildExists || texLogBuildExists) &&
-    !fs.existsSync(path.dirname(pdfOutput))
-  ) {
+  if (pdfBuildExists && !fs.existsSync(path.dirname(pdfOutput))) {
     fs.mkdirSync(path.dirname(pdfOutput), { recursive: true });
+  }
+
+  if ((logBuildExists || texLogBuildExists) && !fs.existsSync(path.dirname(logOutput))) {
+    fs.mkdirSync(path.dirname(logOutput), { recursive: true });
   }
 
   if (pdfBuildExists) {

--- a/apps/cli/src/export/pdf/create.ts
+++ b/apps/cli/src/export/pdf/create.ts
@@ -115,25 +115,25 @@ export async function createPdfGivenTexExport(
     fs.mkdirSync(path.dirname(pdfOutput), { recursive: true });
   }
 
-  if ((logBuildExists || texLogBuildExists) && !fs.existsSync(path.dirname(logOutput))) {
-    fs.mkdirSync(path.dirname(logOutput), { recursive: true });
-  }
-
   if (pdfBuildExists) {
     await copyFile(pdfBuild, pdfOutput);
     session.log.debug(`Copied PDF file to ${pdfOutput}`);
   } else {
     session.log.error(`Could not find ${pdfBuild} as expected`);
   }
+  if (copyLogs) {
+    if ((logBuildExists || texLogBuildExists) && !fs.existsSync(path.dirname(logOutput))) {
+      fs.mkdirSync(path.dirname(logOutput), { recursive: true });
+    }
+    if (logBuildExists) {
+      session.log.debug(`Copying log file: ${logOutput}`);
+      await copyFile(logBuild, logOutput);
+    }
 
-  if (logBuildExists && copyLogs) {
-    session.log.debug(`Copying log file: ${logOutput}`);
-    await copyFile(logBuild, logOutput);
-  }
-
-  if (texLogBuildExists && copyLogs) {
-    session.log.debug(`Copying log file: ${texLogOutput}`);
-    await copyFile(texLogBuild, texLogOutput);
+    if (texLogBuildExists) {
+      session.log.debug(`Copying log file: ${texLogOutput}`);
+      await copyFile(texLogBuild, texLogOutput);
+    }
   }
   if (!fs.existsSync(pdfOutput)) {
     throw Error(`pdf export failed`);

--- a/apps/cli/src/export/pdf/create.ts
+++ b/apps/cli/src/export/pdf/create.ts
@@ -88,8 +88,8 @@ export async function createPdfGivenTexExport(
   const logBuild = path.join(buildPath, logFile);
   const texLogBuild = path.join(buildPath, texLogFile);
   // Log file location saved alongside pdf
-  const logOutput = path.join(path.dirname(pdfOutput), 'logs', logFile);
-  const texLogOutput = path.join(path.dirname(pdfOutput), 'logs', texLogFile);
+  const logOutput = path.join(path.dirname(pdfOutput), `${pdfBasename}_logs`, logFile);
+  const texLogOutput = path.join(path.dirname(pdfOutput), `${pdfBasename}_logs`, texLogFile);
 
   let buildCommand: string;
   if (!template && !templatePath) {

--- a/apps/cli/src/export/pdf/create.ts
+++ b/apps/cli/src/export/pdf/create.ts
@@ -7,6 +7,7 @@ import type { ISession } from '../../session/types';
 import { BUILD_FOLDER, createTempFolder } from '../../utils';
 import type { ExportWithOutput } from '../tex/types';
 import { exec } from '../utils';
+import { cleanOutput } from '../tex/single';
 
 const copyFile = util.promisify(fs.copyFile);
 
@@ -65,7 +66,9 @@ export async function createPdfGivenTexExport(
   pdfOutput: string,
   templatePath?: string,
   copyLogs?: boolean,
+  clean?: boolean,
 ) {
+  if (clean) cleanOutput(session, pdfOutput);
   const { output: texOutput, template } = texExportOptions;
 
   const buildPath = createTempFolder();
@@ -88,8 +91,10 @@ export async function createPdfGivenTexExport(
   const logBuild = path.join(buildPath, logFile);
   const texLogBuild = path.join(buildPath, texLogFile);
   // Log file location saved alongside pdf
-  const logOutput = path.join(path.dirname(pdfOutput), `${pdfBasename}_logs`, logFile);
-  const texLogOutput = path.join(path.dirname(pdfOutput), `${pdfBasename}_logs`, texLogFile);
+  const logOutputFolder = path.join(path.dirname(pdfOutput), `${pdfBasename}_logs`);
+  const logOutput = path.join(logOutputFolder, logFile);
+  const texLogOutput = path.join(logOutputFolder, texLogFile);
+  if (clean) cleanOutput(session, logOutputFolder);
 
   let buildCommand: string;
   if (!template && !templatePath) {

--- a/apps/cli/src/export/pdf/create.ts
+++ b/apps/cli/src/export/pdf/create.ts
@@ -40,4 +40,5 @@ export async function createPdfGivenTexFile(log: Logger, filename: string, useBu
   if (fs.existsSync(built_log)) {
     await copyFile(built_log, outputLogFile);
   }
+  return outputPdfFile;
 }

--- a/apps/cli/src/export/pdf/create.ts
+++ b/apps/cli/src/export/pdf/create.ts
@@ -20,19 +20,21 @@ export async function createPdfGivenTexFile(log: Logger, filename: string, useBu
   const buildPath = path.resolve(useBuildFolder ? path.join(outputPath, BUILD_FOLDER) : outputPath);
   const CMD = `latexmk -f -xelatex -synctex=1 -interaction=batchmode -file-line-error -latexoption="-shell-escape" ${tex_filename} &> ${tex_log_filename}`;
   try {
-    log.debug(`Building LaTeX: logging output to ${tex_log_filename}`);
+    session.log.debug(`Building LaTeX in directory: ${buildPath}`);
+    session.log.debug(`Logging output to: ${tex_log_filename}`);
+    session.log.debug(`Running command:\n> ${CMD}`);
     await exec(CMD, { cwd: buildPath });
-    log.debug(`Done building LaTeX.`);
+    session.log.debug(`Done building LaTeX.`);
   } catch (err) {
-    log.error(`Error while invoking mklatex: ${err}`);
+    session.log.error(`Error while invoking mklatex: ${err}`);
   }
 
   const built_pdf = path.join(buildPath, pdf_filename);
   if (fs.existsSync(built_pdf)) {
     await copyFile(built_pdf, outputPdfFile);
-    log.debug(`Copied PDF file to ${outputPdfFile}`);
+    session.log.debug(`Copied PDF file to ${outputPdfFile}`);
   } else {
-    log.error(`Could not find ${built_pdf} as expected, pdf export failed`);
+    session.log.error(`Could not find ${built_pdf} as expected, pdf export failed`);
     throw Error(`Could not find ${built_pdf} as expected, pdf export failed`);
   }
 

--- a/apps/cli/src/export/pdf/create.ts
+++ b/apps/cli/src/export/pdf/create.ts
@@ -99,12 +99,12 @@ export async function createPdfGivenTexExport(
     buildCommand = jtex.pdfExportCommand(texFile, texLogFile);
   }
   try {
-    session.log.debug(`Building LaTeX in directory: ${buildPath}`);
+    session.log.info(`🖨  Rendering pdf to ${pdfBuild}`);
     session.log.debug(`Running command:\n> ${buildCommand}`);
     await exec(buildCommand, { cwd: buildPath });
     session.log.debug(`Done building LaTeX.`);
   } catch (err) {
-    session.log.error(`Error while invoking mklatex: ${err}`);
+    session.log.error(`Error while invoking mklatex - logs available at: ${buildPath}\n${err}`);
   }
 
   const pdfBuildExists = fs.existsSync(pdfBuild);
@@ -116,6 +116,7 @@ export async function createPdfGivenTexExport(
   }
 
   if (pdfBuildExists) {
+    session.log.info(`🧬 Copying pdf to ${pdfOutput}`);
     await copyFile(pdfBuild, pdfOutput);
     session.log.debug(`Copied PDF file to ${pdfOutput}`);
   } else {

--- a/apps/cli/src/export/pdf/create.ts
+++ b/apps/cli/src/export/pdf/create.ts
@@ -1,13 +1,31 @@
 import fs from 'fs';
 import path from 'path';
 import util from 'util';
+import JTex, { pdfExportCommand } from 'jtex';
+import { ExportFormats } from '@curvenote/frontmatter';
 import type { Logger } from '../../logging';
+import { Session } from '../../session';
+import type { ISession } from '../../session/types';
 import { BUILD_FOLDER } from '../../utils';
+import type { ExportWithOutput } from '../tex/types';
 import { exec } from '../utils';
 
 const copyFile = util.promisify(fs.copyFile);
 
 export async function createPdfGivenTexFile(log: Logger, filename: string, useBuildFolder = true) {
+  return createPdfGivenTexExport(
+    new Session(undefined, { logger: log }),
+    { format: ExportFormats.tex, output: filename },
+    useBuildFolder,
+  );
+}
+export async function createPdfGivenTexExport(
+  session: ISession,
+  exportOptions: ExportWithOutput,
+  useBuildFolder: boolean,
+  templatePath?: string,
+) {
+  const { output: filename, template } = exportOptions;
   const basename = path.basename(filename, path.extname(filename));
   const tex_filename = `${basename}.tex`;
   const pdf_filename = `${basename}.pdf`;
@@ -18,12 +36,19 @@ export async function createPdfGivenTexFile(log: Logger, filename: string, useBu
   const outputLogFile = path.join(outputPath, log_filename);
 
   const buildPath = path.resolve(useBuildFolder ? path.join(outputPath, BUILD_FOLDER) : outputPath);
-  const CMD = `latexmk -f -xelatex -synctex=1 -interaction=batchmode -file-line-error -latexoption="-shell-escape" ${tex_filename} &> ${tex_log_filename}`;
+
+  let buildCommand: string;
+  if (!template && !templatePath) {
+    buildCommand = pdfExportCommand(tex_filename, tex_log_filename);
+  } else {
+    const jtex = new JTex(session, { template: template || undefined, path: templatePath });
+    buildCommand = jtex.pdfExportCommand(tex_filename, tex_log_filename);
+  }
   try {
     session.log.debug(`Building LaTeX in directory: ${buildPath}`);
     session.log.debug(`Logging output to: ${tex_log_filename}`);
-    session.log.debug(`Running command:\n> ${CMD}`);
-    await exec(CMD, { cwd: buildPath });
+    session.log.debug(`Running command:\n> ${buildCommand}`);
+    await exec(buildCommand, { cwd: buildPath });
     session.log.debug(`Done building LaTeX.`);
   } catch (err) {
     session.log.error(`Error while invoking mklatex: ${err}`);

--- a/apps/cli/src/export/pdf/index.ts
+++ b/apps/cli/src/export/pdf/index.ts
@@ -1,8 +1,8 @@
 import { exportFromPath } from '../utils/exportWrapper';
-import { singleArticleToPdf } from './single';
+import { localArticleToPdf, singleArticleToPdf } from './single';
 
 export { singleArticleToPdf } from './single';
 export { multipleArticleToPdf } from './multiple';
 export { buildPdfOnly } from './build';
 
-export const oxaLinkToPdf = exportFromPath(singleArticleToPdf);
+export const oxaLinkToPdf = exportFromPath(singleArticleToPdf, localArticleToPdf);

--- a/apps/cli/src/export/pdf/single.ts
+++ b/apps/cli/src/export/pdf/single.ts
@@ -60,7 +60,8 @@ export async function localArticleToPdf(session: ISession, file: string, opts: T
     const tempFolder = createTempFolder();
     const texExportOptions = texExportOptionsFromPdf(pdfExportOptions, tempFolder);
     await runTexExport(session, file, texExportOptions, opts.templatePath);
-    const tempPdf = await createPdfGivenTexFile(session.log, texExportOptions.output, false);
+    session.log.info(`🖨  Rendering pdf to ${pdfExportOptions.output}`);
     fs.copyFileSync(tempPdf, pdfExportOptions.output);
+    session.log.debug(`Copied PDF file to ${pdfExportOptions.output}`);
   }
 }

--- a/apps/cli/src/export/pdf/single.ts
+++ b/apps/cli/src/export/pdf/single.ts
@@ -4,7 +4,7 @@ import type { VersionId } from '@curvenote/blocks';
 import type { ISession } from '../../session/types';
 import { createTempFolder, findProject } from '../../utils';
 import { singleArticleToTex } from '../tex';
-import { collectExportOptions, runTexExport } from '../tex/single';
+import { cleanOutput, collectExportOptions, runTexExport } from '../tex/single';
 import type { ExportWithOutput, TexExportOptions } from '../tex/types';
 import { createPdfGivenTexFile, createPdfGivenTexExport } from './create';
 
@@ -34,12 +34,19 @@ export async function singleArticleToPdf(
   return article;
 }
 
-export function texExportOptionsFromPdf(pdfExp: ExportWithOutput, keepTex?: boolean) {
+export function texExportOptionsFromPdf(
+  session: ISession,
+  pdfExp: ExportWithOutput,
+  keepTex?: boolean,
+  clean?: boolean,
+) {
   const basename = path.basename(pdfExp.output, path.extname(pdfExp.output));
   const outputTexFile = `${basename}.tex`;
   let output: string;
   if (keepTex) {
-    output = path.join(path.dirname(pdfExp.output), `${basename}_tex`, outputTexFile);
+    const texOutputFolder = path.join(path.dirname(pdfExp.output), `${basename}_tex`);
+    if (clean) cleanOutput(session, texOutputFolder);
+    output = path.join(texOutputFolder, outputTexFile);
   } else {
     output = path.join(createTempFolder(), outputTexFile);
   }

--- a/apps/cli/src/export/pdf/single.ts
+++ b/apps/cli/src/export/pdf/single.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import type { VersionId } from '@curvenote/blocks';
 import { ExportFormats } from '@curvenote/frontmatter';
 import type { ISession } from '../../session/types';
-import { createTempFolder } from '../../utils';
+import { createTempFolder, findProject } from '../../utils';
 import { singleArticleToTex } from '../tex';
 import { collectExportOptions, runTexExport } from '../tex/single';
 import type { ExportWithOutput, TexExportOptions } from '../tex/types';
@@ -47,12 +47,14 @@ export function texExportOptionsFromPdf(pdfExp: ExportWithOutput, keepTex?: bool
 }
 
 export async function localArticleToPdf(session: ISession, file: string, opts: TexExportOptions) {
+  const projectPath = findProject(session, path.dirname(file));
   const pdfExportOptionsList = await collectExportOptions(
     session,
     file,
     'pdf',
     [ExportFormats.pdf, ExportFormats.pdftex],
     DEFAULT_PDF_FILENAME,
+    projectPath,
     opts,
   );
   // Just a normal loop so these output in serial in the CLI

--- a/apps/cli/src/export/pdf/single.ts
+++ b/apps/cli/src/export/pdf/single.ts
@@ -39,7 +39,7 @@ export function texExportOptionsFromPdf(pdfExp: ExportWithOutput, keepTex?: bool
   const outputTexFile = path.basename(pdfExp.output, path.extname(pdfExp.output)) + '.tex';
   let output: string;
   if (keepTex) {
-    output = path.join(path.dirname(pdfExp.output), outputTexFile);
+    output = path.join(path.dirname(pdfExp.output), 'tex', outputTexFile);
   } else {
     output = path.join(createTempFolder(), outputTexFile);
   }

--- a/apps/cli/src/export/pdf/single.ts
+++ b/apps/cli/src/export/pdf/single.ts
@@ -1,7 +1,6 @@
-import fs from 'fs';
 import path from 'path';
+import { ExportFormats } from 'myst-frontmatter';
 import type { VersionId } from '@curvenote/blocks';
-import { ExportFormats } from '@curvenote/frontmatter';
 import type { ISession } from '../../session/types';
 import { createTempFolder, findProject } from '../../utils';
 import { singleArticleToTex } from '../tex';

--- a/apps/cli/src/export/pdf/single.ts
+++ b/apps/cli/src/export/pdf/single.ts
@@ -35,10 +35,11 @@ export async function singleArticleToPdf(
 }
 
 export function texExportOptionsFromPdf(pdfExp: ExportWithOutput, keepTex?: boolean) {
-  const outputTexFile = path.basename(pdfExp.output, path.extname(pdfExp.output)) + '.tex';
+  const basename = path.basename(pdfExp.output, path.extname(pdfExp.output));
+  const outputTexFile = `${basename}.tex`;
   let output: string;
   if (keepTex) {
-    output = path.join(path.dirname(pdfExp.output), 'tex', outputTexFile);
+    output = path.join(path.dirname(pdfExp.output), `${basename}_tex`, outputTexFile);
   } else {
     output = path.join(createTempFolder(), outputTexFile);
   }
@@ -52,7 +53,6 @@ export async function localArticleToPdf(session: ISession, file: string, opts: T
     file,
     'pdf',
     [ExportFormats.pdf, ExportFormats.pdftex],
-    DEFAULT_PDF_FILENAME,
     projectPath,
     opts,
   );

--- a/apps/cli/src/export/pdf/single.ts
+++ b/apps/cli/src/export/pdf/single.ts
@@ -7,7 +7,7 @@ import { createTempFolder } from '../../utils';
 import { singleArticleToTex } from '../tex';
 import { collectExportOptions, runTexExport } from '../tex/single';
 import type { ExportWithOutput, TexExportOptions } from '../tex/types';
-import { createPdfGivenTexFile } from './create';
+import { createPdfGivenTexFile, createPdfGivenTexExport } from './create';
 
 export const DEFAULT_PDF_FILENAME = 'main.pdf';
 
@@ -61,6 +61,12 @@ export async function localArticleToPdf(session: ISession, file: string, opts: T
     const texExportOptions = texExportOptionsFromPdf(pdfExportOptions, tempFolder);
     await runTexExport(session, file, texExportOptions, opts.templatePath);
     session.log.info(`🖨  Rendering pdf to ${pdfExportOptions.output}`);
+    const tempPdf = await createPdfGivenTexExport(
+      session,
+      texExportOptions,
+      false,
+      opts.templatePath,
+    );
     fs.copyFileSync(tempPdf, pdfExportOptions.output);
     session.log.debug(`Copied PDF file to ${pdfExportOptions.output}`);
   }

--- a/apps/cli/src/export/pdf/single.ts
+++ b/apps/cli/src/export/pdf/single.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { ExportFormats } from 'myst-frontmatter';
 import type { VersionId } from '@curvenote/blocks';
 import type { ISession } from '../../session/types';
-import { createTempFolder, findProject } from '../../utils';
+import { createTempFolder, findProjectAndLoad } from '../../utils';
 import { singleArticleToTex } from '../tex';
 import {
   cleanOutput,
@@ -59,7 +59,7 @@ export function texExportOptionsFromPdf(
 }
 
 export async function localArticleToPdf(session: ISession, file: string, opts: TexExportOptions) {
-  const projectPath = findProject(session, path.dirname(file));
+  const projectPath = await findProjectAndLoad(session, path.dirname(file));
   const pdfExportOptionsList = await collectExportOptions(
     session,
     file,

--- a/apps/cli/src/export/pdf/single.ts
+++ b/apps/cli/src/export/pdf/single.ts
@@ -63,7 +63,6 @@ export async function localArticleToPdf(session: ISession, file: string, opts: T
     const keepTexAndLogs = format === ExportFormats.pdftex;
     const texExportOptions = texExportOptionsFromPdf(pdfExportOptions, keepTexAndLogs);
     await runTexExport(session, file, texExportOptions, opts.templatePath, projectPath);
-    session.log.info(`🖨  Rendering pdf to ${output}`);
     await createPdfGivenTexExport(
       session,
       texExportOptions,

--- a/apps/cli/src/export/pdf/single.ts
+++ b/apps/cli/src/export/pdf/single.ts
@@ -1,15 +1,22 @@
+import fs from 'fs';
 import path from 'path';
 import type { VersionId } from '@curvenote/blocks';
+import { ExportFormats } from '@curvenote/frontmatter';
 import type { ISession } from '../../session/types';
+import { createTempFolder } from '../../utils';
 import { singleArticleToTex } from '../tex';
-import type { TexExportOptions } from '../tex/types';
+import { collectExportOptions, runTexExport } from '../tex/single';
+import type { ExportWithOutput, TexExportOptions } from '../tex/types';
 import { createPdfGivenTexFile } from './create';
+
+export const DEFAULT_PDF_FILENAME = 'main.pdf';
 
 export async function singleArticleToPdf(
   session: ISession,
   versionId: VersionId,
   opts: TexExportOptions,
 ) {
+  if (!opts.filename) opts.filename = DEFAULT_PDF_FILENAME;
   const outputPath = path.dirname(opts.filename);
   const basename = path.basename(opts.filename, path.extname(opts.filename));
   const tex_filename = `${basename}.tex`;
@@ -26,4 +33,34 @@ export async function singleArticleToPdf(
   await createPdfGivenTexFile(session.log, targetTexFilename);
 
   return article;
+}
+
+export function texExportOptionsFromPdf(pdfExp: ExportWithOutput, tempFolder?: string) {
+  const outputTexFile = path.basename(pdfExp.output, path.extname(pdfExp.output)) + '.tex';
+  let output: string;
+  if (tempFolder) {
+    output = path.join(tempFolder, outputTexFile);
+  } else {
+    output = path.join(path.dirname(pdfExp.output), outputTexFile);
+  }
+  return { ...pdfExp, format: ExportFormats.tex, output };
+}
+
+export async function localArticleToPdf(session: ISession, file: string, opts: TexExportOptions) {
+  const pdfExportOptionsList = await collectExportOptions(
+    session,
+    file,
+    ExportFormats.pdf,
+    DEFAULT_PDF_FILENAME,
+    opts,
+  );
+  // Just a normal loop so these output in serial in the CLI
+  for (let index = 0; index < pdfExportOptionsList.length; index++) {
+    const pdfExportOptions = pdfExportOptionsList[index];
+    const tempFolder = createTempFolder();
+    const texExportOptions = texExportOptionsFromPdf(pdfExportOptions, tempFolder);
+    await runTexExport(session, file, texExportOptions, opts.templatePath);
+    const tempPdf = await createPdfGivenTexFile(session.log, texExportOptions.output, false);
+    fs.copyFileSync(tempPdf, pdfExportOptions.output);
+  }
 }

--- a/apps/cli/src/export/pdf/single.ts
+++ b/apps/cli/src/export/pdf/single.ts
@@ -56,19 +56,19 @@ export async function localArticleToPdf(session: ISession, file: string, opts: T
     projectPath,
     opts,
   );
-  // Just a normal loop so these output in serial in the CLI
-  for (let index = 0; index < pdfExportOptionsList.length; index++) {
-    const pdfExportOptions = pdfExportOptionsList[index];
-    const { format, output } = pdfExportOptions;
-    const keepTexAndLogs = format === ExportFormats.pdftex;
-    const texExportOptions = texExportOptionsFromPdf(pdfExportOptions, keepTexAndLogs);
-    await runTexExport(session, file, texExportOptions, opts.templatePath, projectPath);
-    await createPdfGivenTexExport(
-      session,
-      texExportOptions,
-      output,
-      opts.templatePath,
-      keepTexAndLogs,
-    );
-  }
+  await Promise.all(
+    pdfExportOptionsList.map(async (exportOptions) => {
+      const { format, output } = exportOptions;
+      const keepTexAndLogs = format === ExportFormats.pdftex;
+      const texExportOptions = texExportOptionsFromPdf(exportOptions, keepTexAndLogs);
+      await runTexExport(session, file, texExportOptions, opts.templatePath, projectPath);
+      await createPdfGivenTexExport(
+        session,
+        texExportOptions,
+        output,
+        opts.templatePath,
+        keepTexAndLogs,
+      );
+    }),
+  );
 }

--- a/apps/cli/src/export/pdf/single.ts
+++ b/apps/cli/src/export/pdf/single.ts
@@ -62,7 +62,7 @@ export async function localArticleToPdf(session: ISession, file: string, opts: T
     const { format, output } = pdfExportOptions;
     const keepTexAndLogs = format === ExportFormats.pdftex;
     const texExportOptions = texExportOptionsFromPdf(pdfExportOptions, keepTexAndLogs);
-    await runTexExport(session, file, texExportOptions, opts.templatePath);
+    await runTexExport(session, file, texExportOptions, opts.templatePath, projectPath);
     session.log.info(`🖨  Rendering pdf to ${output}`);
     await createPdfGivenTexExport(
       session,

--- a/apps/cli/src/export/tex/gather.ts
+++ b/apps/cli/src/export/tex/gather.ts
@@ -82,10 +82,10 @@ export async function gatherAndWriteArticleContent(
     property: 'jtex',
     messages: {},
     errorLogFn: (message: string) => {
-      session.log.error(`Validation error: "${message}`);
+      session.log.error(`Validation error: ${message}`);
     },
     warningLogFn: (message: string) => {
-      session.log.warn(`Validation: "${message}`);
+      session.log.warn(`Validation: ${message}`);
     },
   });
 

--- a/apps/cli/src/export/tex/multiple.ts
+++ b/apps/cli/src/export/tex/multiple.ts
@@ -114,10 +114,10 @@ export async function multipleArticleToTex(
     property: 'job',
     messages: {},
     errorLogFn: (message: string) => {
-      session.log.error(`Validation error: "${message}`);
+      session.log.error(`Validation error: ${message}`);
     },
     warningLogFn: (message: string) => {
-      session.log.warn(`Validation: "${message}`);
+      session.log.warn(`Validation: ${message}`);
     },
   });
   const projectFrontmatter = projectFrontmatterFromDTO(session, project.data, {
@@ -147,10 +147,10 @@ export async function multipleArticleToTex(
     property: 'jtex',
     messages: {},
     errorLogFn: (message: string) => {
-      session.log.error(`Validation error: "${message}`);
+      session.log.error(`Validation error: ${message}`);
     },
     warningLogFn: (message: string) => {
-      session.log.warn(`Validation: "${message}`);
+      session.log.warn(`Validation: ${message}`);
     },
   });
 

--- a/apps/cli/src/export/tex/single.ts
+++ b/apps/cli/src/export/tex/single.ts
@@ -148,6 +148,7 @@ export async function localArticleToTexTemplated(
   templateOptions: ExportWithOutput,
   templatePath?: string,
   projectPath?: string,
+  force?: boolean,
 ) {
   const { frontmatter, mdast, references } = await getFileContent(
     session,
@@ -188,6 +189,7 @@ export async function localArticleToTexTemplated(
     options: templateOptions,
     sourceFile: file,
     imports: mergeExpandedImports(collectedImports, result),
+    force,
   });
 }
 
@@ -324,7 +326,14 @@ export async function runTexExport(
   if (exportOptions.template === null) {
     await localArticleToTexRaw(session, file, exportOptions.output, projectPath);
   } else {
-    await localArticleToTexTemplated(session, file, exportOptions, templatePath, projectPath);
+    await localArticleToTexTemplated(
+      session,
+      file,
+      exportOptions,
+      templatePath,
+      projectPath,
+      clean,
+    );
   }
 }
 
@@ -340,7 +349,7 @@ export async function localArticleToTex(session: ISession, file: string, opts: T
   );
   await Promise.all(
     exportOptionsList.map(async (exportOptions) => {
-      await runTexExport(session, file, exportOptions, opts.templatePath, projectPath);
+      await runTexExport(session, file, exportOptions, opts.templatePath, projectPath, opts.clean);
     }),
   );
 }

--- a/apps/cli/src/export/tex/single.ts
+++ b/apps/cli/src/export/tex/single.ts
@@ -218,8 +218,7 @@ export async function collectExportOptions(
   projectPath: string | undefined,
   opts: TexExportOptions,
 ) {
-  const { filename, disableTemplate, templatePath } = opts;
-  let { template } = opts;
+  const { filename, disableTemplate, templatePath, template } = opts;
   if (disableTemplate && (opts.template || opts.templatePath)) {
     throw new Error(
       'Conflicting tex export options: disableTemplate requested but a template was provided',
@@ -266,18 +265,19 @@ export async function collectExportOptions(
         session.log.error(`The filename must end with '.${extension}': "${output}"`);
         return undefined;
       }
+      const resolvedOptions: { output: string; template?: string | null } = { output };
       if (disableTemplate) {
-        template = null;
+        resolvedOptions.template = null;
       } else if (!template && exp.template) {
         // template path from file frontmatter needs resolution relative to working directory
         const resolvedTemplatePath = path.resolve(path.dirname(file), exp.template);
         if (fs.existsSync(resolvedTemplatePath)) {
-          template = resolvedTemplatePath;
+          resolvedOptions.template = resolvedTemplatePath;
         } else {
-          template = exp.template;
+          resolvedOptions.template = exp.template;
         }
       }
-      return { ...exp, output, template };
+      return { ...exp, ...resolvedOptions };
     })
     .filter((exp): exp is ExportWithOutput => Boolean(exp));
   if (exportOptions.length === 0) {

--- a/apps/cli/src/export/tex/single.ts
+++ b/apps/cli/src/export/tex/single.ts
@@ -227,16 +227,15 @@ export async function collectExportOptions(
   const rawFrontmatter = await getRawFrontmatterFromFile(session, file);
   let exportOptions: Export[] =
     rawFrontmatter?.exports
-      ?.filter((exp: any) => formats.includes(exp?.format))
-      .map((exp: any, ind: number) =>
-        validateExport(exp, {
+      ?.map((exp: any, ind: number) => {
+        return validateExport(exp, {
           property: `exports.${ind}`,
           messages: {},
           errorLogFn: (msg) => session.log.error(msg),
           warningLogFn: (msg) => session.log.warn(msg),
-        }),
-      )
-      .filter((exp: Export | undefined) => exp) || [];
+        });
+      })
+      .filter((exp: Export | undefined) => exp && formats.includes(exp?.format)) || [];
   // If any arguments are provided on the CLI, only do a single export using the first available frontmatter tex options
   if (filename || template || templatePath || disableTemplate) {
     if (exportOptions.length) {

--- a/apps/cli/src/export/tex/single.ts
+++ b/apps/cli/src/export/tex/single.ts
@@ -319,8 +319,9 @@ export async function localArticleToTex(session: ISession, file: string, opts: T
     projectPath,
     opts,
   );
-  // Just a normal loop so these output in serial in the CLI
-  for (let index = 0; index < exportOptionsList.length; index++) {
-    await runTexExport(session, file, exportOptionsList[index], opts.templatePath, projectPath);
-  }
+  await Promise.all(
+    exportOptionsList.map(async (exportOptions) => {
+      await runTexExport(session, file, exportOptions, opts.templatePath, projectPath);
+    }),
+  );
 }

--- a/apps/cli/src/export/tex/single.ts
+++ b/apps/cli/src/export/tex/single.ts
@@ -19,7 +19,7 @@ import {
   selectFile,
   transformMdast,
 } from '../../store/local/actions';
-import { writeFileToFolder } from '../../utils';
+import { findProject, writeFileToFolder } from '../../utils';
 import { assertEndsInExtension, makeBuildPaths } from '../utils';
 import { writeBibtex } from '../utils/writeBibtex';
 import { gatherAndWriteArticleContent } from './gather';
@@ -30,7 +30,6 @@ import {
 } from './template';
 import type { ExportWithOutput, TexExportOptions } from './types';
 import { ifTemplateRunJtex } from './utils';
-import { format } from 'prettier';
 
 export const DEFAULT_TEX_FILENAME = 'main.tex';
 
@@ -117,6 +116,7 @@ export async function getFileContent(session: ISession, file: string, output: st
     file,
     imageWriteFolder: path.join(path.dirname(output), 'images'),
     imageAltOutputFolder: 'images',
+    projectPath: findProject(session, path.dirname(file)),
   });
   return selectFile(session, file);
 }

--- a/apps/cli/src/export/tex/single.ts
+++ b/apps/cli/src/export/tex/single.ts
@@ -22,7 +22,7 @@ import {
 } from '../../store/local/actions';
 import { selectPageSlug } from '../../store/selectors';
 import { createSlug } from '../../toc/utils';
-import { findProject, writeFileToFolder } from '../../utils';
+import { findProjectAndLoad, writeFileToFolder } from '../../utils';
 import { makeBuildPaths } from '../utils';
 import { writeBibtex } from '../utils/writeBibtex';
 import { gatherAndWriteArticleContent } from './gather';
@@ -356,7 +356,7 @@ export async function resolveAndLogErrors(session: ISession, promises: Promise<a
 }
 
 export async function localArticleToTex(session: ISession, file: string, opts: TexExportOptions) {
-  const projectPath = findProject(session, path.dirname(file));
+  const projectPath = await findProjectAndLoad(session, path.dirname(file));
   const exportOptionsList = await collectExportOptions(
     session,
     file,

--- a/apps/cli/src/export/tex/types.ts
+++ b/apps/cli/src/export/tex/types.ts
@@ -1,8 +1,10 @@
+import type { Export } from '@curvenote/frontmatter';
+
 export interface TexExportOptions {
   filename: string;
   multiple?: boolean;
   images?: string;
-  template?: string;
+  template?: string | null;
   templatePath?: string;
   disableTemplate?: boolean;
   options?: string;
@@ -11,3 +13,7 @@ export interface TexExportOptions {
   converter?: 'inkscape' | 'imagemagick';
   templateOptions?: Record<string, any>;
 }
+
+export type ExportWithOutput = Export & {
+  output: string;
+};

--- a/apps/cli/src/export/tex/types.ts
+++ b/apps/cli/src/export/tex/types.ts
@@ -12,6 +12,7 @@ export interface TexExportOptions {
   texIsIntermediate?: boolean;
   converter?: 'inkscape' | 'imagemagick';
   templateOptions?: Record<string, any>;
+  clean?: boolean;
 }
 
 export type ExportWithOutput = Export & {

--- a/apps/cli/src/export/tex/types.ts
+++ b/apps/cli/src/export/tex/types.ts
@@ -1,4 +1,4 @@
-import type { Export } from '@curvenote/frontmatter';
+import type { Export } from 'myst-frontmatter';
 
 export interface TexExportOptions {
   filename: string;

--- a/apps/cli/src/export/tex/utils.ts
+++ b/apps/cli/src/export/tex/utils.ts
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import { oxaLink } from '@curvenote/blocks';
 import { toTex } from '@curvenote/schema';
@@ -9,10 +8,6 @@ import { makeExecutable } from '../utils/exec';
 import { localizationOptions } from '../utils/localizationOptions';
 import type { ArticleState, ArticleStateChild } from '../utils/walkArticle';
 import type { TexExportOptions } from './types';
-
-export function createTempFolder() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'curvenote'));
-}
 
 export function convertAndLocalizeChild(
   session: ISession,

--- a/apps/cli/src/export/word/index.ts
+++ b/apps/cli/src/export/word/index.ts
@@ -12,7 +12,7 @@ import { Block, MyUser, Project, User, Version } from '../../models';
 import type { ISession } from '../../session/types';
 import { loadFile, selectFile, transformMdast } from '../../store/local/actions';
 import type { References } from '../../transforms/types';
-import { createTempFolder, findProject } from '../../utils';
+import { createTempFolder, findProjectAndLoad } from '../../utils';
 import { assertEndsInExtension } from '../utils/assertions';
 import { exportFromPath } from '../utils/exportWrapper';
 import { getChildren } from '../utils/getChildren';
@@ -50,7 +50,7 @@ export async function localArticleToWord(
   await transformMdast(session, {
     file,
     imageWriteFolder: createTempFolder(),
-    projectPath: findProject(session, path.dirname(file)),
+    projectPath: await findProjectAndLoad(session, path.dirname(file)),
   });
   const { frontmatter, mdast, references } = selectFile(session, file);
   const consolidatedChildren = selectAll('block', mdast).reduce((newChildren, block) => {

--- a/apps/cli/src/export/word/index.ts
+++ b/apps/cli/src/export/word/index.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import { writeDocx } from 'prosemirror-docx';
 import { EditorState } from 'prosemirror-state';
 import type { Image, Root } from 'myst-spec';
@@ -11,7 +12,7 @@ import { Block, MyUser, Project, User, Version } from '../../models';
 import type { ISession } from '../../session/types';
 import { loadFile, selectFile, transformMdast } from '../../store/local/actions';
 import type { References } from '../../transforms/types';
-import { createTempFolder } from '../../utils';
+import { createTempFolder, findProject } from '../../utils';
 import { assertEndsInExtension } from '../utils/assertions';
 import { exportFromPath } from '../utils/exportWrapper';
 import { getChildren } from '../utils/getChildren';
@@ -46,7 +47,11 @@ export async function localArticleToWord(
   const { filename, ...docOpts } = opts;
   assertEndsInExtension(filename, 'docx');
   await loadFile(session, file);
-  await transformMdast(session, { file, imageWriteFolder: createTempFolder() });
+  await transformMdast(session, {
+    file,
+    imageWriteFolder: createTempFolder(),
+    projectPath: findProject(session, path.dirname(file)),
+  });
   const { frontmatter, mdast, references } = selectFile(session, file);
   const consolidatedChildren = selectAll('block', mdast).reduce((newChildren, block) => {
     newChildren.push(...(block as any).children);

--- a/apps/cli/src/frontmatter/index.ts
+++ b/apps/cli/src/frontmatter/index.ts
@@ -36,10 +36,10 @@ export function getPageFrontmatter(
     file,
     messages: {},
     errorLogFn: (message: string) => {
-      session.log.error(`Validation error: "${message}"`);
+      session.log.error(`Validation error: ${message}`);
     },
     warningLogFn: (message: string) => {
-      session.log.warn(`Validation: "${message}"`);
+      session.log.warn(`Validation: ${message}`);
     },
   });
 

--- a/apps/cli/src/toc/fromToc.ts
+++ b/apps/cli/src/toc/fromToc.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { join } from 'path';
+import { join, parse } from 'path';
 import type { JupyterBookChapter } from '../export/jupyter-book/toc';
 import { readTOC, tocFile } from '../export/jupyter-book/toc';
 import type { ISession } from '../session/types';
@@ -47,7 +47,8 @@ export function projectFromToc(
   if (!fs.existsSync(filename)) {
     throw new Error(`Could not find TOC "${filename}". Please create a '_toc.yml'.`);
   }
-  const toc = readTOC(session.log, { filename });
+  const { dir, base } = parse(filename);
+  const toc = readTOC(session.log, { filename: base, path: dir });
   const pageSlugs: PageSlugs = {};
   const indexFile = resolveExtension(join(path, toc.root));
   if (!indexFile) {

--- a/apps/cli/src/toc/utils.ts
+++ b/apps/cli/src/toc/utils.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { extname, join, parse, basename } from 'path';
-import { title2name as createSlug } from '@curvenote/blocks';
+import { title2name } from '@curvenote/blocks';
 import { loadConfigOrThrow } from '../config';
 import { CURVENOTE_YML } from '../config/types';
 import type { ISession } from '../session';
@@ -38,19 +38,6 @@ export function removeExtension(file: string): string {
   return file;
 }
 
-export function createTitle(s: string): string {
-  return (
-    s
-      // https://stackoverflow.com/questions/18379254/regex-to-split-camel-case
-      .split(/([A-Z][a-z0-9]+)|_|-/)
-      .filter((e) => e)
-      .join(' ')
-      .trim()
-      // Now make it into title case (simple, but good enough)
-      .replace(/\w\S*/g, (w) => w.replace(/^\w/, (c) => c.toUpperCase()))
-  );
-}
-
 function removeLeadingEnumeration(s: string): string {
   if (s.match(/^([12][0-9]{3})([^0-9])?/)) {
     // Starts with what looks like a year
@@ -65,10 +52,27 @@ function removeLeadingEnumeration(s: string): string {
   return removed;
 }
 
+export function createSlug(s: string): string {
+  return title2name(removeLeadingEnumeration(s));
+}
+
+export function createTitle(s: string): string {
+  return (
+    removeLeadingEnumeration(s)
+      // https://stackoverflow.com/questions/18379254/regex-to-split-camel-case
+      .split(/([A-Z][a-z0-9]+)|_|-/)
+      .filter((e) => e)
+      .join(' ')
+      .trim()
+      // Now make it into title case (simple, but good enough)
+      .replace(/\w\S*/g, (w) => w.replace(/^\w/, (c) => c.toUpperCase()))
+  );
+}
+
 export function fileInfo(file: string, pageSlugs: PageSlugs): { slug: string; title: string } {
   const { name } = parse(file);
-  let slug = createSlug(removeLeadingEnumeration(name));
-  const title = createTitle(removeLeadingEnumeration(name));
+  let slug = createSlug(name);
+  const title = createTitle(name);
   if (pageSlugs[slug]) {
     pageSlugs[slug] += 1;
     slug = `${slug}-${pageSlugs[slug] - 1}`;

--- a/apps/cli/src/transforms/outputs.ts
+++ b/apps/cli/src/transforms/outputs.ts
@@ -11,7 +11,7 @@ import { createWebFileObjectFactory } from '../web/files';
 export async function transformOutputs(session: ISession, mdast: Root, kind: KINDS) {
   const outputs = selectAll('output', mdast) as GenericNode[];
 
-  if (outputs && kind === KINDS.Article) {
+  if (outputs.length && kind === KINDS.Article) {
     const fileFactory = createWebFileObjectFactory(session.log, publicPath(session), '_static', {
       useHash: true,
     });

--- a/apps/cli/src/utils/utils.ts
+++ b/apps/cli/src/utils/utils.ts
@@ -148,7 +148,7 @@ export function writeFileToFolder(
 }
 
 export function computeHash(content: string) {
-  return createHash('sha256').update(content).digest('hex');
+  return createHash('md5').update(content).digest('hex');
 }
 
 /**
@@ -157,7 +157,8 @@ export function computeHash(content: string) {
  * If hashed file already exists, this does nothing
  */
 export function hashAndCopyStaticFile(session: ISession, file: string, writeFolder: string) {
-  const fileHash = `${computeHash(file)}${path.extname(file)}`;
+  const { name, ext } = path.parse(file);
+  const fileHash = `${name.slice(0, 20)}-${computeHash(fs.readFileSync(file).toString())}${ext}`;
   const destination = path.join(writeFolder, fileHash);
   if (fs.existsSync(destination)) {
     session.log.debug(`Cached file found for: ${file}`);

--- a/apps/cli/src/utils/utils.ts
+++ b/apps/cli/src/utils/utils.ts
@@ -7,12 +7,12 @@ import inquirer from 'inquirer';
 import path from 'path';
 import prettyHrtime from 'pretty-hrtime';
 import type { JsonObject, VersionId } from '@curvenote/blocks';
+import { configFileExists, loadConfigOrThrow, readConfig } from '../config';
 import type { Logger } from '../logging';
 import type { ISession } from '../session/types';
 import { selectors } from '../store';
 import type { WarningKind } from '../store/build';
 import { warnings } from '../store/build';
-import { configFileExists, loadConfigOrThrow, readConfig } from 'src/config';
 
 export const BUILD_FOLDER = '_build';
 export const THUMBNAILS_FOLDER = 'thumbnails';

--- a/apps/cli/src/utils/utils.ts
+++ b/apps/cli/src/utils/utils.ts
@@ -12,6 +12,7 @@ import type { ISession } from '../session/types';
 import { selectors } from '../store';
 import type { WarningKind } from '../store/build';
 import { warnings } from '../store/build';
+import { configFileExists, loadConfigOrThrow, readConfig } from 'src/config';
 
 export const BUILD_FOLDER = '_build';
 export const THUMBNAILS_FOLDER = 'thumbnails';
@@ -210,4 +211,34 @@ export function tic() {
     return f ? f.replace('%s', time) : time;
   }
   return toc;
+}
+
+export function findProject(session: ISession, dir: string): string | undefined {
+  dir = path.resolve(dir);
+  if (configFileExists(dir)) {
+    const { project } = readConfig(session, dir);
+    if (project) {
+      loadConfigOrThrow(session, dir);
+      return dir;
+    }
+  }
+  if (path.dirname(dir) === dir) {
+    return undefined;
+  }
+  return findProject(session, path.dirname(dir));
+}
+
+export function findSite(session: ISession, dir: string): string | undefined {
+  dir = path.resolve(dir);
+  if (configFileExists(dir)) {
+    const { site } = readConfig(session, dir);
+    if (site) {
+      loadConfigOrThrow(session, dir);
+      return dir;
+    }
+  }
+  if (path.dirname(dir) === dir) {
+    return undefined;
+  }
+  return findProject(session, path.dirname(dir));
 }

--- a/apps/cli/src/utils/utils.ts
+++ b/apps/cli/src/utils/utils.ts
@@ -10,7 +10,6 @@ import type { JsonObject, VersionId } from '@curvenote/blocks';
 import { configFileExists, loadConfigOrThrow, readConfig } from '../config';
 import type { Logger } from '../logging';
 import type { ISession } from '../session/types';
-import { selectors } from '../store';
 import type { WarningKind } from '../store/build';
 import { warnings } from '../store/build';
 

--- a/apps/cli/src/utils/utils.ts
+++ b/apps/cli/src/utils/utils.ts
@@ -227,18 +227,3 @@ export function findProject(session: ISession, dir: string): string | undefined 
   }
   return findProject(session, path.dirname(dir));
 }
-
-export function findSite(session: ISession, dir: string): string | undefined {
-  dir = path.resolve(dir);
-  if (configFileExists(dir)) {
-    const { site } = readConfig(session, dir);
-    if (site) {
-      loadConfigOrThrow(session, dir);
-      return dir;
-    }
-  }
-  if (path.dirname(dir) === dir) {
-    return undefined;
-  }
-  return findProject(session, path.dirname(dir));
-}

--- a/apps/cli/src/utils/utils.ts
+++ b/apps/cli/src/utils/utils.ts
@@ -158,7 +158,11 @@ export function computeHash(content: string) {
  */
 export function hashAndCopyStaticFile(session: ISession, file: string, writeFolder: string) {
   const { name, ext } = path.parse(file);
-  const fileHash = `${name.slice(0, 20)}-${computeHash(fs.readFileSync(file).toString())}${ext}`;
+  const fd = fs.openSync(file, 'r');
+  const { mtime, size } = fs.fstatSync(fd);
+  fs.closeSync(fd);
+  const hash = computeHash(`${mtime.toString()}${size.toString()}`);
+  const fileHash = `${name.slice(0, 20)}-${hash}${ext}`;
   const destination = path.join(writeFolder, fileHash);
   if (fs.existsSync(destination)) {
     session.log.debug(`Cached file found for: ${file}`);

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -38,8 +38,8 @@
     "url": "https://github.com/curvenote/curvenote/issues"
   },
   "dependencies": {
-    "simple-validators": "^0.0.1",
-    "myst-frontmatter": "^0.0.1"
+    "myst-frontmatter": "^0.0.1",
+    "simple-validators": "^0.0.1"
   },
   "devDependencies": {
     "@types/jest": "^28.1.6",

--- a/packages/frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -236,6 +236,12 @@ describe('validateExport', () => {
   it('format only passes', async () => {
     expect(validateExport({ format: 'pdf' }, opts)).toEqual({ format: 'pdf' });
   });
+  it('pdf+tex passes', async () => {
+    expect(validateExport({ format: 'pdf+tex' }, opts)).toEqual({ format: 'pdf+tex' });
+  });
+  it('tex+pdf passes', async () => {
+    expect(validateExport({ format: 'tex+pdf' }, opts)).toEqual({ format: 'pdf+tex' });
+  });
   it('invalid format errors passes', async () => {
     expect(validateExport({ format: 'str' }, opts)).toEqual(undefined);
     expect(opts.messages.errors?.length).toEqual(1);

--- a/packages/frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -373,12 +373,13 @@ describe('fillPageFrontmatter', () => {
   it('page frontmatter returns self', async () => {
     expect(fillPageFrontmatter(TEST_PAGE_FRONTMATTER, {})).toEqual(TEST_PAGE_FRONTMATTER);
   });
-  it('project frontmatter returns self without title/description/name', async () => {
+  it('project frontmatter returns self without title/description/name/etc', async () => {
     const result = { ...TEST_PROJECT_FRONTMATTER };
     delete result.title;
     delete result.description;
     delete result.name;
     delete result.oxa;
+    delete result.exports;
     expect(fillPageFrontmatter({}, TEST_PROJECT_FRONTMATTER)).toEqual(result);
   });
   it('page and project math are combined', async () => {

--- a/packages/frontmatter/src/frontmatter/types.ts
+++ b/packages/frontmatter/src/frontmatter/types.ts
@@ -83,6 +83,7 @@ export type KernelSpec = {
 export enum ExportFormats {
   pdf = 'pdf',
   tex = 'tex',
+  pdftex = 'pdf+tex',
   docx = 'docx',
 }
 

--- a/packages/frontmatter/src/frontmatter/validators.ts
+++ b/packages/frontmatter/src/frontmatter/validators.ts
@@ -372,6 +372,7 @@ export function validateExport(input: any, opts: ValidationOptions) {
     { ...opts, suppressWarnings: true },
   );
   if (value.format === undefined) return undefined;
+  if (value.format === 'tex+pdf') value.format = 'pdf+tex';
   const format = validateEnum<ExportFormats>(value.format, {
     ...incrementOptions('format', opts),
     enum: ExportFormats,

--- a/packages/frontmatter/src/frontmatter/validators.ts
+++ b/packages/frontmatter/src/frontmatter/validators.ts
@@ -83,7 +83,6 @@ export const USE_PROJECT_FALLBACK = [
   'biblio',
   'numbering',
   'keywords',
-  'exports',
 ];
 
 const AUTHOR_KEYS = [

--- a/packages/jtex/src/export.ts
+++ b/packages/jtex/src/export.ts
@@ -1,0 +1,4 @@
+export function pdfExportCommand(texFile: string, logFile: string, engine?: string) {
+  if (!engine) engine = 'xelatex';
+  return `latexmk -f -${engine} -synctex=1 -interaction=batchmode -file-line-error -latexoption="-shell-escape" ${texFile} &> ${logFile}`;
+}

--- a/packages/jtex/src/index.ts
+++ b/packages/jtex/src/index.ts
@@ -1,5 +1,6 @@
 import JTex from './jtex';
 export * from './download';
+export * from './export';
 export * from './frontmatter';
 export * from './session';
 export * from './types';

--- a/packages/jtex/src/jtex.ts
+++ b/packages/jtex/src/jtex.ts
@@ -175,6 +175,7 @@ class JTex {
     options: any;
     sourceFile?: string;
     imports?: string | ExpandedImports;
+    force?: boolean;
   }) {
     if (!fs.existsSync(join(this.templatePath, TEMPLATE_FILENAME))) {
       throw new Error(
@@ -205,7 +206,7 @@ class JTex {
     const rendered = this.env.render(TEMPLATE_FILENAME, renderer);
     const outputDirectory = dirname(opts.outputPath);
     ensureDirectoryExists(outputDirectory);
-    this.copyTemplateFiles(dirname(opts.outputPath));
+    this.copyTemplateFiles(dirname(opts.outputPath), { force: opts.force });
     fs.writeFileSync(opts.outputPath, `% Created with jtex v.${version}\n${rendered}`);
     fs.writeFileSync(join(outputDirectory, 'curvenote.def'), curvenoteDef);
   }

--- a/packages/jtex/src/jtex.ts
+++ b/packages/jtex/src/jtex.ts
@@ -5,6 +5,7 @@ import nunjucks from 'nunjucks';
 import type { ValidationOptions } from 'simple-validators';
 import { curvenoteDef } from './definitions';
 import { downloadAndUnzipTemplate, resolveInputs, TEMPLATE_FILENAME } from './download';
+import { pdfExportCommand } from './export';
 import { extendJtexFrontmatter } from './frontmatter';
 import { renderImports } from './imports';
 import type { ExpandedImports, ISession, Renderer, TemplateYml } from './types';
@@ -234,6 +235,11 @@ class JTex {
 
   freeform(template: string, data: Record<string, any>) {
     return this.env.renderString(template, data);
+  }
+
+  pdfExportCommand(texFile: string, logFile: string) {
+    const templateYml = this.getValidatedTemplateYml();
+    return pdfExportCommand(texFile, logFile, templateYml.build?.engine);
   }
 }
 

--- a/packages/myst-to-tex/package.json
+++ b/packages/myst-to-tex/package.json
@@ -49,8 +49,8 @@
   "dependencies": {
     "myst-common": "*",
     "myst-frontmatter": "*",
-    "vfile-reporter": "^7.0.4",
-    "unist-util-select": "^4.0.0"
+    "unist-util-select": "^4.0.0",
+    "vfile-reporter": "^7.0.4"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
- [x] Command line pdf export works with local file and uses frontmatter options
- [x] Logging messages on pdf build
- [x] Use format `pdf+tex` to keep build artifacts
- [x] Allow alternative build engine `pdflatex`: https://github.com/curvenote/curvenote/issues/307

More things:
- [x] Don't fall back to project `exports` on page frontmatter (we maybe want to do something more complicated like pages can use the `template` specified in project frontmatter... but simply populating pages with project `exports` feels wrong)
- [x] Fill frontmatter from project (e.g. authors)
- [x] Default `_build` directory should be in project root