### PR TITLE
🧵increase string length limit

### DIFF
--- a/.changeset/popular-starfishes-judge.md
+++ b/.changeset/popular-starfishes-judge.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Increased `work.key` upper limit

--- a/packages/curvenote-cli/src/submissions/utils.ts
+++ b/packages/curvenote-cli/src/submissions/utils.ts
@@ -301,10 +301,8 @@ export async function patchUpdateSubmissionStatus(
 
 export function exitOnInvalidKeyOption(session: ISession, key: string) {
   session.log.debug(`Checking for valid key option: ${key}`);
-  if (key.length < 8 || key.length > 50) {
-    session.log.error(
-      `⛔️ The key must be between 8 and 50 characters long, please specify a longer key.`,
-    );
+  if (key.length < 8 || key.length > 128) {
+    session.log.error(`⛔️ The key must be between 8 and 128 characters long.`);
     process.exit(1);
   }
 }


### PR DESCRIPTION
Aligning with api, max 128

Umm'd and arr'd on whether this should just reply on the API call failing on invalid keys but this is actually validating a user prompt input, so more appropriate to have locally.