### PR TITLE
✅ Allow collection/kind options on check

### DIFF
--- a/.changeset/tender-rules-hammer.md
+++ b/.changeset/tender-rules-hammer.md
@@ -1,0 +1,6 @@
+---
+"@curvenote/cli": patch
+"curvenote": patch
+---
+
+Allow collection/kind options on check

--- a/packages/curvenote/src/check.ts
+++ b/packages/curvenote/src/check.ts
@@ -1,13 +1,15 @@
 import { Command } from 'commander';
 import { clirun } from './clirun.js';
 import { submissions } from '@curvenote/cli';
-import { makeKindOption } from './options.js';
+import { makeCollectionOption, makeKindOption, makeYesOption } from './options.js';
 
 export function makeCheckCLI(program: Command) {
   const command = new Command('check')
     .description('Run checks from plugins or example checks on your MyST project')
     .argument('[venue]', 'Venue to check the submission against locally')
     .addOption(makeKindOption())
+    .addOption(makeCollectionOption())
+    .addOption(makeYesOption())
     .action(clirun(submissions.check, { program }));
   return command;
 }


### PR DESCRIPTION
This attempts to address https://github.com/curvenote/curvenote/issues/539

It reuses as much of the collection/kind selection logic from `submit` as possible. The biggest difference there is that it adds an option `allowClosedCollections` for the selection logic; for `submit` this is `false` (well, `undefined`) - keeping previous behaviour - but for `check`, it is `true`, allowing checks against closed collections. There's also some subtle change to language - a little more careful to not say "you are submitting to..." when just running checks.

By reusing the submit logic, it also means we (1) determine collection first then (2) determine kind; this differs slightly from the previous check behaviour (and the description in #539) where only `kind` is necessary. I think that's ok? Even if the `kind` is shared across collections, this is just an implementation detail. I think the user should always be thinking "I'm submitting to X collection's kind Y"