### PR TITLE
🤐 add `-f` to prevent exit when no status action is available

### DIFF
--- a/packages/curvenote-cli/src/submissions/status.ts
+++ b/packages/curvenote-cli/src/submissions/status.ts
@@ -10,7 +10,16 @@ import {
 import { exitOnInvalidKeyOption, patchUpdateSubmissionStatus } from './utils.js';
 import { keyFromTransferFile } from './utils.transfer.js';
 
-async function updateStatus(action: STATUS_ACTIONS, session: ISession, venue: string) {
+type StatusOptions = {
+  force?: boolean;
+};
+
+async function updateStatus(
+  action: STATUS_ACTIONS,
+  session: ISession,
+  venue: string,
+  opts: StatusOptions = {},
+) {
   if (session.isAnon) {
     throw new Error(
       '⛔️ You must be authenticated for this command. Use `curvenote token set [token]`',
@@ -40,13 +49,18 @@ async function updateStatus(action: STATUS_ACTIONS, session: ISession, venue: st
   }
   session.log.debug(`Found existing submission with key/id: ${key}/${existing.id}`);
 
-  await patchUpdateSubmissionStatus(session, venue, existing.links.self, action);
+  try {
+    await patchUpdateSubmissionStatus(session, venue, existing.links.self, action);
+  } catch (e: any) {
+    if (!opts.force) throw e;
+    session.log.warn(`⚠️  ${e.message}`);
+  }
 }
 
-export async function publish(session: ISession, venue: string) {
-  await updateStatus('publish', session, venue);
+export async function publish(session: ISession, venue: string, opts: StatusOptions = {}) {
+  await updateStatus('publish', session, venue, opts);
 }
 
-export async function unpublish(session: ISession, venue: string) {
-  await updateStatus('unpublish', session, venue);
+export async function unpublish(session: ISession, venue: string, opts: StatusOptions = {}) {
+  await updateStatus('unpublish', session, venue, opts);
 }

--- a/packages/curvenote/src/submissions.ts
+++ b/packages/curvenote/src/submissions.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { clirun } from './clirun.js';
 import {
   makeDraftOption,
@@ -48,6 +48,12 @@ function makeSubmissionPublishCLI(program: Command) {
   const command = new Command('publish')
     .description('Publish your Submission')
     .argument('[venue]', 'Venue to publish the submission to')
+    .addOption(
+      new Option(
+        '-f, --force',
+        'If the publish action is not available, do not throw an error',
+      ).default(false),
+    )
     .action(clirun(submissions.publish, { program, requireSiteConfig: true }));
   return command;
 }
@@ -56,6 +62,12 @@ function makeSubmissionUnpublishCLI(program: Command) {
   const command = new Command('unpublish')
     .description('Unpublish an existing Submission')
     .argument('[venue]', 'Venue to unpublish the submission from')
+    .addOption(
+      new Option(
+        '-f, --force',
+        'If the unpublish action is not available, do not throw an error',
+      ).default(false),
+    )
     .action(clirun(submissions.unpublish, { program, requireSiteConfig: true }));
   return command;
 }


### PR DESCRIPTION
This enables a script, that publishes many things, to run and publish any articles that it can, without failing on ones that are already published.