### PR TITLE
🎬 Fix init to correctly pull project

### DIFF
--- a/.changeset/lucky-planets-raise.md
+++ b/.changeset/lucky-planets-raise.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Fix init to correctly pull project

--- a/.changeset/strong-beds-smoke.md
+++ b/.changeset/strong-beds-smoke.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Fix to curvenote init to ensure that the project gets pulled from remote link

--- a/packages/curvenote-cli/src/sync/init.ts
+++ b/packages/curvenote-cli/src/sync/init.ts
@@ -174,7 +174,10 @@ export async function init(session: ISession, opts: Options) {
     throw Error(`Invalid init content: ${content}`);
   }
   // If there is a new project config, save to the state and write to disk
-  if (projectConfig) writeConfigs(session, currentPath, { projectConfig });
+  if (projectConfig) {
+    writeConfigs(session, currentPath, { projectConfig });
+    session.store.dispatch(config.actions.receiveCurrentProjectPath({ path: currentPath }));
+  }
   // Personalize the config
   session.log.info(`📓 Creating site config`);
   me = await me;


### PR DESCRIPTION
This fixes the error when performing `curvenote init` from a curvenote URL source: `No valid files with extensions .md or .ipynb or .tex found in path`. Now the project gets pulled as expected.