### PR TITLE
🐛 Fix 'Bearer undefined' bug

### DIFF
--- a/.changeset/poor-keys-share.md
+++ b/.changeset/poor-keys-share.md
@@ -1,0 +1,6 @@
+---
+"@curvenote/cli": patch
+"curvenote": patch
+---
+
+Allow user to set curvenote to anonymous session

--- a/.changeset/unlucky-rockets-shop.md
+++ b/.changeset/unlucky-rockets-shop.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Fix 'Bearer undefined' bug

--- a/.changeset/wet-cooks-roll.md
+++ b/.changeset/wet-cooks-roll.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Select API urls based on resolved url

--- a/packages/curvenote-cli/src/session/config.ts
+++ b/packages/curvenote-cli/src/session/config.ts
@@ -83,7 +83,7 @@ export async function selectToken(log: Logger) {
   }
 
   const config = JSON.parse(fs.readFileSync(configPath).toString()) as TokenData;
-  if ((config.tokens && config.tokens.length === 0) || !config.token) {
+  if (config.tokens && config.tokens.length === 0) {
     log.error(`🫙 No tokens found. Try running ${chalk.bold('curvenote token set')} first.`);
     return;
   }
@@ -131,6 +131,35 @@ export async function selectToken(log: Logger) {
       `Token set for @${resp.selected.username} <${resp.selected.email}> at ${resp.selected.api}.`,
     ),
   );
+}
+
+export async function selectAnonymousToken(log: Logger) {
+  const configPath = getConfigPath();
+  if (!fs.existsSync(configPath)) {
+    log.error(`🫙 No saved tokens; your session will be anonymous.`);
+    return;
+  }
+
+  const config = JSON.parse(fs.readFileSync(configPath).toString()) as TokenData;
+  if ((config.tokens && config.tokens.length === 0) || !config.token) {
+    log.error(`🫙 No saved tokens; your session will be anonymous.`);
+    return;
+  }
+
+  if (config.token && !config.tokens) {
+    log.error(
+      `🛟 Session has an unsaved token. To run anonymously you must explicitly run ${chalk.bold('curvenote token delete')}.`,
+    );
+    return;
+  }
+
+  const updated = {
+    ...config,
+    token: undefined,
+  };
+
+  fs.writeFileSync(configPath, JSON.stringify(updated));
+  log.info(chalk.green(`Anonymous session selected.`));
 }
 
 export function deleteToken(logger: Logger = chalkLogger(LogLevel.info, process.cwd())) {

--- a/packages/curvenote-cli/src/session/session.ts
+++ b/packages/curvenote-cli/src/session/session.ts
@@ -87,12 +87,12 @@ export class Session implements ISession {
     this.PRIVATE_CDN = 'https://prv.curvenote.com';
     this.TEMP_CDN = 'https://tmp.curvenote.com';
     this.PUBLIC_CDN = 'https://cdn.curvenote.com';
-    if (url?.startsWith(STAGING_API_URL)) {
+    if (this.API_URL?.startsWith(STAGING_API_URL)) {
       this.JOURNALS_URL = STAGING_SITES_API_URL;
       this.PRIVATE_CDN = 'https://prv.curvenote.dev';
       this.TEMP_CDN = 'https://tmp.curvenote.dev';
       this.PUBLIC_CDN = 'https://cdn.curvenote.dev';
-    } else if (url?.startsWith(LOCAL_API_URL)) {
+    } else if (this.API_URL?.startsWith(LOCAL_API_URL)) {
       this.JOURNALS_URL = LOCAL_SITES_API_URL;
       this.PRIVATE_CDN = 'https://prv.curvenote.dev';
       this.TEMP_CDN = 'https://tmp.curvenote.dev';

--- a/packages/curvenote-cli/src/session/tokens.ts
+++ b/packages/curvenote-cli/src/session/tokens.ts
@@ -80,7 +80,7 @@ export async function getHeaders(
     'X-Client-Version': CLIENT_VERSION,
   };
   const sessionToken = await getSessionToken(session, tokens);
-  if (session) {
+  if (sessionToken) {
     tokens.session = sessionToken;
     headers.Authorization = `Bearer ${sessionToken}`;
   }

--- a/packages/curvenote/src/token.ts
+++ b/packages/curvenote/src/token.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { deleteToken, setToken, selectToken } from '@curvenote/cli';
+import { deleteToken, setToken, selectToken, selectAnonymousToken } from '@curvenote/cli';
 import { clirun } from './clirun.js';
 
 export function addTokenCLI(program: Command) {
@@ -21,6 +21,17 @@ export function addTokenCLI(program: Command) {
     .description('Set a token and save to a config directory')
     .action(
       clirun(async (session) => selectToken(session.log), {
+        program,
+        anonymous: true,
+        skipProjectLoading: true,
+      }),
+    );
+  command
+    .command('anonymous')
+    .alias('anon')
+    .description('Use an anonymous session, without deleting your saved tokens')
+    .action(
+      clirun((session) => selectAnonymousToken(session.log), {
         program,
         anonymous: true,
         skipProjectLoading: true,


### PR DESCRIPTION
Anonymous sessions should not have a `Bearer` token - we were accidentally setting `Bearer undefined` - just a simple bug.

I also added a command `curvenote token anon` so we can run curvenote unauthenticated without deleting the saved tokens.