### PR TITLE
⏭ add `auth check` alias and skip project loading in `auth` and `token`

### DIFF
--- a/.changeset/proud-boats-shake.md
+++ b/.changeset/proud-boats-shake.md
@@ -1,0 +1,6 @@
+---
+"@curvenote/cli": patch
+"curvenote": patch
+---
+
+Some cli commands should skip project loading

--- a/packages/curvenote-cli/src/session/config.ts
+++ b/packages/curvenote-cli/src/session/config.ts
@@ -41,7 +41,7 @@ export async function setToken(log: Logger, token?: string) {
     ]);
     token = resp.token;
   }
-  const session = new Session(token);
+  const session = new Session(token, { skipProjectLoading: true });
   let me;
   try {
     me = await new MyUser(session).get();

--- a/packages/curvenote-cli/src/session/session.ts
+++ b/packages/curvenote-cli/src/session/session.ts
@@ -42,6 +42,7 @@ export type SessionOptions = {
   apiUrl?: string;
   siteUrl?: string;
   logger?: Logger;
+  skipProjectLoading?: boolean;
 };
 
 function withQuery(url: string, query: Record<string, string> = {}) {
@@ -113,8 +114,10 @@ export class Session implements ISession {
     }
 
     this.store = createStore(rootReducer);
-    findCurrentProjectAndLoad(this, '.');
-    findCurrentSiteAndLoad(this, '.');
+    if (!opts.skipProjectLoading) {
+      findCurrentProjectAndLoad(this, '.');
+      findCurrentSiteAndLoad(this, '.');
+    }
   }
 
   proxyAgent?: HttpsProxyAgent<string>;

--- a/packages/curvenote-cli/src/session/types.ts
+++ b/packages/curvenote-cli/src/session/types.ts
@@ -7,6 +7,7 @@ import type { CheckInterface } from '@curvenote/check-implementations';
 export type SessionOpts = {
   debug?: boolean;
   config?: string;
+  skipProjectLoading?: boolean;
 };
 
 export type Tokens = Partial<Record<'user' | 'session', string>>;

--- a/packages/curvenote-cli/src/session/utils.ts
+++ b/packages/curvenote-cli/src/session/utils.ts
@@ -6,7 +6,7 @@ import { getToken } from './config.js';
 
 export function anonSession(opts?: SessionOpts): ISession {
   const logger = chalkLogger(getLogLevel(opts?.debug), process.cwd());
-  const session = new Session(undefined, { logger });
+  const session = new Session(undefined, { logger, skipProjectLoading: opts?.skipProjectLoading });
   return session;
 }
 
@@ -20,7 +20,7 @@ export function getSession(opts?: SessionOpts & { hideNoTokenWarning?: boolean }
   }
   let session;
   try {
-    session = new Session(token, { logger });
+    session = new Session(token, { logger, skipProjectLoading: opts?.skipProjectLoading });
   } catch (error) {
     logger.error((error as Error).message);
     logger.info('You can remove your token using:');

--- a/packages/curvenote/src/auth.ts
+++ b/packages/curvenote/src/auth.ts
@@ -4,6 +4,10 @@ import { auth } from '@curvenote/cli';
 
 export function addAuthCLI(program: Command) {
   const command = new Command('auth').description('Check if you are logged into the API');
-  command.command('list').description('List ').action(clirun(auth.checkAuth, { program }));
+  command
+    .command('list')
+    .description('List ')
+    .action(clirun(auth.checkAuth, { program, skipProjectLoading: true }))
+    .alias('check');
   program.addCommand(command);
 }

--- a/packages/curvenote/src/token.ts
+++ b/packages/curvenote/src/token.ts
@@ -13,6 +13,7 @@ export function addTokenCLI(program: Command) {
       clirun(async (session, token?: string) => setToken(session.log, token), {
         program,
         anonymous: true,
+        skipProjectLoading: true,
       }),
     );
   command
@@ -22,6 +23,7 @@ export function addTokenCLI(program: Command) {
       clirun(async (session) => selectToken(session.log), {
         program,
         anonymous: true,
+        skipProjectLoading: true,
       }),
     );
   command
@@ -32,6 +34,7 @@ export function addTokenCLI(program: Command) {
       clirun((session) => deleteToken(session.log), {
         program,
         anonymous: true,
+        skipProjectLoading: true,
       }),
     );
   program.addCommand(command);


### PR DESCRIPTION
this means that project related errors and warnings are not shown for certain commands, like when checking auth or managing tokens