### PR TITLE
🙋‍♂️ Just try to get venue collections for `check` without checking access

### DIFF
--- a/.changeset/bright-jobs-matter.md
+++ b/.changeset/bright-jobs-matter.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Just try to get venue collections without checking access

--- a/packages/curvenote-cli/src/submissions/check.ts
+++ b/packages/curvenote-cli/src/submissions/check.ts
@@ -5,7 +5,11 @@ import { writeJsonLogs } from '../utils/utils.js';
 import type { ISession } from '../session/types.js';
 import type { SubmissionKindDTO } from '@curvenote/common';
 import type { Check } from '@curvenote/check-definitions';
-import { checkVenueAccess, checkVenueExists, determineCollectionAndKind } from './submit.utils.js';
+import {
+  checkVenueExists,
+  determineCollectionAndKind,
+  getVenueCollections,
+} from './submit.utils.js';
 
 //
 // get checks
@@ -39,7 +43,7 @@ function getCheckImplementations(session: ISession) {
 async function getChecks(session: ISession, opts: CheckOpts): Promise<Check[]> {
   if (opts.venue) {
     await checkVenueExists(session, opts.venue);
-    const collections = await checkVenueAccess(session, opts.venue);
+    const collections = await getVenueCollections(session, opts.venue);
     const { kind } = await determineCollectionAndKind(session, opts.venue, collections, {
       ...opts,
       allowClosedCollection: true,

--- a/packages/curvenote-cli/src/submissions/submit.ts
+++ b/packages/curvenote-cli/src/submissions/submit.ts
@@ -6,7 +6,6 @@ import { postNewCliCheckJob, patchUpdateCliCheckJob, exitOnInvalidKeyOption } fr
 import {
   ensureVenue,
   checkVenueExists,
-  checkVenueAccess,
   performCleanRebuild,
   confirmUpdateToExistingSubmission,
   updateExistingSubmission,
@@ -17,6 +16,8 @@ import {
   promptForNewKey,
   getAllSubmissionsUsingKey,
   getSubmissionToUpdate,
+  checkVenueSubmitAccess,
+  getVenueCollections,
 } from './submit.utils.js';
 import { submissionRuleChecks } from '@curvenote/check-implementations';
 import type { CompiledCheckResults } from '../check/index.js';
@@ -52,7 +53,8 @@ export async function submit(session: ISession, venue: string, opts?: SubmitOpts
 
   venue = await ensureVenue(session, venue, opts);
   await checkVenueExists(session, venue);
-  const collections = await checkVenueAccess(session, venue);
+  await checkVenueSubmitAccess(session, venue);
+  const collections = await getVenueCollections(session, venue);
 
   let key = workKeyFromConfig(session);
   // Deprecation step to handle old transfer.yml files


### PR DESCRIPTION
Checks cannot be run against a journal if you are unauthenticated. For public journals, this does not need to be the case - even if you cannot `submit`, you should still be able to run the checks.

This PR separates `submit access check` from `getting the collections` - for `submit`, we still do both, but for `check` we only do the latter. For private sites, getting the collections should still fail, but for public sites, users can carry on with their checks.