### PR TITLE
🔑 Update work post from key -> cdn_key

### DIFF
--- a/.changeset/sixty-kiwis-kneel.md
+++ b/.changeset/sixty-kiwis-kneel.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Update work post from key -> cdn_key

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,7 +170,7 @@
       }
     },
     "mystjs/packages/myst-cli": {
-      "version": "1.1.46",
+      "version": "1.1.47",
       "license": "MIT",
       "dependencies": {
         "@jupyterlab/services": "^7.0.0",
@@ -198,9 +198,9 @@
         "mdast": "^3.0.0",
         "meca": "^1.0.8",
         "mime-types": "^2.1.35",
-        "myst-cli-utils": "^2.0.8",
-        "myst-common": "^1.1.29",
-        "myst-config": "^1.1.29",
+        "myst-cli-utils": "^2.0.9",
+        "myst-common": "^1.1.30",
+        "myst-config": "^1.1.30",
         "myst-execute": "^0.0.3",
         "myst-ext-card": "^1.0.5",
         "myst-ext-exercise": "^1.0.5",
@@ -208,17 +208,17 @@
         "myst-ext-proof": "^1.0.8",
         "myst-ext-reactive": "^1.0.5",
         "myst-ext-tabs": "^1.0.5",
-        "myst-frontmatter": "^1.1.29",
-        "myst-parser": "^1.0.24",
+        "myst-frontmatter": "^1.1.30",
+        "myst-parser": "^1.1.0",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.1.29",
+        "myst-spec-ext": "^1.1.30",
         "myst-templates": "^1.0.17",
         "myst-to-docx": "^1.0.9",
         "myst-to-jats": "^1.0.24",
         "myst-to-md": "^1.0.10",
         "myst-to-tex": "^1.0.22",
         "myst-to-typst": "^0.0.11",
-        "myst-transforms": "^1.2.5",
+        "myst-transforms": "^1.3.0",
         "nanoid": "^4.0.0",
         "nbtx": "^0.2.3",
         "node-fetch": "^3.3.1",
@@ -257,7 +257,7 @@
       }
     },
     "mystjs/packages/myst-cli-utils": {
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.2.0",
@@ -438,11 +438,11 @@
       "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
     "mystjs/packages/myst-common": {
-      "version": "1.1.29",
+      "version": "1.1.30",
       "license": "MIT",
       "dependencies": {
         "mdast": "^3.0.0",
-        "myst-frontmatter": "^1.1.29",
+        "myst-frontmatter": "^1.1.30",
         "myst-spec": "^0.0.5",
         "nanoid": "^4.0.0",
         "unified": "^10.1.2",
@@ -454,7 +454,7 @@
       "devDependencies": {
         "@jupyterlab/nbformat": "^3.5.2",
         "@lumino/coreutils": "^2.0.0",
-        "myst-spec-ext": "^1.1.29",
+        "myst-spec-ext": "^1.1.30",
         "unist-builder": "3.0.0"
       }
     },
@@ -472,10 +472,10 @@
       }
     },
     "mystjs/packages/myst-config": {
-      "version": "1.1.29",
+      "version": "1.1.30",
       "license": "MIT",
       "dependencies": {
-        "myst-frontmatter": "^1.1.29",
+        "myst-frontmatter": "^1.1.30",
         "simple-validators": "^1.0.4"
       },
       "devDependencies": {
@@ -483,12 +483,13 @@
       }
     },
     "mystjs/packages/myst-directives": {
-      "version": "1.0.24",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
+        "classnames": "^2.3.2",
         "js-yaml": "^4.1.0",
-        "myst-common": "^1.1.29",
-        "myst-spec-ext": "^1.1.29",
+        "myst-common": "^1.1.30",
+        "myst-spec-ext": "^1.1.30",
         "nanoid": "^4.0.2",
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.7"
@@ -607,7 +608,7 @@
       }
     },
     "mystjs/packages/myst-frontmatter": {
-      "version": "1.1.29",
+      "version": "1.1.30",
       "license": "MIT",
       "dependencies": {
         "credit-roles": "^2.1.0",
@@ -624,7 +625,7 @@
       }
     },
     "mystjs/packages/myst-parser": {
-      "version": "1.0.24",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "he": "^1.2.0",
@@ -637,9 +638,9 @@
         "markdown-it-myst": "1.0.5",
         "markdown-it-myst-extras": "0.3.0",
         "markdown-it-task-lists": "^2.1.1",
-        "myst-common": "^1.1.29",
-        "myst-directives": "^1.0.24",
-        "myst-roles": "^1.0.24",
+        "myst-common": "^1.1.30",
+        "myst-directives": "^1.1.0",
+        "myst-roles": "^1.1.0",
         "myst-spec": "^0.0.5",
         "unified": "^10.1.1",
         "unist-builder": "^3.0.0",
@@ -656,8 +657,8 @@
         "@types/markdown-it": "^12.2.3",
         "@types/mdast": "^3.0.10",
         "js-yaml": "^4.1.0",
-        "myst-to-html": "^1.0.24",
-        "myst-transforms": "^1.2.5",
+        "myst-to-html": "^1.1.0",
+        "myst-transforms": "^1.3.0",
         "rehype-stringify": "^9.0.3"
       }
     },
@@ -676,15 +677,15 @@
       }
     },
     "mystjs/packages/myst-roles": {
-      "version": "1.0.24",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.1.29",
-        "myst-spec-ext": "^1.1.29"
+        "myst-common": "^1.1.30",
+        "myst-spec-ext": "^1.1.30"
       }
     },
     "mystjs/packages/myst-spec-ext": {
-      "version": "1.1.29",
+      "version": "1.1.30",
       "license": "MIT",
       "dependencies": {
         "myst-spec": "^0.0.5"
@@ -736,7 +737,7 @@
       }
     },
     "mystjs/packages/myst-to-html": {
-      "version": "1.0.24",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2",
@@ -746,7 +747,7 @@
         "mdast": "^3.0.0",
         "mdast-util-find-and-replace": "^2.1.0",
         "mdast-util-to-hast": "^12.3.0",
-        "myst-common": "^1.1.29",
+        "myst-common": "^1.1.30",
         "rehype-format": "^4.0.1",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
@@ -905,7 +906,7 @@
       }
     },
     "mystjs/packages/myst-transforms": {
-      "version": "1.2.5",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "doi-utils": "^2.0.0",
@@ -915,11 +916,11 @@
         "js-yaml": "^4.1.0",
         "katex": "^0.15.2",
         "mdast-util-find-and-replace": "^2.1.0",
-        "myst-common": "^1.1.29",
-        "myst-frontmatter": "^1.1.29",
+        "myst-common": "^1.1.30",
+        "myst-frontmatter": "^1.1.30",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.1.29",
-        "myst-to-html": "1.0.24",
+        "myst-spec-ext": "^1.1.30",
+        "myst-to-html": "1.1.0",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
         "unified": "^10.0.0",
@@ -952,7 +953,7 @@
       }
     },
     "mystjs/packages/mystmd": {
-      "version": "1.1.46",
+      "version": "1.1.47",
       "license": "MIT",
       "bin": {
         "myst": "dist/myst.cjs"
@@ -962,7 +963,7 @@
         "commander": "^10.0.1",
         "core-js": "^3.31.1",
         "js-yaml": "^4.1.0",
-        "myst-cli": "^1.1.46"
+        "myst-cli": "^1.1.47"
       }
     },
     "mystjs/packages/mystmd/node_modules/chalk": {
@@ -26623,9 +26624,9 @@
         "mdast": "^3.0.0",
         "meca": "^1.0.8",
         "mime-types": "^2.1.35",
-        "myst-cli-utils": "^2.0.8",
-        "myst-common": "^1.1.29",
-        "myst-config": "^1.1.29",
+        "myst-cli-utils": "^2.0.9",
+        "myst-common": "^1.1.30",
+        "myst-config": "^1.1.30",
         "myst-execute": "^0.0.3",
         "myst-ext-card": "^1.0.5",
         "myst-ext-exercise": "^1.0.5",
@@ -26633,17 +26634,17 @@
         "myst-ext-proof": "^1.0.8",
         "myst-ext-reactive": "^1.0.5",
         "myst-ext-tabs": "^1.0.5",
-        "myst-frontmatter": "^1.1.29",
-        "myst-parser": "^1.0.24",
+        "myst-frontmatter": "^1.1.30",
+        "myst-parser": "^1.1.0",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.1.29",
+        "myst-spec-ext": "^1.1.30",
         "myst-templates": "^1.0.17",
         "myst-to-docx": "^1.0.9",
         "myst-to-jats": "^1.0.24",
         "myst-to-md": "^1.0.10",
         "myst-to-tex": "^1.0.22",
         "myst-to-typst": "^0.0.11",
-        "myst-transforms": "^1.2.5",
+        "myst-transforms": "^1.3.0",
         "nanoid": "^4.0.0",
         "nbtx": "^0.2.3",
         "node-fetch": "^3.3.1",
@@ -26793,9 +26794,9 @@
         "@jupyterlab/nbformat": "^3.5.2",
         "@lumino/coreutils": "^2.0.0",
         "mdast": "^3.0.0",
-        "myst-frontmatter": "^1.1.29",
+        "myst-frontmatter": "^1.1.30",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.1.29",
+        "myst-spec-ext": "^1.1.30",
         "nanoid": "^4.0.0",
         "unified": "^10.1.2",
         "unist-builder": "3.0.0",
@@ -26820,16 +26821,17 @@
       "version": "file:mystjs/packages/myst-config",
       "requires": {
         "moment": "^2.29.4",
-        "myst-frontmatter": "^1.1.29",
+        "myst-frontmatter": "^1.1.30",
         "simple-validators": "^1.0.4"
       }
     },
     "myst-directives": {
       "version": "file:mystjs/packages/myst-directives",
       "requires": {
+        "classnames": "^2.3.2",
         "js-yaml": "^4.1.0",
-        "myst-common": "^1.1.29",
-        "myst-spec-ext": "^1.1.29",
+        "myst-common": "^1.1.30",
+        "myst-spec-ext": "^1.1.30",
         "nanoid": "^4.0.2",
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.7"
@@ -26947,12 +26949,12 @@
         "markdown-it-myst": "1.0.5",
         "markdown-it-myst-extras": "0.3.0",
         "markdown-it-task-lists": "^2.1.1",
-        "myst-common": "^1.1.29",
-        "myst-directives": "^1.0.24",
-        "myst-roles": "^1.0.24",
+        "myst-common": "^1.1.30",
+        "myst-directives": "^1.1.0",
+        "myst-roles": "^1.1.0",
         "myst-spec": "^0.0.5",
-        "myst-to-html": "^1.0.24",
-        "myst-transforms": "^1.2.5",
+        "myst-to-html": "^1.1.0",
+        "myst-transforms": "^1.3.0",
         "rehype-stringify": "^9.0.3",
         "unified": "^10.1.1",
         "unist-builder": "^3.0.0",
@@ -26977,8 +26979,8 @@
     "myst-roles": {
       "version": "file:mystjs/packages/myst-roles",
       "requires": {
-        "myst-common": "^1.1.29",
-        "myst-spec-ext": "^1.1.29"
+        "myst-common": "^1.1.30",
+        "myst-spec-ext": "^1.1.30"
       }
     },
     "myst-spec": {
@@ -27039,7 +27041,7 @@
         "mdast": "^3.0.0",
         "mdast-util-find-and-replace": "^2.1.0",
         "mdast-util-to-hast": "^12.3.0",
-        "myst-common": "^1.1.29",
+        "myst-common": "^1.1.30",
         "rehype-format": "^4.0.1",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
@@ -27184,11 +27186,11 @@
         "js-yaml": "^4.1.0",
         "katex": "^0.15.2",
         "mdast-util-find-and-replace": "^2.1.0",
-        "myst-common": "^1.1.29",
-        "myst-frontmatter": "^1.1.29",
+        "myst-common": "^1.1.30",
+        "myst-frontmatter": "^1.1.30",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.1.29",
-        "myst-to-html": "1.0.24",
+        "myst-spec-ext": "^1.1.30",
+        "myst-to-html": "1.1.0",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
         "unified": "^10.0.0",
@@ -27290,7 +27292,7 @@
         "commander": "^10.0.1",
         "core-js": "^3.31.1",
         "js-yaml": "^4.1.0",
-        "myst-cli": "^1.1.46"
+        "myst-cli": "^1.1.47"
       },
       "dependencies": {
         "chalk": {

--- a/packages/curvenote-cli/src/submissions/submit.ts
+++ b/packages/curvenote-cli/src/submissions/submit.ts
@@ -303,7 +303,7 @@ export async function submit(session: ISession, venue: string, opts?: SubmitOpts
       ...job.results,
       error: err.message,
     });
-    session.log.error(`📣 ${chalk.bold.red(err.message)}.`);
+    session.log.error(`📣 ${chalk.bold.red(err.message)}`);
     session.log.info('📨 Please contact support@curvenote.com');
   }
   writeJsonLogs(session, 'curvenote.submit.json', submitLog);

--- a/packages/curvenote-cli/src/submissions/submit.utils.ts
+++ b/packages/curvenote-cli/src/submissions/submit.utils.ts
@@ -365,6 +365,6 @@ export async function updateExistingSubmission(
     logCollector.submissionVersion = submissionVersion;
   } catch (err: any) {
     session.log.error(err.message);
-    throw new Error(`🚨 ${chalk.bold.red('Could not update your submission')}.`);
+    throw new Error(`🚨 ${chalk.bold.red('Could not update your submission')}`);
   }
 }

--- a/packages/curvenote-cli/src/submissions/utils.ts
+++ b/packages/curvenote-cli/src/submissions/utils.ts
@@ -79,7 +79,7 @@ export async function postNewWork(
   session.log.debug(
     `POST to ${session.JOURNALS_URL}works with cdnKey: ${cdnKey} and cdn: ${cdn}...`,
   );
-  const resp = await postToJournals(session, 'works', { key: cdnKey, cdn });
+  const resp = await postToJournals(session, 'works', { cdn_key: cdnKey, cdn });
   session.log.debug(`${resp.status} ${resp.statusText}`);
   if (resp.ok) {
     const json = (await resp.json()) as any;
@@ -114,7 +114,7 @@ export async function postNewWorkVersion(
   session.log.debug(
     `POST to ${session.JOURNALS_URL}works/${workId}/versions with cdnKey: ${cdnKey} and cdn: ${cdn}...`,
   );
-  const resp = await postToJournals(session, `works/${workId}/versions`, { key: cdnKey, cdn });
+  const resp = await postToJournals(session, `works/${workId}/versions`, { cdn_key: cdnKey, cdn });
   session.log.debug(`${resp.status} ${resp.statusText}`);
 
   if (resp.ok) {

--- a/packages/curvenote-cli/src/utils/types.ts
+++ b/packages/curvenote-cli/src/utils/types.ts
@@ -1,5 +1,5 @@
 export interface WorkBody {
-  key: string;
+  cdn_key: string;
   cdn: string;
 }
 


### PR DESCRIPTION
API changed to accept `cdn_key` instead of `key` on work post request/response.