### PR TITLE
Add `parts` to block type

### DIFF
--- a/packages/blocks/src/blocks/index.ts
+++ b/packages/blocks/src/blocks/index.ts
@@ -107,6 +107,7 @@ export function blockFromDTO(blockId: BlockId, json: JsonObject): Block {
     published: (json.published_versions ?? []).length > 0,
     published_versions: json.published_versions ?? [],
     tags: getTags(json.tags),
+    parts: getTags(json.parts),
     latest_version: json.latest_version ?? null,
     default_draft: json.default_draft ?? null,
     num_versions: json.num_versions ?? 0,

--- a/packages/blocks/src/blocks/types/index.ts
+++ b/packages/blocks/src/blocks/types/index.ts
@@ -47,6 +47,7 @@ export interface PartialBlock extends BlockFrontMatterProps {
   caption: string | null;
   name: string | null;
   tags: string[];
+  parts: string[];
   default_draft: string | null;
   pending: string | null;
 }

--- a/packages/blocks/src/helpers.ts
+++ b/packages/blocks/src/helpers.ts
@@ -16,7 +16,8 @@ export function getTags(tags?: string | string[], defaultTags?: string[]): strin
   return tags.split(',');
 }
 
-export function formatTags(tags: string[]) {
+export function formatTags(tags?: string[]) {
+  if (!tags) return [];
   return [...tags];
 }
 

--- a/packages/curvenote/src/export/markdown/index.ts
+++ b/packages/curvenote/src/export/markdown/index.ts
@@ -85,6 +85,7 @@ export async function articleToMarkdown(
       const blockData = {
         oxa: oxaLink('', child.version.id),
         tags: child.block?.data.tags || [],
+        parts: child.block?.data.parts || [],
       };
       let md = '';
       let mdastSnippets: Record<string, GenericNode<Record<string, any>>> = {};

--- a/packages/curvenote/src/frontmatter/frontmatter.spec.ts
+++ b/packages/curvenote/src/frontmatter/frontmatter.spec.ts
@@ -236,6 +236,7 @@ describe('pageFrontmatterFromDTO', () => {
     date_modified: date,
     pending: '',
     tags: ['a-tag'],
+    parts: ['a-part'],
     default_draft: '',
     links: {
       project: '',


### PR DESCRIPTION
This adds `parts` alongside `tags` on the `block` type. It also adds `parts` as myst metadata when pulling a block from the API.