### PR TITLE
🗑 Remove dependence on site-common

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13710,7 +13710,6 @@
       "license": "MIT",
       "dependencies": {
         "@curvenote/blocks": "^1.5.16",
-        "@curvenote/site-common": "^0.0.18",
         "@reduxjs/toolkit": "^1.7.2",
         "adm-zip": "^0.5.9",
         "chalk": "^5.1.2",
@@ -20597,7 +20596,6 @@
       "version": "file:packages/myst-cli",
       "requires": {
         "@curvenote/blocks": "^1.5.16",
-        "@curvenote/site-common": "^0.0.18",
         "@reduxjs/toolkit": "^1.7.2",
         "@types/jest": "^28.1.6",
         "adm-zip": "^0.5.9",

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -55,7 +55,6 @@
   "dependencies": {
     "@curvenote/blocks": "^1.5.16",
     "nbtx": "^0.1.11",
-    "@curvenote/site-common": "^0.0.18",
     "@reduxjs/toolkit": "^1.7.2",
     "adm-zip": "^0.5.9",
     "chalk": "^5.1.2",

--- a/packages/myst-cli/src/process/file.ts
+++ b/packages/myst-cli/src/process/file.ts
@@ -8,11 +8,7 @@ import { warnings, watch } from '../store/reducers';
 import { loadCitations } from './citations';
 import { parseMyst } from './myst';
 import { processNotebook } from './notebook';
-
-export enum KINDS {
-  Article = 'Article',
-  Notebook = 'Notebook',
-}
+import { KINDS } from '../transforms/types';
 
 export async function loadFile(
   session: ISession,

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -27,6 +27,7 @@ import { watch } from '../store/reducers';
 import type { ISession } from '../session/types';
 import { castSession } from '../session';
 import type { References, RendererData } from '../transforms/types';
+import { KINDS } from '../transforms/types';
 import {
   checkLinksTransform,
   importMdastFromJson,
@@ -40,7 +41,7 @@ import {
 } from '../transforms';
 import { logMessagesFromVFile } from '../utils';
 import { combineCitationRenderers } from './citations';
-import { bibFilesInDir, KINDS, selectFile } from './file';
+import { bibFilesInDir, selectFile } from './file';
 import { loadIntersphinx } from './intersphinx';
 
 const LINKS_SELECTOR = 'link,card,linkBlock';

--- a/packages/myst-cli/src/transforms/outputs.ts
+++ b/packages/myst-cli/src/transforms/outputs.ts
@@ -1,11 +1,11 @@
 import type { GenericNode } from 'mystjs';
 import { selectAll } from 'mystjs';
 import type { CellOutput } from '@curvenote/blocks';
-import { KINDS } from '@curvenote/blocks';
 import { minifyCellOutput, walkPaths } from 'nbtx';
 import type { Root } from 'mdast';
 import type { ISession } from '../session/types';
 import { createWebFileObjectFactory } from '../utils';
+import { KINDS } from './types';
 
 export async function transformOutputs(session: ISession, mdast: Root, kind: KINDS) {
   const outputs = selectAll('output', mdast) as GenericNode[];

--- a/packages/myst-cli/src/transforms/types.ts
+++ b/packages/myst-cli/src/transforms/types.ts
@@ -1,12 +1,24 @@
-import type { CitationRenderer } from 'citation-js-utils';
-import type { KINDS } from '@curvenote/blocks';
-import type { References as SiteReferences } from '@curvenote/site-common';
-import type { PageFrontmatter } from 'myst-frontmatter';
+import type { FootnoteDefinition } from 'myst-spec';
 import type { Root } from 'mdast';
+import type { PageFrontmatter } from 'myst-frontmatter';
+import type { CitationRenderer } from 'citation-js-utils';
 
-export type { Citations, Footnotes } from '@curvenote/site-common';
+export enum KINDS {
+  Article = 'Article',
+  Notebook = 'Notebook',
+}
 
-export type References = Required<Omit<SiteReferences, 'article'>>;
+type Citations = {
+  order: string[];
+  data: Record<string, { html: string; number: number; doi: string | undefined }>;
+};
+
+type Footnotes = Record<string, FootnoteDefinition>;
+
+export type References = {
+  cite: Citations;
+  footnotes: Footnotes;
+};
 
 export type PreRendererData = {
   file: string;


### PR DESCRIPTION
This is a super simple PR that removes dependence on the site-common types. It duplicates some of the pieces around footnotes and citations. We need to do a bit better there and they should just be part of the myst-spec instead of being side-car-ed in.