### PR TITLE
🔑 Add keywords to block frontmatter properties

### DIFF
--- a/packages/blocks/src/blocks/types/frontMatter.ts
+++ b/packages/blocks/src/blocks/types/frontMatter.ts
@@ -12,6 +12,7 @@ export type FrontMatterProps = {
   github: string | null;
   binder: string | null;
   subject: string | null;
+  keywords: string[] | null;
   subtitle: string | null;
   short_title: string | null;
   venue: { title?: string; url?: string } | null;
@@ -37,6 +38,7 @@ export const PROJECT_FRONT_MATTER_KEYS = [
   'github',
   'binder',
   'subject',
+  'keywords',
   'short_title',
 ] as (keyof ProjectFrontMatterProps)[];
 

--- a/packages/blocks/src/blocks/utils.spec.ts
+++ b/packages/blocks/src/blocks/utils.spec.ts
@@ -43,6 +43,7 @@ describe('extractBlockFrontMatter', () => {
       open_access: false,
       venue: {},
       biblio: {},
+      keywords: [],
     };
 
     expect(extractBlockFrontMatter(frontmatter)).toEqual(frontmatter);

--- a/packages/curvenote/src/session/session.ts
+++ b/packages/curvenote/src/session/session.ts
@@ -13,6 +13,8 @@ import type { ISession, Response, Tokens } from './types';
 
 const DEFAULT_API_URL = 'https://api.curvenote.com';
 const DEFAULT_SITE_URL = 'https://curvenote.com';
+const LOCAL_API_URL = 'http://localhost:8083';
+const LOCAL_SITE_URL = 'http://localhost:3000';
 const CONFIG_FILES = ['curvenote.yml', 'myst.yml'];
 
 export type SessionOptions = {
@@ -50,9 +52,13 @@ export class Session implements ISession {
     this.$logger = opts.logger ?? basicLogger(LogLevel.info);
     const url = this.setToken(token);
     this.API_URL = opts.apiUrl ?? url ?? DEFAULT_API_URL;
-    this.SITE_URL = opts.siteUrl ?? DEFAULT_SITE_URL;
+    this.SITE_URL =
+      opts.siteUrl ?? (this.API_URL === LOCAL_API_URL ? LOCAL_SITE_URL : DEFAULT_SITE_URL);
     if (this.API_URL !== DEFAULT_API_URL) {
       this.log.warn(`Connecting to API at: "${this.API_URL}".`);
+    }
+    if (this.SITE_URL !== DEFAULT_SITE_URL) {
+      this.log.warn(`Connecting to Site at: "${this.SITE_URL}".`);
     }
     this.store = createStore(rootReducer);
     findCurrentProjectAndLoad(this, '.');


### PR DESCRIPTION
Keywords are already included in `myst-frontmatter`, this adds them to curvenote block classes.