### PR TITLE
🛻 exporting function and adding well known part name

### DIFF
--- a/.changeset/afraid-balloons-brush.md
+++ b/.changeset/afraid-balloons-brush.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/blocks": patch
+---
+
+Expose `input2name` and add a default block part name

--- a/packages/blocks/src/blocks/types/misc.ts
+++ b/packages/blocks/src/blocks/types/misc.ts
@@ -31,6 +31,7 @@ export enum WellKnownBlockParts {
   discussion = 'discussion',
   introduction = 'introduction',
   availability = 'availability',
+  data_availability = 'data_availability',
   summary = 'summary',
 }
 

--- a/packages/blocks/src/utils/id.ts
+++ b/packages/blocks/src/utils/id.ts
@@ -95,7 +95,7 @@ export const convertToSrcId = (id: VersionId | DraftId | null): SrcId | null => 
   return null;
 };
 
-function input2name(input: string, allowed: RegExp, join: string) {
+export function input2name(input: string, allowed: RegExp, join: string) {
   let name = `¶${input}`
     .replace(/æ/g, 'ae')
     .replace(/œ/g, 'oe')


### PR DESCRIPTION
this is to allow reuse of `input2name` in platform and extending the enum of well known parts, although I am not clear on what consumes `WellKnownBlockParts` outside platform and whether it needs to be in blocks at all