### PR TITLE
🥇 Prioritize default collections on selection

### DIFF
--- a/.changeset/dirty-tables-share.md
+++ b/.changeset/dirty-tables-share.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Prioritize default collections on selection


### PR DESCRIPTION
This updates the collection selection CLI:

- if `--collection` is provided, no changes, only better error messaging
- if `-y` is provided:
  - Open default collection will be selected, even if there are are multiple open collections
  - Closed default collection will error (even if there are open collections)
- if `-y` is not provided:
  - Open default collections will be at the top of the selection list
  - User will be warned if default collection is closed.