### PR TITLE
🏗 cli uses the job lifecycle

### DIFF
--- a/.changeset/mighty-crews-work.md
+++ b/.changeset/mighty-crews-work.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Submitted works now have a job id sent with them, and the cli uses the job lifecycle more fully, creating a job and updating it

--- a/packages/curvenote-cli/src/submissions/submit.ts
+++ b/packages/curvenote-cli/src/submissions/submit.ts
@@ -23,6 +23,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { getChecksForSubmission } from './check.js';
 import { getGitRepoInfo } from './utils.git.js';
+import { uploadContentAndDeployToPrivateCdn } from '../index.js';
 
 export async function submit(session: ISession, venue: string, opts?: SubmitOpts) {
   const submitLog: Record<string, any> = {
@@ -162,11 +163,11 @@ export async function submit(session: ISession, venue: string, opts?: SubmitOpts
     session.log.info(`🏁 checks completed`);
   }
 
-  const cdnKey = 'ad7fa60f-5460-4bf9-96ea-59be87944e41'; // dev debug
-  // const cdnKey = await uploadContentAndDeployToPrivateCdn(session, {
-  //   ...opts,
-  //   ci: opts?.yes,
-  // });
+  // const cdnKey = 'ad7fa60f-5460-4bf9-96ea-59be87944e41'; // dev debug
+  const cdnKey = await uploadContentAndDeployToPrivateCdn(session, {
+    ...opts,
+    ci: opts?.yes,
+  });
   session.log.info(`🚀 ${chalk.bold.green(`Content uploaded with key ${cdnKey}`)}.`);
 
   //

--- a/packages/curvenote-cli/src/submissions/submit.ts
+++ b/packages/curvenote-cli/src/submissions/submit.ts
@@ -2,8 +2,7 @@ import type { ISession } from '../session/types.js';
 import { upwriteTransferFile } from './utils.transfer.js';
 import { confirmOrExit, writeJsonLogs } from '../utils/utils.js';
 import chalk from 'chalk';
-import { postNewCliCheckJob } from './utils.js';
-import { uploadContentAndDeployToPrivateCdn } from '../utils/web.js';
+import { postNewCliCheckJob, patchUpdateCliCheckJob } from './utils.js';
 import {
   ensureVenue,
   checkVenueExists,
@@ -163,18 +162,46 @@ export async function submit(session: ISession, venue: string, opts?: SubmitOpts
     session.log.info(`🏁 checks completed`);
   }
 
-  // const cdnKey = 'ad7fa60f-5460-4bf9-96ea-59be87944e41'; // dev debug
-  const cdnKey = await uploadContentAndDeployToPrivateCdn(session, {
-    ...opts,
-    ci: opts?.yes,
-  });
+  const cdnKey = 'ad7fa60f-5460-4bf9-96ea-59be87944e41'; // dev debug
+  // const cdnKey = await uploadContentAndDeployToPrivateCdn(session, {
+  //   ...opts,
+  //   ci: opts?.yes,
+  // });
   session.log.info(`🚀 ${chalk.bold.green(`Content uploaded with key ${cdnKey}`)}.`);
+
+  //
+  // Create a job to track the build and checks
+  //
+  const source = {
+    repo: gitInfo?.repo,
+    branch: gitInfo?.branch,
+    path: gitInfo?.path,
+    commit: gitInfo?.commit,
+  };
+
+  const job = await postNewCliCheckJob(
+    session,
+    {
+      site: venue,
+      source,
+      key,
+    },
+    { checks: { venue, kind, report } },
+  );
+  const buildUrl = `${session.JOURNALS_URL.replace('v1/', '')}build/${job.id}`;
+  session.log.info(`🤖 created a job to track this build: ${buildUrl}`);
+
+  process.on('exit', async (exitCode: number) => {
+    // TODO https://stackoverflow.com/questions/40574218/how-to-perform-an-async-operation-on-exit
+    if (exitCode === 0) return;
+    await patchUpdateCliCheckJob(session, job.id, 'FAILED', 'Submission from CLI failed', {});
+  });
 
   //
   // Create work and submission
   //
   if (transferData?.[venue] && !opts?.draft) {
-    await updateExistingSubmission(session, submitLog, venue, cdnKey, transferData[venue]);
+    await updateExistingSubmission(session, submitLog, venue, cdnKey, transferData[venue], job.id);
   } else {
     if (opts?.draft) {
       session.log.info(
@@ -190,7 +217,7 @@ export async function submit(session: ISession, venue: string, opts?: SubmitOpts
         session.log.error('🚨 No submission kind found.');
         process.exit(1);
       }
-      await createNewSubmission(session, submitLog, venue, kind, cdnKey, key, opts);
+      await createNewSubmission(session, submitLog, venue, kind, cdnKey, job.id, key, opts);
     } catch (err: any) {
       session.log.info(`\n\n🚨 ${chalk.bold.red('Could not submit your work')}.`);
       session.log.info(`📣 ${chalk.bold(err.message)}.`);
@@ -200,30 +227,14 @@ export async function submit(session: ISession, venue: string, opts?: SubmitOpts
 
   session.log.debug(`generating a build artifact for the submission...`);
 
-  const source = {
-    repo: gitInfo?.repo,
-    branch: gitInfo?.branch,
-    path: gitInfo?.path,
-    commit: gitInfo?.commit,
-  };
+  await patchUpdateCliCheckJob(session, job.id, 'COMPLETED', 'Submission completed', {
+    submissionId: submitLog.submission.id,
+    submissionVersionId: submitLog.submissionVersion.id,
+    workId: submitLog.work.id,
+    workVersionId: submitLog.workVersion.id,
+    // checks: { venue, kind, report },
+  });
 
-  const job = await postNewCliCheckJob(
-    session,
-    {
-      journal: venue,
-      source,
-      key,
-    },
-    {
-      submissionId: submitLog.submission.id,
-      submissionVersionId: submitLog.submissionVersion.id,
-      workId: submitLog.work.id,
-      workVersionId: submitLog.workVersion.id,
-      checks: { venue, kind, report },
-    },
-  );
-
-  const buildUrl = `${session.JOURNALS_URL.replace('v1/', '')}build/${job.id}`;
   submitLog.key = key;
   submitLog.venue = venue;
   submitLog.kind = kind;

--- a/packages/curvenote-cli/src/submissions/submit.utils.ts
+++ b/packages/curvenote-cli/src/submissions/submit.utils.ts
@@ -21,6 +21,7 @@ import {
 } from './utils.js';
 import inquirer from 'inquirer';
 import type { SubmissionsListItemDTO, SubmissionsListingDTO } from '@curvenote/common';
+import { tr } from 'date-fns/locale';
 
 export type SubmitOpts = {
   kind?: string;
@@ -341,8 +342,7 @@ export async function updateExistingSubmission(
     logCollector.submission = submission;
     logCollector.submissionVersion = submissionVersion;
   } catch (err: any) {
-    session.log.info(`\n\n🚨 ${chalk.bold.red('Could not update your submission')}.`);
-    session.log.info(`📣 ${chalk.red(err.message)}.`);
-    process.exit(1);
+    session.log.error(err.message);
+    throw new Error(`🚨 ${chalk.bold.red('Could not update your submission')}.`);
   }
 }

--- a/packages/curvenote-cli/src/submissions/submit.utils.ts
+++ b/packages/curvenote-cli/src/submissions/submit.utils.ts
@@ -259,6 +259,7 @@ export async function createNewSubmission(
   venue: string,
   kind: string,
   cdnKey: string,
+  jobId: string,
   key?: string,
   opts?: SubmitOpts,
 ) {
@@ -273,6 +274,7 @@ export async function createNewSubmission(
     kind,
     workVersion.id,
     opts?.draft ?? false,
+    jobId,
     key,
   );
 
@@ -296,6 +298,7 @@ export async function updateExistingSubmission(
   venue: string,
   cdnKey: string,
   venueTransferData: TransferDataItem,
+  jobId: string,
 ) {
   session.log.debug(`existing submission - upload & post`);
   const workId = venueTransferData.work?.id;
@@ -324,6 +327,7 @@ export async function updateExistingSubmission(
       venue,
       submissionId,
       workVersion.id,
+      jobId,
     );
 
     session.log.debug(`submission version posted with id ${submissionVersion.id}`);

--- a/packages/curvenote-cli/src/submissions/utils.ts
+++ b/packages/curvenote-cli/src/submissions/utils.ts
@@ -95,8 +95,7 @@ export async function postNewWork(
       },
     };
   } else {
-    session.log.debug(`${resp.status} ${resp.statusText}`);
-    throw new Error('Posting new work failed: Please contact support@curvenote.com');
+    throw new Error('Posting new work failed');
   }
 }
 
@@ -132,7 +131,7 @@ export async function postNewWorkVersion(
       },
     };
   } else {
-    throw new Error('Posting new version of the work failed: Please contact support@curvenote.com');
+    throw new Error('Posting new version of the work failed');
   }
 }
 
@@ -157,7 +156,7 @@ export async function postNewCliCheckJob(
     session.log.debug(`Job status: ${json.status}`);
     return json;
   } else {
-    throw new Error('Job creation failed: Please contact support@curvenote.com');
+    throw new Error('Job creation failed');
   }
 }
 
@@ -184,7 +183,7 @@ export async function patchUpdateCliCheckJob(
     session.log.debug(`Job status: ${json.status}`);
     return json;
   } else {
-    throw new Error('Job creation failed: Please contact support@curvenote.com');
+    throw new Error('Job update failed');
   }
 }
 
@@ -227,7 +226,7 @@ export async function postNewSubmission(
       },
     };
   } else {
-    throw new Error('Submission failed: Please contact support@curvenote.com');
+    throw new Error('Creating new submission failed');
   }
 }
 
@@ -266,6 +265,6 @@ export async function postUpdateSubmissionWorkVersion(
       },
     };
   } else {
-    throw new Error('Submission failed: Please contact support@curvenote.com');
+    throw new Error('Updating submission failed');
   }
 }

--- a/packages/curvenote-cli/src/utils/types.ts
+++ b/packages/curvenote-cli/src/utils/types.ts
@@ -25,15 +25,23 @@ export interface CreateSubmissionBody {
   work_version_id: string;
   kind: string;
   draft: boolean;
+  job_id: string;
   key?: string;
 }
 
 export interface UpdateSubmissionBody {
   work_version_id: string;
+  job_id: string;
 }
 
 export interface CreateCliCheckJobPostBody {
   job_type: 'CLI_CHECK';
   payload: Record<string, any>;
+  results: Record<string, any>;
+}
+
+export interface UpdateCliCheckJobPostBody {
+  status: string;
+  message: string;
   results: Record<string, any>;
 }


### PR DESCRIPTION
job id is sent with submission post and so the job is created earlier.

## todo

- [x] create the job earlier and update it ahead of submission
- [x] improve try/catch usage in api calls and put a top level catch in place to set jobs to FAILED more easily