### PR TITLE
⛔️ Do not prompt on --yes option, fail instead

### DIFF
--- a/.changeset/quick-mice-appear.md
+++ b/.changeset/quick-mice-appear.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Do not prompt on --yes option, fail instead

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,7 +170,7 @@
       }
     },
     "mystjs/packages/myst-cli": {
-      "version": "1.1.51",
+      "version": "1.1.52",
       "license": "MIT",
       "dependencies": {
         "@jupyterlab/services": "^7.0.0",
@@ -199,8 +199,8 @@
         "meca": "^1.0.8",
         "mime-types": "^2.1.35",
         "myst-cli-utils": "^2.0.9",
-        "myst-common": "^1.1.34",
-        "myst-config": "^1.1.34",
+        "myst-common": "^1.1.35",
+        "myst-config": "^1.1.35",
         "myst-execute": "^0.0.4",
         "myst-ext-card": "^1.0.5",
         "myst-ext-exercise": "^1.0.5",
@@ -208,17 +208,17 @@
         "myst-ext-proof": "^1.0.8",
         "myst-ext-reactive": "^1.0.5",
         "myst-ext-tabs": "^1.0.5",
-        "myst-frontmatter": "^1.1.34",
-        "myst-parser": "^1.2.2",
+        "myst-frontmatter": "^1.1.35",
+        "myst-parser": "^1.2.3",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.1.34",
+        "myst-spec-ext": "^1.1.35",
         "myst-templates": "^1.0.17",
         "myst-to-docx": "^1.0.9",
         "myst-to-jats": "^1.0.24",
         "myst-to-md": "^1.0.10",
         "myst-to-tex": "^1.0.25",
         "myst-to-typst": "^0.0.13",
-        "myst-transforms": "^1.3.3",
+        "myst-transforms": "^1.3.4",
         "nanoid": "^4.0.0",
         "nbtx": "^0.2.3",
         "node-fetch": "^3.3.1",
@@ -589,11 +589,11 @@
       }
     },
     "mystjs/packages/myst-common": {
-      "version": "1.1.34",
+      "version": "1.1.35",
       "license": "MIT",
       "dependencies": {
         "mdast": "^3.0.0",
-        "myst-frontmatter": "^1.1.34",
+        "myst-frontmatter": "^1.1.35",
         "myst-spec": "^0.0.5",
         "nanoid": "^4.0.0",
         "unified": "^10.1.2",
@@ -605,7 +605,7 @@
       "devDependencies": {
         "@jupyterlab/nbformat": "^3.5.2",
         "@lumino/coreutils": "^2.0.0",
-        "myst-spec-ext": "^1.1.34",
+        "myst-spec-ext": "^1.1.35",
         "unist-builder": "3.0.0"
       }
     },
@@ -623,10 +623,10 @@
       }
     },
     "mystjs/packages/myst-config": {
-      "version": "1.1.34",
+      "version": "1.1.35",
       "license": "MIT",
       "dependencies": {
-        "myst-frontmatter": "^1.1.34",
+        "myst-frontmatter": "^1.1.35",
         "simple-validators": "^1.0.4"
       },
       "devDependencies": {
@@ -634,13 +634,13 @@
       }
     },
     "mystjs/packages/myst-directives": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2",
         "js-yaml": "^4.1.0",
-        "myst-common": "^1.1.34",
-        "myst-spec-ext": "^1.1.34",
+        "myst-common": "^1.1.35",
+        "myst-spec-ext": "^1.1.35",
         "nanoid": "^4.0.2",
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.7"
@@ -759,7 +759,7 @@
       }
     },
     "mystjs/packages/myst-frontmatter": {
-      "version": "1.1.34",
+      "version": "1.1.35",
       "license": "MIT",
       "dependencies": {
         "credit-roles": "^2.1.0",
@@ -776,7 +776,7 @@
       }
     },
     "mystjs/packages/myst-parser": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "he": "^1.2.0",
@@ -789,9 +789,9 @@
         "markdown-it-myst": "1.0.7",
         "markdown-it-myst-extras": "0.3.0",
         "markdown-it-task-lists": "^2.1.1",
-        "myst-common": "^1.1.34",
-        "myst-directives": "^1.2.2",
-        "myst-roles": "^1.2.2",
+        "myst-common": "^1.1.35",
+        "myst-directives": "^1.2.3",
+        "myst-roles": "^1.2.3",
         "myst-spec": "^0.0.5",
         "unified": "^10.1.1",
         "unist-builder": "^3.0.0",
@@ -808,8 +808,8 @@
         "@types/markdown-it": "^12.2.3",
         "@types/mdast": "^3.0.10",
         "js-yaml": "^4.1.0",
-        "myst-to-html": "^1.2.2",
-        "myst-transforms": "^1.3.3",
+        "myst-to-html": "^1.2.3",
+        "myst-transforms": "^1.3.4",
         "rehype-stringify": "^9.0.3"
       }
     },
@@ -828,15 +828,15 @@
       }
     },
     "mystjs/packages/myst-roles": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.1.34",
-        "myst-spec-ext": "^1.1.34"
+        "myst-common": "^1.1.35",
+        "myst-spec-ext": "^1.1.35"
       }
     },
     "mystjs/packages/myst-spec-ext": {
-      "version": "1.1.34",
+      "version": "1.1.35",
       "license": "MIT",
       "dependencies": {
         "myst-spec": "^0.0.5"
@@ -888,7 +888,7 @@
       }
     },
     "mystjs/packages/myst-to-html": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2",
@@ -898,7 +898,7 @@
         "mdast": "^3.0.0",
         "mdast-util-find-and-replace": "^2.1.0",
         "mdast-util-to-hast": "^12.3.0",
-        "myst-common": "^1.1.34",
+        "myst-common": "^1.1.35",
         "rehype-format": "^4.0.1",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
@@ -1057,7 +1057,7 @@
       }
     },
     "mystjs/packages/myst-transforms": {
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "doi-utils": "^2.0.0",
@@ -1067,11 +1067,11 @@
         "js-yaml": "^4.1.0",
         "katex": "^0.15.2",
         "mdast-util-find-and-replace": "^2.1.0",
-        "myst-common": "^1.1.34",
-        "myst-frontmatter": "^1.1.34",
+        "myst-common": "^1.1.35",
+        "myst-frontmatter": "^1.1.35",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.1.34",
-        "myst-to-html": "1.2.2",
+        "myst-spec-ext": "^1.1.35",
+        "myst-to-html": "1.2.3",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
         "unified": "^10.0.0",
@@ -1104,7 +1104,7 @@
       }
     },
     "mystjs/packages/mystmd": {
-      "version": "1.1.51",
+      "version": "1.1.52",
       "license": "MIT",
       "bin": {
         "myst": "dist/myst.cjs"
@@ -1114,7 +1114,7 @@
         "commander": "^10.0.1",
         "core-js": "^3.31.1",
         "js-yaml": "^4.1.0",
-        "myst-cli": "^1.1.51"
+        "myst-cli": "^1.1.52"
       }
     },
     "mystjs/packages/mystmd/node_modules/chalk": {
@@ -26825,8 +26825,8 @@
         "meca": "^1.0.8",
         "mime-types": "^2.1.35",
         "myst-cli-utils": "^2.0.9",
-        "myst-common": "^1.1.34",
-        "myst-config": "^1.1.34",
+        "myst-common": "^1.1.35",
+        "myst-config": "^1.1.35",
         "myst-execute": "^0.0.4",
         "myst-ext-card": "^1.0.5",
         "myst-ext-exercise": "^1.0.5",
@@ -26834,17 +26834,17 @@
         "myst-ext-proof": "^1.0.8",
         "myst-ext-reactive": "^1.0.5",
         "myst-ext-tabs": "^1.0.5",
-        "myst-frontmatter": "^1.1.34",
-        "myst-parser": "^1.2.2",
+        "myst-frontmatter": "^1.1.35",
+        "myst-parser": "^1.2.3",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.1.34",
+        "myst-spec-ext": "^1.1.35",
         "myst-templates": "^1.0.17",
         "myst-to-docx": "^1.0.9",
         "myst-to-jats": "^1.0.24",
         "myst-to-md": "^1.0.10",
         "myst-to-tex": "^1.0.25",
         "myst-to-typst": "^0.0.13",
-        "myst-transforms": "^1.3.3",
+        "myst-transforms": "^1.3.4",
         "nanoid": "^4.0.0",
         "nbtx": "^0.2.3",
         "node-fetch": "^3.3.1",
@@ -27112,9 +27112,9 @@
         "@jupyterlab/nbformat": "^3.5.2",
         "@lumino/coreutils": "^2.0.0",
         "mdast": "^3.0.0",
-        "myst-frontmatter": "^1.1.34",
+        "myst-frontmatter": "^1.1.35",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.1.34",
+        "myst-spec-ext": "^1.1.35",
         "nanoid": "^4.0.0",
         "unified": "^10.1.2",
         "unist-builder": "3.0.0",
@@ -27139,7 +27139,7 @@
       "version": "file:mystjs/packages/myst-config",
       "requires": {
         "moment": "^2.29.4",
-        "myst-frontmatter": "^1.1.34",
+        "myst-frontmatter": "^1.1.35",
         "simple-validators": "^1.0.4"
       }
     },
@@ -27148,8 +27148,8 @@
       "requires": {
         "classnames": "^2.3.2",
         "js-yaml": "^4.1.0",
-        "myst-common": "^1.1.34",
-        "myst-spec-ext": "^1.1.34",
+        "myst-common": "^1.1.35",
+        "myst-spec-ext": "^1.1.35",
         "nanoid": "^4.0.2",
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.7"
@@ -27267,12 +27267,12 @@
         "markdown-it-myst": "1.0.7",
         "markdown-it-myst-extras": "0.3.0",
         "markdown-it-task-lists": "^2.1.1",
-        "myst-common": "^1.1.34",
-        "myst-directives": "^1.2.2",
-        "myst-roles": "^1.2.2",
+        "myst-common": "^1.1.35",
+        "myst-directives": "^1.2.3",
+        "myst-roles": "^1.2.3",
         "myst-spec": "^0.0.5",
-        "myst-to-html": "^1.2.2",
-        "myst-transforms": "^1.3.3",
+        "myst-to-html": "^1.2.3",
+        "myst-transforms": "^1.3.4",
         "rehype-stringify": "^9.0.3",
         "unified": "^10.1.1",
         "unist-builder": "^3.0.0",
@@ -27297,8 +27297,8 @@
     "myst-roles": {
       "version": "file:mystjs/packages/myst-roles",
       "requires": {
-        "myst-common": "^1.1.34",
-        "myst-spec-ext": "^1.1.34"
+        "myst-common": "^1.1.35",
+        "myst-spec-ext": "^1.1.35"
       }
     },
     "myst-spec": {
@@ -27359,7 +27359,7 @@
         "mdast": "^3.0.0",
         "mdast-util-find-and-replace": "^2.1.0",
         "mdast-util-to-hast": "^12.3.0",
-        "myst-common": "^1.1.34",
+        "myst-common": "^1.1.35",
         "rehype-format": "^4.0.1",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
@@ -27504,11 +27504,11 @@
         "js-yaml": "^4.1.0",
         "katex": "^0.15.2",
         "mdast-util-find-and-replace": "^2.1.0",
-        "myst-common": "^1.1.34",
-        "myst-frontmatter": "^1.1.34",
+        "myst-common": "^1.1.35",
+        "myst-frontmatter": "^1.1.35",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.1.34",
-        "myst-to-html": "1.2.2",
+        "myst-spec-ext": "^1.1.35",
+        "myst-to-html": "1.2.3",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
         "unified": "^10.0.0",
@@ -27610,7 +27610,7 @@
         "commander": "^10.0.1",
         "core-js": "^3.31.1",
         "js-yaml": "^4.1.0",
-        "myst-cli": "^1.1.51"
+        "myst-cli": "^1.1.52"
       },
       "dependencies": {
         "chalk": {

--- a/packages/curvenote-cli/src/submissions/submit.ts
+++ b/packages/curvenote-cli/src/submissions/submit.ts
@@ -50,7 +50,7 @@ export async function submit(session: ISession, venue: string, opts?: SubmitOpts
   // TODO check the venue allows for submissions & updates to the submission
   // TODO check user has permission to submit /  update a submission
 
-  venue = await ensureVenue(session, venue);
+  venue = await ensureVenue(session, venue, opts);
   await checkVenueExists(session, venue);
   const collections = await checkVenueAccess(session, venue);
 


### PR DESCRIPTION
Even when providing CLI flag `-y`, user was still prompted for `venue`, `collection`, and `kind`.

Now, the CLI will hard fail if `-y` is used but the submission cannot be completed due to ambiguity of these fields.