### PR TITLE
📤 Update the export and clean cli

### DIFF
--- a/.changeset/afraid-years-lay.md
+++ b/.changeset/afraid-years-lay.md
@@ -1,0 +1,5 @@
+---
+"curvenote": patch
+---
+
+Add typst and cache to clean options

--- a/.changeset/green-hotels-wave.md
+++ b/.changeset/green-hotels-wave.md
@@ -1,0 +1,5 @@
+---
+"curvenote": patch
+---
+
+Fix site build cli command to correct scope

--- a/.changeset/purple-bees-pay.md
+++ b/.changeset/purple-bees-pay.md
@@ -1,0 +1,6 @@
+---
+"@curvenote/cli": patch
+"curvenote": patch
+---
+
+Add jats and meca to export/clean cli

--- a/.changeset/yellow-eggs-look.md
+++ b/.changeset/yellow-eggs-look.md
@@ -1,0 +1,6 @@
+---
+"@curvenote/cli": patch
+"curvenote": patch
+---
+
+Add typst export to curvenote cli

--- a/packages/curvenote-cli/src/export/index.ts
+++ b/packages/curvenote-cli/src/export/index.ts
@@ -5,5 +5,7 @@ export * from './pdf/index.js';
 export * from './notebook/index.js';
 export * from './jupyter-book/index.js';
 export * from './utils/index.js';
+export * from './jats.js';
+export * from './meca.js';
 export * from './typst.js';
 export * from './multiple.js';

--- a/packages/curvenote-cli/src/export/index.ts
+++ b/packages/curvenote-cli/src/export/index.ts
@@ -5,4 +5,5 @@ export * from './pdf/index.js';
 export * from './notebook/index.js';
 export * from './jupyter-book/index.js';
 export * from './utils/index.js';
+export * from './typst.js';
 export * from './multiple.js';

--- a/packages/curvenote-cli/src/export/jats.ts
+++ b/packages/curvenote-cli/src/export/jats.ts
@@ -1,0 +1,4 @@
+import { localArticleToJats } from 'myst-cli';
+import { localExportWrapper } from './utils/localExportWrapper.js';
+
+export const oxaLinkToJats = localExportWrapper(localArticleToJats, { force: true });

--- a/packages/curvenote-cli/src/export/meca.ts
+++ b/packages/curvenote-cli/src/export/meca.ts
@@ -1,0 +1,4 @@
+import { localProjectToMeca } from 'myst-cli';
+import { localExportWrapper } from './utils/localExportWrapper.js';
+
+export const oxaLinkToMeca = localExportWrapper(localProjectToMeca, { force: true });

--- a/packages/curvenote-cli/src/export/typst.ts
+++ b/packages/curvenote-cli/src/export/typst.ts
@@ -1,0 +1,4 @@
+import { localArticleToTypst } from 'myst-cli';
+import { localExportWrapper } from './utils/localExportWrapper.js';
+
+export const oxaLinkToTypst = localExportWrapper(localArticleToTypst, { force: true });

--- a/packages/curvenote/src/clean.ts
+++ b/packages/curvenote/src/clean.ts
@@ -1,12 +1,14 @@
 import { Command, Option } from 'commander';
 import { clean } from 'myst-cli';
 import {
+  makeCacheOption,
   makeDocxOption,
   makeExecuteOption,
   makeLogsOption,
   makePdfOption,
   makeSiteOption,
   makeTexOption,
+  makeTypstOption,
   makeYesOption,
 } from './options.js';
 import { clirun } from './clirun.js';
@@ -41,14 +43,16 @@ export function makeAllOption() {
 
 export function makeCleanCLI(program: Command) {
   const command = new Command('clean')
-    .description('Clean built pdf, tex, and word exports and other build artifacts')
+    .description('Clean built pdf, tex, word, etc exports and other build artifacts')
     .argument('[files...]', 'list of files to clean corresponding outputs')
     .addOption(makePdfOption('Clean'))
     .addOption(makeTexOption('Clean'))
+    .addOption(makeTypstOption('Clean'))
     .addOption(makeDocxOption('Clean'))
     .addOption(makeSiteOption('Clean'))
     .addOption(makeTempOption())
     .addOption(makeLogsOption('Clean logs'))
+    .addOption(makeCacheOption('Clean web request cache'))
     .addOption(makeExportsOption())
     .addOption(makeExecuteOption('Clean execute cache'))
     .addOption(makeTemplatesOption())

--- a/packages/curvenote/src/clean.ts
+++ b/packages/curvenote/src/clean.ts
@@ -4,7 +4,9 @@ import {
   makeCacheOption,
   makeDocxOption,
   makeExecuteOption,
+  makeJatsOption,
   makeLogsOption,
+  makeMecaOption,
   makePdfOption,
   makeSiteOption,
   makeTexOption,
@@ -49,6 +51,8 @@ export function makeCleanCLI(program: Command) {
     .addOption(makeTexOption('Clean'))
     .addOption(makeTypstOption('Clean'))
     .addOption(makeDocxOption('Clean'))
+    .addOption(makeJatsOption('Clean'))
+    .addOption(makeMecaOption('Clean'))
     .addOption(makeSiteOption('Clean'))
     .addOption(makeTempOption())
     .addOption(makeLogsOption('Clean logs'))

--- a/packages/curvenote/src/export.ts
+++ b/packages/curvenote/src/export.ts
@@ -76,6 +76,24 @@ function makeTexExportCLI(program: Command) {
   return command;
 }
 
+function makeTypstExportCLI(program: Command) {
+  const command = new Command('typst')
+    .alias('typ')
+    .description('Export a typst file from a local markdown/notebook file or a Curvenote link')
+    .argument(
+      '<article>',
+      'A local file or link to the Curvenote article (e.g. OXA Link or API link)',
+    )
+    .argument('[output]', 'The document filename to export to', '')
+    .addOption(makeDisableTemplateOption())
+    .addOption(makeTemplateOption())
+    .addOption(makeCleanOption())
+    .addOption(makeZipOption())
+    .addOption(makeTemplateOptionsOption())
+    .action(clirun(exp.oxaLinkToTypst, { program }, 3));
+  return command;
+}
+
 function makePdfExportCLI(program: Command) {
   const command = new Command('pdf')
     .description('Export a pdf file from a local markdown/notebook file or a Curvenote link')
@@ -136,6 +154,7 @@ export function addExportCLI(program: Command) {
   command.addCommand(makeWordExportCLI(program));
   command.addCommand(makeMarkdownExportCLI(program));
   command.addCommand(makeTexExportCLI(program));
+  command.addCommand(makeTypstExportCLI(program));
   command.addCommand(makePdfExportCLI(program));
   command.addCommand(makePdfBuildCLI(program));
   command.addCommand(makeJupyterNotebookExportCLI(program));

--- a/packages/curvenote/src/export.ts
+++ b/packages/curvenote/src/export.ts
@@ -111,6 +111,32 @@ function makePdfExportCLI(program: Command) {
   return command;
 }
 
+function makeJatsExportCLI(program: Command) {
+  const command = new Command('jats')
+    .description('Export a JATS file from a local markdown/notebook file or a Curvenote link')
+    .argument(
+      '<article>',
+      'A local file or link to the Curvenote article (e.g. OXA Link or API link)',
+    )
+    .argument('[output]', 'The document filename to export to', '')
+    .addOption(makeCleanOption())
+    .action(clirun(exp.oxaLinkToJats, { program }, 3));
+  return command;
+}
+
+function makeMecaExportCLI(program: Command) {
+  const command = new Command('meca')
+    .description('Export a MECA file from a local project or a Curvenote link')
+    .argument(
+      '<article>',
+      'A local file or link to the Curvenote article (e.g. OXA Link or API link)',
+    )
+    .argument('[output]', 'The document filename to export to', '')
+    .addOption(makeCleanOption())
+    .action(clirun(exp.oxaLinkToMeca, { program }, 3));
+  return command;
+}
+
 function makePdfBuildCLI(program: Command) {
   const command = new Command('pdf:build')
     .description('Build a pdf given a tex file')
@@ -156,6 +182,8 @@ export function addExportCLI(program: Command) {
   command.addCommand(makeTexExportCLI(program));
   command.addCommand(makeTypstExportCLI(program));
   command.addCommand(makePdfExportCLI(program));
+  command.addCommand(makeJatsExportCLI(program));
+  command.addCommand(makeMecaExportCLI(program));
   command.addCommand(makePdfBuildCLI(program));
   command.addCommand(makeJupyterNotebookExportCLI(program));
   command.addCommand(makeJupyterBookExportCLI(program));

--- a/packages/curvenote/src/options.ts
+++ b/packages/curvenote/src/options.ts
@@ -93,6 +93,14 @@ export function makeDocxOption(verb: string) {
   return new Option('--word, --docx', `${verb} Docx output`).default(false);
 }
 
+export function makeJatsOption(verb: string) {
+  return new Option('--jats, --xml', `${verb} JATS output`).default(false);
+}
+
+export function makeMecaOption(verb: string) {
+  return new Option('--meca', `${verb} MECA output`).default(false);
+}
+
 export function makeSiteOption(verb: string) {
   return new Option('--site', `${verb} MyST site content`).default(false);
 }

--- a/packages/curvenote/src/options.ts
+++ b/packages/curvenote/src/options.ts
@@ -85,6 +85,10 @@ export function makeTexOption(verb: string) {
   return new Option('--tex', `${verb} Tex outputs`).default(false);
 }
 
+export function makeTypstOption(verb: string) {
+  return new Option('--typst', `${verb} Typst outputs`).default(false);
+}
+
 export function makeDocxOption(verb: string) {
   return new Option('--word, --docx', `${verb} Docx output`).default(false);
 }
@@ -99,4 +103,8 @@ export function makeExecuteOption(description: string) {
 
 export function makeLogsOption(description: string) {
   return new Option('--logs', description).default(false);
+}
+
+export function makeCacheOption(description: string) {
+  return new Option('--cache', description).default(false);
 }

--- a/packages/curvenote/src/web.ts
+++ b/packages/curvenote/src/web.ts
@@ -9,10 +9,6 @@ import {
   makeCheckLinksOption,
   makeKeepHostOption,
   makeHeadlessOption,
-  makePdfOption,
-  makeTexOption,
-  makeDocxOption,
-  makeSiteOption,
   makeDomainOption,
   makeVenueOption,
   makeExecuteOption,
@@ -30,14 +26,7 @@ function makeCurvenoteStartCLI(program: Command) {
 
 function makeBuildCLI(program: Command) {
   const command = new Command('build')
-    .description(
-      'Build pdf, tex, and word exports from MyST files as well as build MyST site content',
-    )
-    .argument('[files...]', 'list of files to export')
-    .addOption(makePdfOption('Build'))
-    .addOption(makeTexOption('Build'))
-    .addOption(makeDocxOption('Build'))
-    .addOption(makeSiteOption('Build'))
+    .description('Build MyST site content')
     .addOption(makeExecuteOption('Execute Notebooks'))
     .addOption(makeForceOption())
     .addOption(makeCheckLinksOption())


### PR DESCRIPTION
This adds `typst`, `jats`, and `meca` commands to the `curvenote export` CLI. It also adds all of these as well as `--cache` to the `curvenote clean` CLI. All of this follows the exact same pattern as existing work. It is dependent on https://github.com/executablebooks/mystmd/pull/935