### PR TITLE
🐛 Fix export wrapper bugs and pass through temp folders / log files

### DIFF
--- a/.changeset/neat-dolls-destroy.md
+++ b/.changeset/neat-dolls-destroy.md
@@ -1,0 +1,5 @@
+---
+'curvenote': patch
+---
+
+Fix project path when exporting from a curvenote url

--- a/.changeset/rude-bats-impress.md
+++ b/.changeset/rude-bats-impress.md
@@ -1,0 +1,5 @@
+---
+'curvenote': patch
+---
+
+Return all temp folders and log files from export functions

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,13 +37,13 @@
       }
     },
     "mystjs/packages/jats-to-myst": {
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "doi-utils": "^2.0.0",
         "jats-tags": "^1.0.0",
         "jats-xml": "^1.0.1",
-        "myst-common": "^1.0.0",
+        "myst-common": "^1.0.1",
         "myst-frontmatter": "^1.0.0",
         "myst-spec": "^0.0.4",
         "myst-spec-ext": "^1.0.0",
@@ -53,15 +53,15 @@
       }
     },
     "mystjs/packages/jtex": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.2.0",
         "commander": "^10.0.1",
         "js-yaml": "^4.1.0",
         "myst-cli-utils": "^2.0.0",
-        "myst-frontmatter": "^1.0.0",
-        "myst-templates": "^1.0.0",
+        "myst-frontmatter": "^1.0.1",
+        "myst-templates": "^1.0.1",
         "node-fetch": "^3.3.1",
         "nunjucks": "^3.2.4",
         "pretty-hrtime": "^1.0.3",
@@ -108,7 +108,7 @@
       }
     },
     "mystjs/packages/myst-cli": {
-      "version": "1.0.1",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@jupyterlab/nbformat": "3.5.2",
@@ -128,11 +128,11 @@
         "inquirer": "^8.2.2",
         "intersphinx": "^1.0.2",
         "js-yaml": "^4.1.0",
-        "jtex": "^1.0.0",
+        "jtex": "^1.0.1",
         "mdast": "^3.0.0",
         "mime-types": "^2.1.35",
         "myst-cli-utils": "^2.0.0",
-        "myst-common": "^1.0.0",
+        "myst-common": "^1.0.1",
         "myst-config": "^1.0.0",
         "myst-ext-card": "^1.0.0",
         "myst-ext-exercise": "^1.0.0",
@@ -140,15 +140,16 @@
         "myst-ext-proof": "^1.0.0",
         "myst-ext-reactive": "^1.0.0",
         "myst-ext-tabs": "^1.0.0",
-        "myst-frontmatter": "^1.0.0",
+        "myst-frontmatter": "^1.0.1",
         "myst-parser": "^1.0.1",
         "myst-spec": "^0.0.4",
-        "myst-spec-ext": "^1.0.0",
-        "myst-templates": "^1.0.0",
+        "myst-spec-ext": "^1.0.1",
+        "myst-templates": "^1.0.1",
         "myst-to-docx": "^1.0.0",
-        "myst-to-jats": "^1.0.0",
-        "myst-to-tex": "^1.0.0",
-        "myst-transforms": "^1.0.0",
+        "myst-to-jats": "^1.0.1",
+        "myst-to-md": "^1.0.2",
+        "myst-to-tex": "^1.0.1",
+        "myst-transforms": "^1.0.1",
         "nanoid": "^4.0.0",
         "nbtx": "^0.2.3",
         "node-fetch": "^3.3.1",
@@ -156,14 +157,15 @@
         "redux": "^4.2.0",
         "simple-validators": "^1.0.0",
         "strip-ansi": "^7.0.1",
-        "tex-to-myst": "^1.0.0",
+        "tex-to-myst": "^1.0.1",
         "unified": "^10.1.2",
         "unist-util-filter": "^4.0.0",
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.5",
         "which": "^3.0.1",
-        "ws": "^8.9.0"
+        "ws": "^8.9.0",
+        "xml-js": "^1.6.11"
       },
       "bin": {
         "myst": "dist/myst.cjs"
@@ -213,7 +215,7 @@
       }
     },
     "mystjs/packages/myst-common": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "mdast": "^3.0.0",
@@ -323,7 +325,7 @@
       }
     },
     "mystjs/packages/myst-frontmatter": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "credit-roles": "^2.0.0",
@@ -383,7 +385,7 @@
       "devDependencies": {}
     },
     "mystjs/packages/myst-spec-ext": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "myst-spec": "^0.0.4"
@@ -391,7 +393,7 @@
       "devDependencies": {}
     },
     "mystjs/packages/myst-templates": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.2.0",
@@ -399,7 +401,7 @@
         "js-yaml": "^4.1.0",
         "myst-cli-utils": "^2.0.0",
         "myst-common": "^1.0.0",
-        "myst-frontmatter": "^1.0.0",
+        "myst-frontmatter": "^1.0.1",
         "node-fetch": "^3.3.1",
         "pretty-hrtime": "^1.0.3",
         "simple-validators": "^1.0.0",
@@ -448,12 +450,12 @@
       "devDependencies": {}
     },
     "mystjs/packages/myst-to-jats": {
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "citation-js-utils": "^1.0.0",
         "jats-tags": "^1.0.1",
-        "myst-common": "^1.0.0",
+        "myst-common": "^1.0.1",
         "myst-frontmatter": "^1.0.0",
         "myst-spec": "^0.0.4",
         "myst-spec-ext": "^1.0.0",
@@ -472,14 +474,14 @@
       }
     },
     "mystjs/packages/myst-to-md": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "mdast-util-gfm-footnote": "^1.0.2",
         "mdast-util-gfm-table": "^1.0.7",
         "mdast-util-to-markdown": "^1.5.0",
         "myst-common": "^1.0.0",
-        "myst-frontmatter": "^1.0.0",
+        "myst-frontmatter": "^1.0.1",
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.7",
         "vfile-reporter": "^7.0.4"
@@ -487,11 +489,11 @@
       "devDependencies": {}
     },
     "mystjs/packages/myst-to-tex": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "myst-common": "^1.0.0",
-        "myst-frontmatter": "^1.0.0",
+        "myst-frontmatter": "^1.0.1",
         "myst-spec-ext": "^1.0.0",
         "unist-util-select": "^4.0.3",
         "vfile-reporter": "^7.0.4"
@@ -499,7 +501,7 @@
       "devDependencies": {}
     },
     "mystjs/packages/myst-transforms": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "doi-utils": "^2.0.0",
@@ -539,12 +541,12 @@
       }
     },
     "mystjs/packages/tex-to-myst": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@unified-latex/unified-latex": "^1.2.2",
         "myst-common": "^1.0.0",
-        "myst-frontmatter": "^1.0.0",
+        "myst-frontmatter": "^1.0.1",
         "myst-spec-ext": "^1.0.0",
         "unist-util-select": "^4.0.3",
         "vfile-reporter": "^7.0.4"

--- a/packages/curvenote/src/export/utils/localExportWrapper.ts
+++ b/packages/curvenote/src/export/utils/localExportWrapper.ts
@@ -24,6 +24,7 @@ export const localExportWrapper =
     opts: Record<string, any>,
     templateOptions?: Record<string, any>,
   ) => {
+    let localFolder: string | undefined;
     let localPath: string;
     if (fs.existsSync(path)) {
       session.log.info(`🔍 Found local file to export: ${path}`);
@@ -31,14 +32,14 @@ export const localExportWrapper =
     } else {
       session.log.info(`🌍 Downloading: ${path}`);
       const localFilename = 'output.md';
-      const localFolder = createTempFolder(session);
+      localFolder = createTempFolder(session);
       localPath = join(localFolder, localFilename);
       await oxaLinkToMarkdown(session, path, localFilename, { path: localFolder });
     }
     await exportLocalArticle(
       session,
       localPath,
-      { ...defaultOptions, filename, ...opts },
+      { ...defaultOptions, filename, projectPath: localFolder, ...opts },
       templateOptions,
       [new OxaTransformer(session)],
     );

--- a/packages/curvenote/src/export/utils/localExportWrapper.ts
+++ b/packages/curvenote/src/export/utils/localExportWrapper.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import type { ExportResults } from 'myst-cli';
 import { createTempFolder } from 'myst-cli';
 import type { LinkTransformer } from 'myst-transforms';
 import { join } from 'node:path';
@@ -14,7 +15,7 @@ export const localExportWrapper =
       opts: { filename: string } & Record<string, any>,
       templateOptions?: Record<string, any>,
       extraLinkTransformers?: LinkTransformer[],
-    ) => Promise<void>,
+    ) => Promise<ExportResults>,
     defaultOptions: Record<string, any>,
   ) =>
   async (
@@ -36,11 +37,15 @@ export const localExportWrapper =
       localPath = join(localFolder, localFilename);
       await oxaLinkToMarkdown(session, path, localFilename, { path: localFolder });
     }
-    await exportLocalArticle(
+    const results = await exportLocalArticle(
       session,
       localPath,
       { ...defaultOptions, filename, projectPath: localFolder, ...opts },
       templateOptions,
       [new OxaTransformer(session)],
     );
+    if (localFolder) {
+      results.tempFolders.push(localFolder);
+    }
+    return results;
   };

--- a/packages/curvenote/src/session/session.ts
+++ b/packages/curvenote/src/session/session.ts
@@ -171,8 +171,4 @@ export class Session implements ISession {
   publicPath(): string {
     return path.join(this.sitePath(), 'public');
   }
-
-  staticPath(): string {
-    return path.join(this.publicPath(), '_static');
-  }
 }

--- a/packages/curvenote/src/transforms/links.ts
+++ b/packages/curvenote/src/transforms/links.ts
@@ -60,17 +60,18 @@ export class OxaTransformer implements LinkTransformer {
 
 export async function transformOxalinkStore(
   session: ISession,
-  opts: { file: string; projectSlug: string },
+  opts: { file: string; projectSlug?: string },
 ) {
   const cache = castSession(session);
   const mdastPost = cache.$mdast[opts.file].post;
   const oxa = mdastPost?.frontmatter.oxa;
   if (oxa) {
+    const url = opts.projectSlug ? `/${opts.projectSlug}/${mdastPost.slug}` : `/${mdastPost.slug}`;
     session.store.dispatch(
       oxalink.actions.updateLinkInfo({
         path: opts.file,
         oxa: oxa,
-        url: `/${opts.projectSlug}/${mdastPost.slug}`,
+        url,
       }),
     );
   }

--- a/packages/curvenote/tests/smoke.spec.ts
+++ b/packages/curvenote/tests/smoke.spec.ts
@@ -5,14 +5,18 @@ import util from 'util';
 const exec = util.promisify(execWithCb);
 
 describe('CLI Smoke Tests', () => {
-  test('an example site', async () => {
-    expect.assertions(0);
-    try {
-      const { stdout } = await exec('curvenote build', { cwd: 'tests/example' });
-      console.log(stdout);
-    } catch (error) {
-      console.error(error);
-      expect(error).not.toBeNull();
-    }
-  });
+  test(
+    'an example site',
+    async () => {
+      expect.assertions(0);
+      try {
+        const { stdout } = await exec('curvenote build', { cwd: 'tests/example' });
+        console.log(stdout);
+      } catch (error) {
+        console.error(error);
+        expect(error).not.toBeNull();
+      }
+    },
+    { timeout: 15000 },
+  );
 });


### PR DESCRIPTION
This resolves failures when exporting from a curvenote link - the project path was not maintained, so source md files were not found correctly.

This also consumes https://github.com/executablebooks/mystjs/pull/442 to pass through temp folders / log files created during exports.