### PR TITLE
flat projects like mystmd on init from curvenote

### DIFF
--- a/.changeset/tasty-shrimps-peel.md
+++ b/.changeset/tasty-shrimps-peel.md
@@ -1,0 +1,5 @@
+---
+'curvenote': patch
+---
+
+`curvenote init` nwow creates a flat project/site when initializing from curvenote. This bring behaviour into line with initializing from a local folder.

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,17 +41,17 @@
       }
     },
     "mystjs/packages/jats-to-myst": {
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "MIT",
       "dependencies": {
         "doi-utils": "^2.0.0",
         "jats-tags": "^1.0.8",
         "jats-xml": "^1.0.8",
-        "myst-common": "^1.1.17",
-        "myst-frontmatter": "^1.1.17",
+        "myst-common": "^1.1.20",
+        "myst-frontmatter": "^1.1.20",
         "myst-spec": "^0.0.4",
-        "myst-spec-ext": "^1.1.17",
-        "myst-transforms": "^1.1.15",
+        "myst-spec-ext": "^1.1.20",
+        "myst-transforms": "^1.1.18",
         "unified": "^10.0.0",
         "unist-builder": "^3.0.0",
         "unist-util-remove": "^3.1.0",
@@ -60,7 +60,7 @@
         "vfile-reporter": "^7.0.4"
       },
       "devDependencies": {
-        "myst-to-tex": "^1.0.14"
+        "myst-to-tex": "^1.0.16"
       }
     },
     "mystjs/packages/jats-to-myst/node_modules/chalk": {
@@ -103,21 +103,21 @@
       }
     },
     "mystjs/packages/jtex": {
-      "version": "1.0.10",
+      "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
         "chalk": "^5.2.0",
         "commander": "^10.0.1",
         "js-yaml": "^4.1.0",
-        "myst-cli-utils": "^2.0.4",
-        "myst-common": "^1.1.13",
-        "myst-frontmatter": "^1.1.13",
-        "myst-templates": "^1.0.12",
+        "myst-cli-utils": "^2.0.7",
+        "myst-common": "^1.1.20",
+        "myst-frontmatter": "^1.1.20",
+        "myst-templates": "^1.0.15",
         "node-fetch": "^3.3.1",
         "nunjucks": "^3.2.4",
         "pretty-hrtime": "^1.0.3",
-        "simple-validators": "^1.0.3"
+        "simple-validators": "^1.0.4"
       },
       "bin": {
         "jtex": "dist/jtex.cjs"
@@ -168,7 +168,7 @@
       }
     },
     "mystjs/packages/myst-cli": {
-      "version": "1.1.34",
+      "version": "1.1.37",
       "license": "MIT",
       "dependencies": {
         "@jupyterlab/nbformat": "3.5.2",
@@ -190,30 +190,31 @@
         "inquirer": "^8.2.2",
         "intersphinx": "^1.0.2",
         "js-yaml": "^4.1.0",
-        "jtex": "^1.0.10",
+        "jtex": "^1.0.12",
         "latest-version": "^7.0.0",
         "mdast": "^3.0.0",
         "meca": "^1.0.8",
         "mime-types": "^2.1.35",
         "myst-cli-utils": "^2.0.7",
-        "myst-common": "^1.1.19",
-        "myst-config": "^1.1.19",
-        "myst-ext-card": "^1.0.4",
-        "myst-ext-exercise": "^1.0.4",
-        "myst-ext-grid": "^1.0.4",
-        "myst-ext-proof": "^1.0.6",
-        "myst-ext-reactive": "^1.0.4",
-        "myst-ext-tabs": "^1.0.4",
-        "myst-frontmatter": "^1.1.19",
-        "myst-parser": "^1.0.18",
+        "myst-common": "^1.1.21",
+        "myst-config": "^1.1.21",
+        "myst-ext-card": "^1.0.5",
+        "myst-ext-exercise": "^1.0.5",
+        "myst-ext-grid": "^1.0.5",
+        "myst-ext-proof": "^1.0.7",
+        "myst-ext-reactive": "^1.0.5",
+        "myst-ext-tabs": "^1.0.5",
+        "myst-frontmatter": "^1.1.21",
+        "myst-parser": "^1.0.21",
         "myst-spec": "^0.0.4",
-        "myst-spec-ext": "^1.1.19",
-        "myst-templates": "^1.0.13",
-        "myst-to-docx": "^1.0.7",
-        "myst-to-jats": "^1.0.19",
-        "myst-to-md": "^1.0.9",
-        "myst-to-tex": "^1.0.15",
-        "myst-transforms": "^1.1.16",
+        "myst-spec-ext": "^1.1.21",
+        "myst-templates": "^1.0.15",
+        "myst-to-docx": "^1.0.8",
+        "myst-to-jats": "^1.0.20",
+        "myst-to-md": "^1.0.10",
+        "myst-to-tex": "^1.0.16",
+        "myst-to-typst": "^0.0.8",
+        "myst-transforms": "^1.1.19",
         "nanoid": "^4.0.0",
         "nbtx": "^0.2.3",
         "node-fetch": "^3.3.1",
@@ -221,7 +222,7 @@
         "redux": "^4.2.0",
         "simple-validators": "^1.0.4",
         "strip-ansi": "^7.0.1",
-        "tex-to-myst": "^1.0.15",
+        "tex-to-myst": "^1.0.16",
         "unified": "^10.1.2",
         "unist-util-filter": "^4.0.0",
         "unist-util-remove": "^3.1.0",
@@ -417,11 +418,11 @@
       }
     },
     "mystjs/packages/myst-common": {
-      "version": "1.1.19",
+      "version": "1.1.21",
       "license": "MIT",
       "dependencies": {
         "mdast": "^3.0.0",
-        "myst-frontmatter": "^1.1.19",
+        "myst-frontmatter": "^1.1.21",
         "myst-spec": "^0.0.4",
         "nanoid": "^4.0.0",
         "unified": "^10.1.2",
@@ -431,7 +432,7 @@
         "vfile-message": "^3.0.0"
       },
       "devDependencies": {
-        "myst-spec-ext": "^1.1.19",
+        "myst-spec-ext": "^1.1.21",
         "unist-builder": "3.0.0"
       }
     },
@@ -449,10 +450,10 @@
       }
     },
     "mystjs/packages/myst-config": {
-      "version": "1.1.19",
+      "version": "1.1.21",
       "license": "MIT",
       "dependencies": {
-        "myst-frontmatter": "^1.1.19",
+        "myst-frontmatter": "^1.1.21",
         "simple-validators": "^1.0.4"
       },
       "devDependencies": {
@@ -460,79 +461,80 @@
       }
     },
     "mystjs/packages/myst-directives": {
-      "version": "1.0.18",
+      "version": "1.0.21",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",
-        "myst-common": "^1.1.18",
-        "myst-spec-ext": "^1.1.18",
+        "myst-common": "^1.1.21",
+        "myst-spec-ext": "^1.1.21",
+        "nanoid": "^4.0.2",
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.7"
       }
     },
     "mystjs/packages/myst-ext-card": {
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.1.7"
+        "myst-common": "^1.1.20"
       },
       "devDependencies": {
-        "myst-parser": "^1.0.8"
+        "myst-parser": "^1.0.20"
       }
     },
     "mystjs/packages/myst-ext-exercise": {
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.1.7"
+        "myst-common": "^1.1.20"
       },
       "devDependencies": {
-        "myst-parser": "^1.0.8"
+        "myst-parser": "^1.0.20"
       }
     },
     "mystjs/packages/myst-ext-grid": {
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.1.7"
+        "myst-common": "^1.1.20"
       },
       "devDependencies": {
-        "myst-parser": "^1.0.8"
+        "myst-parser": "^1.0.20"
       }
     },
     "mystjs/packages/myst-ext-proof": {
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.1.11",
+        "myst-common": "^1.1.20",
         "myst-spec": "^0.0.4"
       },
       "devDependencies": {
-        "myst-parser": "^1.0.10"
+        "myst-parser": "^1.0.20"
       }
     },
     "mystjs/packages/myst-ext-reactive": {
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.1.7"
+        "myst-common": "^1.1.20"
       },
       "devDependencies": {
-        "myst-parser": "^1.0.8"
+        "myst-parser": "^1.0.20"
       }
     },
     "mystjs/packages/myst-ext-tabs": {
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.1.7"
+        "myst-common": "^1.1.20"
       },
       "devDependencies": {
-        "myst-parser": "^1.0.8"
+        "myst-parser": "^1.0.20"
       }
     },
     "mystjs/packages/myst-frontmatter": {
-      "version": "1.1.19",
+      "version": "1.1.21",
       "license": "MIT",
       "dependencies": {
         "credit-roles": "^2.1.0",
@@ -549,7 +551,7 @@
       }
     },
     "mystjs/packages/myst-parser": {
-      "version": "1.0.18",
+      "version": "1.0.21",
       "license": "MIT",
       "dependencies": {
         "he": "^1.2.0",
@@ -562,9 +564,9 @@
         "markdown-it-myst": "1.0.5",
         "markdown-it-myst-extras": "0.3.0",
         "markdown-it-task-lists": "^2.1.1",
-        "myst-common": "^1.1.18",
-        "myst-directives": "^1.0.18",
-        "myst-roles": "^1.0.18",
+        "myst-common": "^1.1.21",
+        "myst-directives": "^1.0.21",
+        "myst-roles": "^1.0.21",
         "myst-spec": "^0.0.4",
         "unified": "^10.1.1",
         "unist-builder": "^3.0.0",
@@ -581,8 +583,8 @@
         "@types/markdown-it": "^12.2.3",
         "@types/mdast": "^3.0.10",
         "js-yaml": "^4.1.0",
-        "myst-to-html": "^1.0.18",
-        "myst-transforms": "^1.1.16",
+        "myst-to-html": "^1.0.21",
+        "myst-transforms": "^1.1.19",
         "rehype-stringify": "^9.0.3"
       }
     },
@@ -596,22 +598,22 @@
       }
     },
     "mystjs/packages/myst-roles": {
-      "version": "1.0.18",
+      "version": "1.0.21",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.1.18",
-        "myst-spec-ext": "^1.1.18"
+        "myst-common": "^1.1.21",
+        "myst-spec-ext": "^1.1.21"
       }
     },
     "mystjs/packages/myst-spec-ext": {
-      "version": "1.1.19",
+      "version": "1.1.21",
       "license": "MIT",
       "dependencies": {
         "myst-spec": "^0.0.4"
       }
     },
     "mystjs/packages/myst-templates": {
-      "version": "1.0.13",
+      "version": "1.0.15",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -619,9 +621,9 @@
         "commander": "^10.0.1",
         "glob": "^10.3.1",
         "js-yaml": "^4.1.0",
-        "myst-cli-utils": "^2.0.6",
-        "myst-common": "^1.1.15",
-        "myst-frontmatter": "^1.1.15",
+        "myst-cli-utils": "^2.0.7",
+        "myst-common": "^1.1.20",
+        "myst-frontmatter": "^1.1.20",
         "node-fetch": "^3.3.1",
         "pretty-hrtime": "^1.0.3",
         "simple-validators": "^1.0.4"
@@ -643,20 +645,20 @@
       }
     },
     "mystjs/packages/myst-to-docx": {
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "buffer-image-size": "^0.6.4",
         "docx": "^7.3.0",
-        "myst-common": "^1.1.10",
-        "myst-frontmatter": "^1.1.10",
+        "myst-common": "^1.1.20",
+        "myst-frontmatter": "^1.1.20",
         "myst-spec": "^0.0.4",
-        "myst-spec-ext": "^1.1.10",
+        "myst-spec-ext": "^1.1.20",
         "unist-util-select": "^4.0.3"
       }
     },
     "mystjs/packages/myst-to-html": {
-      "version": "1.0.18",
+      "version": "1.0.21",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2",
@@ -666,7 +668,7 @@
         "mdast": "^3.0.0",
         "mdast-util-find-and-replace": "^2.1.0",
         "mdast-util-to-hast": "^12.3.0",
-        "myst-common": "^1.1.18",
+        "myst-common": "^1.1.21",
         "rehype-format": "^4.0.1",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
@@ -695,7 +697,7 @@
       }
     },
     "mystjs/packages/myst-to-jats": {
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "MIT",
       "dependencies": {
         "citation-js-utils": "^1.0.2",
@@ -704,11 +706,11 @@
         "jats-tags": "^1.0.8",
         "jats-utils": "^1.0.8",
         "katex": "^0.15.2",
-        "myst-common": "^1.1.17",
-        "myst-frontmatter": "^1.1.17",
+        "myst-common": "^1.1.20",
+        "myst-frontmatter": "^1.1.20",
         "myst-spec": "^0.0.4",
-        "myst-spec-ext": "^1.1.17",
-        "myst-transforms": "^1.1.15",
+        "myst-spec-ext": "^1.1.20",
+        "myst-transforms": "^1.1.18",
         "nbtx": "^0.2.3",
         "unified": "^10.1.2",
         "unist-util-remove": "^3.1.0",
@@ -723,7 +725,7 @@
         "@types/mdast": "^3.0.10",
         "jats-xml": "^1.0.7",
         "js-yaml": "^4.1.0",
-        "myst-cli-utils": "^2.0.6"
+        "myst-cli-utils": "^2.0.7"
       }
     },
     "mystjs/packages/myst-to-jats/node_modules/@types/katex": {
@@ -774,50 +776,50 @@
       }
     },
     "mystjs/packages/myst-to-md": {
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "mdast-util-gfm-footnote": "^1.0.2",
         "mdast-util-gfm-table": "^1.0.7",
         "mdast-util-to-markdown": "^1.5.0",
-        "myst-common": "^1.1.10",
-        "myst-frontmatter": "^1.1.10",
+        "myst-common": "^1.1.20",
+        "myst-frontmatter": "^1.1.20",
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.7",
         "vfile-reporter": "^7.0.4"
       }
     },
     "mystjs/packages/myst-to-tex": {
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.1.19",
-        "myst-ext-proof": "^1.0.6",
-        "myst-frontmatter": "^1.1.19",
-        "myst-spec-ext": "^1.1.19",
+        "myst-common": "^1.1.20",
+        "myst-ext-proof": "^1.0.7",
+        "myst-frontmatter": "^1.1.20",
+        "myst-spec-ext": "^1.1.20",
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.3",
         "vfile-reporter": "^7.0.4"
       },
       "devDependencies": {
-        "myst-parser": "^1.0.16"
+        "myst-parser": "^1.0.20"
       }
     },
     "mystjs/packages/myst-to-typst": {
-      "version": "0.0.6",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.1.10",
-        "myst-frontmatter": "^1.1.10",
-        "myst-spec-ext": "^1.1.10",
-        "tex-to-typst": "^0.0.3",
+        "myst-common": "^1.1.21",
+        "myst-frontmatter": "^1.1.21",
+        "myst-spec-ext": "^1.1.21",
+        "tex-to-typst": "^0.0.4",
         "unist-util-select": "^4.0.3",
         "vfile-reporter": "^7.0.4"
       }
     },
     "mystjs/packages/myst-transforms": {
-      "version": "1.1.16",
+      "version": "1.1.19",
       "license": "MIT",
       "dependencies": {
         "doi-utils": "^2.0.0",
@@ -827,10 +829,10 @@
         "js-yaml": "^4.1.0",
         "katex": "^0.15.2",
         "mdast-util-find-and-replace": "^2.1.0",
-        "myst-common": "^1.1.18",
+        "myst-common": "^1.1.21",
         "myst-spec": "^0.0.4",
-        "myst-spec-ext": "^1.1.18",
-        "myst-to-html": "1.0.18",
+        "myst-spec-ext": "^1.1.21",
+        "myst-to-html": "1.0.21",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
         "unified": "^10.0.0",
@@ -855,7 +857,7 @@
       "dev": true
     },
     "mystjs/packages/mystmd": {
-      "version": "1.1.34",
+      "version": "1.1.37",
       "license": "MIT",
       "bin": {
         "myst": "dist/myst.cjs"
@@ -865,7 +867,7 @@
         "commander": "^10.0.1",
         "core-js": "^3.31.1",
         "js-yaml": "^4.1.0",
-        "myst-cli": "^1.1.34"
+        "myst-cli": "^1.1.37"
       }
     },
     "mystjs/packages/mystmd/node_modules/chalk": {
@@ -888,13 +890,13 @@
       }
     },
     "mystjs/packages/tex-to-myst": {
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "MIT",
       "dependencies": {
         "@unified-latex/unified-latex": "^1.2.2",
-        "myst-common": "^1.1.19",
-        "myst-frontmatter": "^1.1.19",
-        "myst-spec-ext": "^1.1.19",
+        "myst-common": "^1.1.20",
+        "myst-frontmatter": "^1.1.20",
+        "myst-spec-ext": "^1.1.20",
         "unist-builder": "^3.0.0",
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.3",
@@ -15213,9 +15215,9 @@
       "link": true
     },
     "node_modules/tex-to-typst": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tex-to-typst/-/tex-to-typst-0.0.3.tgz",
-      "integrity": "sha512-aNR+mi4i/n/O7GiTtElFaklvj4nKyoSlN+gEB55atgQYMnUAI1cjZHXJ0L/r5u/yB3RZdmg9oYx3hrhH+TjdTA==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/tex-to-typst/-/tex-to-typst-0.0.4.tgz",
+      "integrity": "sha512-6rHYjSAcHGEea228LuWRg+PEJ3RHIhG6lPLRCU3xS146GuZaqgWB+XlWrT3awvlNLukeC1yl4sic/gc4B9BIoA==",
       "dependencies": {
         "@unified-latex/unified-latex": "^1.4.0",
         "@unified-latex/unified-latex-util-arguments": "^1.4.0",

--- a/packages/curvenote/src/sync/init.ts
+++ b/packages/curvenote/src/sync/init.ts
@@ -170,7 +170,6 @@ export async function init(session: ISession, opts: Options) {
     projectConfig = results.projectConfig;
     title = projectConfig.title;
     currentPath = siteProject.path;
-    siteConfig.projects = [siteProject];
     session.log.info(`Add other projects using: ${chalk.bold('curvenote clone')}\n`);
   } else {
     throw Error(`Invalid init content: ${content}`);

--- a/packages/curvenote/src/sync/init.ts
+++ b/packages/curvenote/src/sync/init.ts
@@ -170,7 +170,6 @@ export async function init(session: ISession, opts: Options) {
     projectConfig = results.projectConfig;
     title = projectConfig.title;
     currentPath = siteProject.path;
-    session.log.info(`Add other projects using: ${chalk.bold('curvenote clone')}\n`);
   } else {
     throw Error(`Invalid init content: ${content}`);
   }


### PR DESCRIPTION
previously running `init` on a local folder behaved like `mystmd`, with this PR we get the same behavior on `init` from a remote curvenote project. `pull` and `clone` continue to work as expected with the new layout.