### PR TITLE
📓 Update check command to only need kind, not collection

### DIFF
--- a/.changeset/lemon-suns-juggle.md
+++ b/.changeset/lemon-suns-juggle.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Update check command to only need kind, not collection

--- a/packages/curvenote-cli/src/submissions/check.ts
+++ b/packages/curvenote-cli/src/submissions/check.ts
@@ -12,7 +12,7 @@ import {
   getSubmissionKind,
   getVenueCollections,
 } from './submit.utils.js';
-import { determineKind } from './kind.utils.js';
+import { determineKindFromVenue } from './kind.utils.js';
 
 /**
  * Return list of checks from `kind` object and print log message
@@ -67,6 +67,7 @@ async function getChecks(session: ISession, opts: CheckOpts): Promise<Check[]> {
     await checkVenueExists(session, opts.venue);
     const collections = await getVenueCollections(session, opts.venue, false);
     let kind: SubmissionKindDTO;
+    let prompted = false;
     if (opts.kind) {
       try {
         kind = await getSubmissionKind(session, opts.venue, opts.kind);
@@ -99,12 +100,20 @@ async function getChecks(session: ISession, opts: CheckOpts): Promise<Check[]> {
         allowClosedCollection: true,
       });
       kind = result.kind;
+      prompted = result.prompted || prompted;
     } else {
-      kind = await determineKind(session, opts.venue, collections, opts);
+      const result = await determineKindFromVenue(session, opts.venue, collections, opts);
+      kind = result.kind;
+      prompted = result.prompted || prompted;
     }
     session.log.info(
-      `${chalk.green(`Running checks against kind "${kind.name}" from venue "${opts.venue}"`)}`,
+      `${chalk.green(`🏃‍♂️ Running checks against kind "${kind.name}" from venue "${opts.venue}"`)}`,
     );
+    if (prompted) {
+      session.log.info(
+        `${chalk.bold.green(`👉 You may rerun these same checks with: \`curvenote check ${opts.venue} --kind ${kind.name}\``)}`,
+      );
+    }
     return prepareChecksForSubmission(session, opts.venue, kind);
   }
   session.log.warn('No venue provided, running basic submission checks');

--- a/packages/curvenote-cli/src/submissions/check.ts
+++ b/packages/curvenote-cli/src/submissions/check.ts
@@ -111,7 +111,7 @@ async function getChecks(session: ISession, opts: CheckOpts): Promise<Check[]> {
     );
     if (prompted) {
       session.log.info(
-        `${chalk.bold.green(`👉 You may rerun these same checks with: \`curvenote check ${opts.venue} --kind ${kind.name}\``)}`,
+        `${chalk.bold.green(`👉 You may run these same checks again with: \`curvenote check ${opts.venue} --kind ${kind.name}\``)}`,
       );
     }
     return prepareChecksForSubmission(session, opts.venue, kind);

--- a/packages/curvenote-cli/src/submissions/kind.utils.ts
+++ b/packages/curvenote-cli/src/submissions/kind.utils.ts
@@ -46,12 +46,12 @@ function collectionsWithKind(kindId: string, collections: CollectionListingDTO) 
  * This function also takes `collections`. These have no effect on the `kind` determination,
  * but they can improve messaging during interactive selection.
  */
-export async function determineKind(
+export async function determineKindFromVenue(
   session: ISession,
   venue: string,
   collections?: CollectionListingDTO,
   opts?: { yes?: boolean },
-) {
+): Promise<{ kind: SubmissionKindDTO; prompted?: boolean }> {
   let kinds: SubmissionKindDTO[];
   try {
     const resp = await listSubmissionKinds(session, venue);
@@ -66,13 +66,13 @@ export async function determineKind(
   }
   if (kinds.length === 1) {
     session.log.debug(`using only available kind ${kinds[0].name}`);
-    return kinds[0];
+    return { kind: kinds[0] };
   }
   if (opts?.yes) {
-    const defaultKind = kinds.find((k) => k.default) ?? (kinds.length === 1 ? kinds[0] : undefined);
+    const defaultKind = kinds.find((k) => k.default);
     if (defaultKind) {
       session.log.debug(`using default kind ${defaultKind.name}`);
-      return defaultKind;
+      return { kind: defaultKind };
     }
     session.log.info(`${chalk.red(`⛔️ kind must be specified for venue "${venue}"`)}`);
     process.exit(1);
@@ -97,5 +97,5 @@ export async function determineKind(
       }),
     },
   ]);
-  return response.kind;
+  return { kind: response.kind, prompted: true };
 }

--- a/packages/curvenote-cli/src/submissions/kind.utils.ts
+++ b/packages/curvenote-cli/src/submissions/kind.utils.ts
@@ -1,0 +1,101 @@
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import { plural } from 'myst-common';
+import type {
+  CollectionListingDTO,
+  SubmissionKindDTO,
+  SubmissionKindListingDTO,
+} from '@curvenote/common';
+import type { ISession } from '../session/types.js';
+import { getFromJournals } from './utils.js';
+
+/**
+ * Fetch `venue` kinds from API
+ */
+export async function listSubmissionKinds(
+  session: ISession,
+  venue: string,
+): Promise<SubmissionKindListingDTO> {
+  return getFromJournals(session, `sites/${venue}/kinds`);
+}
+
+/**
+ * Get list of collection names for collections that include kind as id
+ */
+function collectionsWithKind(kindId: string, collections: CollectionListingDTO) {
+  return collections.items
+    .filter((c) => {
+      return c.kinds.map((k) => k.id).includes(kindId);
+    })
+    .map((c) => c.name);
+}
+
+/**
+ * Choose and return one kind based only on venue
+ *
+ * Successful cases include:
+ * - `venue` with a single `kind`, which is returned
+ * - `opts.yes` is `true` and the `venue` has a default `kind`, which is returned
+ * - user interactively selects one of the available `kinds` on the `venue`
+ *
+ * On failure, this function will `process.exit(1)`. Failure cases include:
+ * - Fetch for venue kinds fails (user is not authorized, venue does not exist, etc)
+ * - Venue has no kinds
+ * - `opts.yes` is `true` but there is no default `kind`
+ *
+ * This function also takes `collections`. These have no effect on the `kind` determination,
+ * but they can improve messaging during interactive selection.
+ */
+export async function determineKind(
+  session: ISession,
+  venue: string,
+  collections?: CollectionListingDTO,
+  opts?: { yes?: boolean },
+) {
+  let kinds: SubmissionKindDTO[];
+  try {
+    const resp = await listSubmissionKinds(session, venue);
+    kinds = [...resp.items.filter((k) => k.default), ...resp.items.filter((k) => !k.default)];
+  } catch {
+    session.log.info(`${chalk.red(`⛔️ unable to get available kinds from venue "${venue}"`)}`);
+    process.exit(1);
+  }
+  if (kinds.length === 0) {
+    session.log.info(`${chalk.red(`⛔️ venue "${venue}" has no kinds`)}`);
+    process.exit(1);
+  }
+  if (kinds.length === 1) {
+    session.log.debug(`using only available kind ${kinds[0].name}`);
+    return kinds[0];
+  }
+  if (opts?.yes) {
+    const defaultKind = kinds.find((k) => k.default) ?? (kinds.length === 1 ? kinds[0] : undefined);
+    if (defaultKind) {
+      session.log.debug(`using default kind ${defaultKind.name}`);
+      return defaultKind;
+    }
+    session.log.info(`${chalk.red(`⛔️ kind must be specified for venue "${venue}"`)}`);
+    process.exit(1);
+  }
+  const response = await inquirer.prompt([
+    {
+      name: 'kind',
+      type: 'list',
+      message: `Venue ${venue} has multiple kinds. Which do you want to select?`,
+      choices: kinds.map((k) => {
+        let suffix = '';
+        if (collections) {
+          const suffixCollections = collectionsWithKind(k.id, collections);
+          if (suffixCollections) {
+            suffix = ` (${plural('collection(s)', suffixCollections)}: ${suffixCollections.join(', ')})`;
+          }
+        }
+        return {
+          name: `${k.name}${suffix}`,
+          value: k,
+        };
+      }),
+    },
+  ]);
+  return response.kind;
+}

--- a/packages/curvenote-cli/src/submissions/submit.utils.ts
+++ b/packages/curvenote-cli/src/submissions/submit.utils.ts
@@ -349,6 +349,11 @@ export async function promptForNewKey(
   return customKey;
 }
 
+/**
+ * Ensure that a `venue` exists by performing a basic request to the venue
+ *
+ * If venue does not exist, fails with `process.exit(1)`.
+ */
 export async function checkVenueExists(session: ISession, venue: string) {
   try {
     session.log.debug(`GET from journals API sites/${venue}`);

--- a/packages/curvenote-cli/src/submissions/submit.utils.ts
+++ b/packages/curvenote-cli/src/submissions/submit.utils.ts
@@ -191,13 +191,6 @@ export async function getSubmissionKind(
   return kind;
 }
 
-export async function listSubmissionKinds(
-  session: ISession,
-  venue: string,
-): Promise<SubmissionKindListingDTO> {
-  return getFromJournals(session, `sites/${venue}/kinds`);
-}
-
 export async function determineSubmissionKindFromCollection(
   session: ISession,
   venue: string,

--- a/packages/curvenote-cli/src/submissions/submit.utils.ts
+++ b/packages/curvenote-cli/src/submissions/submit.utils.ts
@@ -57,7 +57,7 @@ export function collectionQuestions(
   return {
     name: 'collections',
     type: 'list',
-    message: `Venue ${venue} has multiple collections${opts?.allowClosedCollection ? '' : 'open for submission'}. Which do you want to select?`,
+    message: `Venue ${venue} has multiple collections${opts?.allowClosedCollection ? '' : ' open for submission'}. Which do you want to select?`,
     choices: collections.map((item) => ({
       name: collectionMoniker(item),
       value: item,
@@ -180,14 +180,15 @@ export async function determineCollectionAndKind(
   return { collection: selectedCollection, kind };
 }
 
+/**
+ * Fetch a single `venue` kind from API
+ */
 export async function getSubmissionKind(
   session: ISession,
   venue: string,
   kindIdOrName: string,
 ): Promise<SubmissionKindDTO> {
-  const kind = await getFromJournals(session, `sites/${venue}/kinds/${kindIdOrName}`);
-  if (!kind) throw new Error('kind not found');
-  return kind;
+  return getFromJournals(session, `sites/${venue}/kinds/${kindIdOrName}`);
 }
 
 export async function determineSubmissionKindFromCollection(
@@ -409,21 +410,21 @@ export async function getVenueCollections(
     process.exit(1);
   }
 
-    const openCollections = collections.items.filter((c) => c.open);
+  const openCollections = collections.items.filter((c) => c.open);
 
-    if (openCollections.length === 0) {
-      session.log.info(`${chalk.red(`🚦 venue "${venue}" is not accepting submissions.`)}`);
+  if (openCollections.length === 0) {
+    session.log.info(`${chalk.red(`🚦 venue "${venue}" is not accepting submissions.`)}`);
     if (requireOpenCollections) process.exit(1);
   } else if (openCollections.length > 1) {
-      session.log.info(
-        `${chalk.green(`💚 venue "${venue}" is accepting submissions in the following collections: ${openCollections.map((c) => collectionMoniker(c)).join(', ')}`)}`,
-      );
-    } else {
-      session.log.info(
-        `${chalk.green(`💚 venue "${venue}" is accepting submissions (${collectionMoniker(openCollections[0])}).`)}`,
-      );
-    }
-    return collections;
+    session.log.info(
+      `${chalk.green(`💚 venue "${venue}" is accepting submissions in the following collections: ${openCollections.map((c) => collectionMoniker(c)).join(', ')}`)}`,
+    );
+  } else {
+    session.log.info(
+      `${chalk.green(`💚 venue "${venue}" is accepting submissions (${collectionMoniker(openCollections[0])}).`)}`,
+    );
+  }
+  return collections;
 }
 
 export async function checkForSubmissionKeyInUse(session: ISession, venue: string, key: string) {

--- a/packages/curvenote-cli/src/submissions/utils.ts
+++ b/packages/curvenote-cli/src/submissions/utils.ts
@@ -19,6 +19,12 @@ export function formatDate(date: string) {
   return format(new Date(date), 'dd MMM, yyyy HH:mm:ss');
 }
 
+/**
+ * Perform json GET request to `url`
+ *
+ * If request is successful, return the response json.
+ * If request fails, throw an error.
+ */
 export async function getFromUrl(session: ISession, url: string) {
   session.log.debug('Getting from', url);
   const headers = await getHeaders(session, (session as any).$tokens);
@@ -41,10 +47,15 @@ export async function getFromUrl(session: ISession, url: string) {
   }
 }
 
+/**
+ * Perform json GET request to `pathname` on the journals API
+ *
+ * If request is successful, return the response json.
+ * If request fails, throw an error.
+ */
 export async function getFromJournals(session: ISession, pathname: string) {
   const url = `${session.JOURNALS_URL}${pathname}`;
-  const resp = await getFromUrl(session, url);
-  return resp;
+  return getFromUrl(session, url);
 }
 
 export async function postToUrl(


### PR DESCRIPTION
`curvenote check` will now run if only `--kind` is provided, or, if nothing is provided, it will only prompt for `kind`.

You may still specify `--collection`: If `collection` is specified and not `kind`, it will only prompt for kinds in the collection (this case is the previous behaviour, which used to require collection and kind). If both `collection` and `kind` are specified, only `kind` will be used for the checks, but there may be some additional error logging if collection and kind are incompatible.