### PR TITLE
🔧 Fix oxa links in site build

### DIFF
--- a/.changeset/warm-scissors-double.md
+++ b/.changeset/warm-scissors-double.md
@@ -1,0 +1,5 @@
+---
+'curvenote': patch
+---
+
+Fix oxa links in site build

--- a/packages/curvenote/src/sync/init.ts
+++ b/packages/curvenote/src/sync/init.ts
@@ -19,6 +19,7 @@ import { interactiveCloneQuestions } from './clone.js';
 import { pullProjects } from './pull.js';
 import questions from './questions.js';
 import { getDefaultProjectConfig, getDefaultSiteConfig, INIT_LOGO_PATH } from './utils.js';
+import { addOxaTransformersToOpts } from '../utils/utils.js';
 
 // TODO
 const CURVENOTE_YML = 'curvenote.yml';
@@ -205,7 +206,7 @@ export async function init(session: ISession, opts: Options) {
   if (start) {
     await pullProcess;
     session.log.info(chalk.dim('\nStarting local server with: '), chalk.bold('curvenote start'));
-    await startServer(session, opts);
+    await startServer(session, addOxaTransformersToOpts(session, opts));
   }
   await pullProcess;
 }

--- a/packages/curvenote/src/utils/utils.ts
+++ b/packages/curvenote/src/utils/utils.ts
@@ -2,6 +2,8 @@ import inquirer from 'inquirer';
 import path from 'node:path';
 import type { Logger } from 'myst-cli-utils';
 import type { JsonObject, VersionId } from '@curvenote/blocks';
+import type { ISession } from '../session/types.js';
+import { OxaTransformer, transformOxalinkStore } from '../transforms/links.js';
 
 export const BUILD_FOLDER = '_build';
 export const THUMBNAILS_FOLDER = 'thumbnails';
@@ -38,4 +40,13 @@ export async function confirmOrExit(message: string, opts?: { yes?: boolean }) {
   if (!question.confirm) {
     throw new Error('Exiting');
   }
+}
+
+/** Add oxa link transformers to options */
+export function addOxaTransformersToOpts(session: ISession, opts: Record<string, any>) {
+  return {
+    ...opts,
+    extraLinkTransformers: [...(opts.extraLinkTransformers ?? []), new OxaTransformer(session)],
+    extraTransforms: [...(opts.extraTransforms ?? []), transformOxalinkStore as any],
+  };
 }

--- a/packages/curvenote/src/web/deploy.ts
+++ b/packages/curvenote/src/web/deploy.ts
@@ -16,7 +16,7 @@ import type {
 } from '@curvenote/blocks';
 import { MyUser } from '../models.js';
 import type { ISession } from '../session/types.js';
-import { confirmOrExit } from '../utils/index.js';
+import { addOxaTransformersToOpts, confirmOrExit } from '../utils/index.js';
 
 type FromTo = {
   from: string;
@@ -240,7 +240,7 @@ export async function deploy(
   // clean the site folder, otherwise downloadable files will accumulate
   await clean(session, [], { site: true, yes: true });
   // Build the files in the content folder and process them
-  await buildSite(session, opts);
+  await buildSite(session, addOxaTransformersToOpts(session, opts));
   const cdnKey = await deployContentToCdn(session, opts);
   await promoteContent(session, cdnKey, domains);
 }

--- a/packages/curvenote/src/web/utils.ts
+++ b/packages/curvenote/src/web/utils.ts
@@ -1,4 +1,5 @@
 import type { ISession } from '../session/types.js';
+import { addOxaTransformersToOpts } from '../utils/utils.js';
 
 export const siteCommandWrapper =
   (
@@ -6,5 +7,5 @@ export const siteCommandWrapper =
     defaultOptions: Record<string, any>,
   ) =>
   async (session: ISession, opts: Record<string, any>) => {
-    await siteCommand(session, { ...defaultOptions, ...opts });
+    await siteCommand(session, addOxaTransformersToOpts(session, { ...defaultOptions, ...opts }));
   };


### PR DESCRIPTION
This should resolve https://github.com/curvenote/curvenote/issues/435

The oxa link transforms were already present in the codebase but somehow they were no longer getting used. This just adds them back in all the appropriate places.