### PR TITLE
🧹👷🏽 clean rebuild on `works create`

### DIFF
--- a/.changeset/clean-readers-doubt.md
+++ b/.changeset/clean-readers-doubt.md
@@ -1,0 +1,5 @@
+---
+'curvenote': patch
+---
+
+`works create` now triggers a clean rebuild of the exports and site


### PR DESCRIPTION
this ensures that assets such as `meca.zip` and other things that might be needed online for the work and submission are [re]built and available.