### PR TITLE
📑 Move template yml types from jtex to myst-templates

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -81,6 +81,7 @@
     "myst-common": "*",
     "myst-frontmatter": "*",
     "myst-spec": "^0.0.4",
+    "myst-templates": "*",
     "myst-to-docx": "*",
     "myst-to-tex": "*",
     "myst-transforms": "*",

--- a/apps/cli/src/export/tex/single.ts
+++ b/apps/cli/src/export/tex/single.ts
@@ -1,8 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-import type { TemplatePartDefinition, TemplateImports, TemplateYml } from 'jtex';
+import type { TemplateImports } from 'jtex';
 import JTex, { mergeTemplateImports } from 'jtex';
 import type { Root } from 'mdast';
+import type { TemplatePartDefinition, TemplateYml } from 'myst-templates';
 import { selectAll, unified } from 'mystjs';
 import mystToTex from 'myst-to-tex';
 import type { LatexResult } from 'myst-to-tex';

--- a/packages/blocks/src/utils/id.ts
+++ b/packages/blocks/src/utils/id.ts
@@ -182,7 +182,13 @@ export function ensureConsistentChildren(oldOrder: string[], oldChildren: BlockC
 }
 
 export function splitScopedTemplateId(scopedId: string) {
-  const [owner, templateId] = scopedId.split('/');
+  // Account for public/default and tex/myst/curvenote id
+  const parts = scopedId.split('/');
+  let [owner, templateId] = parts.slice(1);
+  if (!templateId) {
+    [owner, templateId] = parts;
+  }
   if (!templateId) throw Error(`Malformed scopedId: ${scopedId}`);
-  return { owner, templateId, isPrivate: owner !== 'public' };
+  const publicOwners = ['public', 'myst'];
+  return { owner, templateId, isPrivate: !publicOwners.includes(owner) };
 }

--- a/packages/jtex/package.json
+++ b/packages/jtex/package.json
@@ -61,6 +61,7 @@
     "js-yaml": "^4.1.0",
     "myst-cli-utils": "^0.0.4",
     "myst-frontmatter": "^0.0.1",
+    "myst-templates": "^0.0.1",
     "node-fetch": "^2.6.7",
     "nunjucks": "^3.2.3",
     "pretty-hrtime": "^1.0.3",

--- a/packages/jtex/src/download.ts
+++ b/packages/jtex/src/download.ts
@@ -1,10 +1,11 @@
 import { createHash } from 'crypto';
 import fs, { createReadStream, createWriteStream, mkdirSync } from 'fs';
+import type { TemplateYmlListResponse, TemplateYmlResponse } from 'myst-templates';
 import fetch from 'node-fetch';
 import unzipper from 'unzipper';
 import { join, parse } from 'path';
 import { validateUrl } from 'simple-validators';
-import type { ISession, TemplateYmlListResponse, TemplateYmlResponse } from './types';
+import type { ISession } from './types';
 
 export const TEMPLATE_FILENAME = 'template.tex';
 

--- a/packages/jtex/src/jtex.ts
+++ b/packages/jtex/src/jtex.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { extname, basename, join, dirname } from 'path';
 import yaml from 'js-yaml';
+import type { TemplateYml } from 'myst-templates';
 import nunjucks from 'nunjucks';
 import type { ValidationOptions } from 'simple-validators';
 import { curvenoteDef } from './definitions';
@@ -9,7 +10,7 @@ import { pdfExportCommand } from './export';
 import { extendJtexFrontmatter } from './frontmatter';
 import { renderImports } from './imports';
 import { getSession } from './session';
-import type { TemplateImports, ISession, Renderer, TemplateYml } from './types';
+import type { TemplateImports, ISession, Renderer } from './types';
 import { ensureDirectoryExists, errorLogger, warningLogger } from './utils';
 import {
   validateTemplateDoc,

--- a/packages/jtex/src/types.ts
+++ b/packages/jtex/src/types.ts
@@ -1,5 +1,5 @@
 import type { ISession as BaseISession } from 'myst-cli-utils';
-import type { Author, Licenses, PageFrontmatter } from 'myst-frontmatter';
+import type { Author, PageFrontmatter } from 'myst-frontmatter';
 import { PAGE_FRONTMATTER_KEYS } from 'myst-frontmatter';
 
 export interface ISession extends BaseISession {
@@ -10,104 +10,6 @@ export type TemplateImports = {
   imports: string[];
   commands: Record<string, string>;
 };
-
-export type TemplatePartDefinition = {
-  id: string;
-  title?: string;
-  description?: string;
-  required?: boolean;
-  plain?: boolean;
-  max_chars?: number;
-  max_words?: number;
-  condition?: {
-    id: string;
-    value?: any;
-  };
-};
-
-export enum TemplateOptionTypes {
-  boolean = 'boolean',
-  string = 'string',
-  choice = 'choice',
-}
-
-export type TemplateDocDefinition = {
-  id: string;
-  title?: string;
-  description?: string;
-  required?: boolean;
-  condition?: {
-    id: string;
-    value?: any;
-  };
-};
-
-export type TemplateOptionDefinition = TemplateDocDefinition & {
-  type: TemplateOptionTypes;
-  default?: any;
-  choices?: string[];
-  max_chars?: number;
-};
-
-export type TemplateStyles = {
-  citation?: 'numerical-only';
-  bibliography?: 'natbib' | 'biblatex';
-};
-
-type TemplateYmlListPartial = {
-  title?: string;
-  description?: string;
-  version?: string;
-  authors?: Author[];
-  license?: Licenses;
-  tags?: string[];
-};
-
-type TemplateYmlPartial = {
-  jtex: 'v1';
-  github?: string;
-  build?: { engine?: string };
-  style?: TemplateStyles;
-  parts?: TemplatePartDefinition[];
-  doc?: TemplateDocDefinition[];
-  options?: TemplateOptionDefinition[];
-  packages?: string[];
-  files?: string[];
-};
-
-type TemplateYmlIdLinks = {
-  id: string;
-  links: {
-    self: string;
-    download: string;
-    thumbnail: string;
-    source?: string;
-  };
-};
-
-/**
- * Type template.yml files are directly validated against
- */
-export type TemplateYml = TemplateYmlPartial &
-  TemplateYmlListPartial & {
-    source?: string;
-    thumbnail?: string;
-  };
-
-/**
- * Type for /template/tex API list response
- */
-export type TemplateYmlListResponse = {
-  items: (TemplateYmlListPartial &
-    TemplateYmlIdLinks & {
-      kind: string;
-    })[];
-};
-
-/**
- * Type for /template/tex/org/name API response
- */
-export type TemplateYmlResponse = TemplateYmlPartial & TemplateYmlListPartial & TemplateYmlIdLinks;
 
 export type ValueAndIndex = {
   value: any;

--- a/packages/jtex/src/validators.ts
+++ b/packages/jtex/src/validators.ts
@@ -8,6 +8,14 @@ import {
   validateLicenses,
   validatePageFrontmatter,
 } from 'myst-frontmatter';
+import type {
+  TemplateDocDefinition,
+  TemplateOptionDefinition,
+  TemplatePartDefinition,
+  TemplateStyles,
+  TemplateYml,
+} from 'myst-templates';
+import { TemplateOptionTypes } from 'myst-templates';
 import {
   defined,
   incrementOptions,
@@ -24,14 +32,6 @@ import {
   validationError,
 } from 'simple-validators';
 import type { ValidationOptions } from 'simple-validators';
-import type {
-  TemplateDocDefinition,
-  TemplateOptionDefinition,
-  TemplatePartDefinition,
-  TemplateStyles,
-  TemplateYml,
-} from './types';
-import { TemplateOptionTypes } from './types';
 
 export function validateTemplateOption(
   input: any,

--- a/packages/myst-templates/src/index.ts
+++ b/packages/myst-templates/src/index.ts
@@ -1,22 +1,104 @@
-import type { Author, License } from 'myst-frontmatter';
+import type { Author, Licenses } from 'myst-frontmatter';
 
 export enum TemplateKind {
   tex = 'tex',
+  docx = 'docx',
 }
 
-export type TemplateDTO = {
+export type TemplatePartDefinition = {
   id: string;
-  kind: TemplateKind;
-  title: string;
-  description: string;
-  authors: Author[];
-  license?: License;
-  tags: string[];
-  version: string;
-  links: {
-    self: string;
-    source: string;
-    thumbnail: string;
-    download: string;
+  title?: string;
+  description?: string;
+  required?: boolean;
+  plain?: boolean;
+  max_chars?: number;
+  max_words?: number;
+  condition?: {
+    id: string;
+    value?: any;
   };
 };
+
+export enum TemplateOptionTypes {
+  boolean = 'boolean',
+  string = 'string',
+  choice = 'choice',
+}
+
+export type TemplateDocDefinition = {
+  id: string;
+  title?: string;
+  description?: string;
+  required?: boolean;
+  condition?: {
+    id: string;
+    value?: any;
+  };
+};
+
+export type TemplateOptionDefinition = TemplateDocDefinition & {
+  type: TemplateOptionTypes;
+  default?: any;
+  choices?: string[];
+  max_chars?: number;
+};
+
+export type TemplateStyles = {
+  citation?: 'numerical-only';
+  bibliography?: 'natbib' | 'biblatex';
+};
+
+type TemplateYmlListPartial = {
+  title?: string;
+  description?: string;
+  version?: string;
+  authors?: Author[];
+  license?: Licenses;
+  tags?: string[];
+};
+
+type TemplateYmlPartial = {
+  jtex: 'v1';
+  github?: string;
+  build?: { engine?: string };
+  style?: TemplateStyles;
+  parts?: TemplatePartDefinition[];
+  doc?: TemplateDocDefinition[];
+  options?: TemplateOptionDefinition[];
+  packages?: string[];
+  files?: string[];
+};
+
+type TemplateYmlIdLinks = {
+  id: string;
+  links: {
+    self: string;
+    download: string;
+    thumbnail: string;
+    source?: string;
+  };
+};
+
+/**
+ * Type template.yml files are directly validated against
+ */
+export type TemplateYml = TemplateYmlPartial &
+  TemplateYmlListPartial & {
+    source?: string;
+    thumbnail?: string;
+  };
+
+/**
+ * Type for /template/tex API list response
+ */
+export type TemplateYmlListResponse = {
+  items: (TemplateYmlListPartial &
+    TemplateYmlIdLinks & {
+      kind: TemplateKind;
+    })[];
+};
+
+/**
+ * Type for /template/tex/org/name API response
+ */
+export type TemplateYmlResponse = TemplateYmlPartial & TemplateYmlListPartial & TemplateYmlIdLinks;


### PR DESCRIPTION
This allows us to import these types without all the additional jtex baggage.