### PR TITLE
🛠 fix flat project for programatic clone

### DIFF
--- a/.changeset/silly-foxes-cheat.md
+++ b/.changeset/silly-foxes-cheat.md
@@ -1,0 +1,5 @@
+---
+'curvenote': patch
+---
+
+Additional change to ensure flat projects when `sync.clone` is used from the client library.

--- a/packages/curvenote/src/sync/utils.ts
+++ b/packages/curvenote/src/sync/utils.ts
@@ -38,7 +38,6 @@ export async function getDefaultSiteConfigFromRemote(
   if (!remoteSiteConfig.data.nav) {
     siteConfig.nav = [{ title: project.data.title || '', url: `/${siteProject.slug}` }];
   }
-  siteConfig.projects = [...(siteConfig.projects || []), siteProject];
   return siteConfig;
 }
 


### PR DESCRIPTION
fixes another route for the project config being setup, this was used in launchpad!