### PR TITLE
🔧 Update checks for gentler doi.org failures

### DIFF
--- a/.changeset/pretty-cows-fail.md
+++ b/.changeset/pretty-cows-fail.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Update checks for gentler doi failures

--- a/package-lock.json
+++ b/package-lock.json
@@ -1844,20 +1844,20 @@
       "link": true
     },
     "node_modules/@curvenote/check-definitions": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@curvenote/check-definitions/-/check-definitions-0.0.19.tgz",
-      "integrity": "sha512-BU3ayM7kfS+Cx51qV/P8fZ/TOJa6d79JEWxVj4gV8MUnGz2MTREmIek85ZSm+Gwgt2vx4WuS51QpEN8vxNWG/Q==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@curvenote/check-definitions/-/check-definitions-0.0.20.tgz",
+      "integrity": "sha512-XKpragBGj9/EEFSw9YTPGhsj3S6A4Kpe71V/ISVBH6GhmOMWzo7wkv2EiQ1EDDr1pVEjq1uT1KU+6uxPp/WQDA==",
       "dependencies": {
         "myst-common": "^1.2.0",
         "myst-templates": "^1.0.17"
       }
     },
     "node_modules/@curvenote/check-implementations": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@curvenote/check-implementations/-/check-implementations-0.0.19.tgz",
-      "integrity": "sha512-oHtMQB7Tzt+xiXfnPImeIkp+k+LEOLAnOa60F3SQWYvmI90PzjThVKkHHPL4a4XnJC52vwxR01acWnuVLNMkpw==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@curvenote/check-implementations/-/check-implementations-0.0.20.tgz",
+      "integrity": "sha512-6kdzsmdOP4dTa+AqXxXXE4OiVg82qbUFy1ef10q1JRr6LUGoDzVhyQm1DBu5XGQJhO2Ijja+gATzC0CYXfMAxQ==",
       "dependencies": {
-        "@curvenote/check-definitions": "^0.0.19",
+        "@curvenote/check-definitions": "^0.0.20",
         "@wordpress/wordcount": "^3.50.0",
         "lodash.isequal": "^4.5.0",
         "myst-cli": "^1.1.54",
@@ -17305,8 +17305,8 @@
       "license": "MIT",
       "dependencies": {
         "@curvenote/blocks": "^1.5.26",
-        "@curvenote/check-definitions": "^0.0.19",
-        "@curvenote/check-implementations": "^0.0.19",
+        "@curvenote/check-definitions": "^0.0.20",
+        "@curvenote/check-implementations": "^0.0.20",
         "@curvenote/cli-plugin": "^0.9.6",
         "@curvenote/common": "^0.1.30",
         "@curvenote/schema": "0.12.18",

--- a/packages/curvenote-cli/package.json
+++ b/packages/curvenote-cli/package.json
@@ -39,8 +39,8 @@
   },
   "dependencies": {
     "@curvenote/blocks": "^1.5.26",
-    "@curvenote/check-definitions": "^0.0.19",
-    "@curvenote/check-implementations": "^0.0.19",
+    "@curvenote/check-definitions": "^0.0.20",
+    "@curvenote/check-implementations": "^0.0.20",
     "@curvenote/cli-plugin": "^0.9.6",
     "@curvenote/common": "^0.1.30",
     "@curvenote/schema": "0.12.18",


### PR DESCRIPTION
DOI checks are failing on CI because doi.org is responding with 403s. This PR consumes a release of `check-implementations` that returns an "optional" (i.e. non-critical) failure for valid DOIs (checked against other services) that gave a 403 from doi.org.

This does not address the underlying issue where the _build_ may have issues from these 403s - a workaround for that must come in to myst.