### PR TITLE
📝 Allow drafts to use works without key

### DIFF
--- a/.changeset/moody-dogs-clean.md
+++ b/.changeset/moody-dogs-clean.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Allow drafts to use works without key

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       }
     },
     "mystjs/packages/citation-js-utils": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@citation-js/core": "^0.7.14",
@@ -43,17 +43,17 @@
       }
     },
     "mystjs/packages/jats-to-myst": {
-      "version": "1.0.26",
+      "version": "1.0.27",
       "license": "MIT",
       "dependencies": {
         "doi-utils": "^2.0.0",
         "jats-tags": "^1.0.8",
         "jats-xml": "^1.0.8",
-        "myst-common": "^1.3.0",
-        "myst-frontmatter": "^1.3.0",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.3.0",
-        "myst-transforms": "^1.3.7",
+        "myst-spec-ext": "^1.5.1",
+        "myst-transforms": "^1.3.20",
         "unified": "^10.0.0",
         "unist-builder": "^3.0.0",
         "unist-util-remove": "^3.1.0",
@@ -62,7 +62,7 @@
         "vfile-reporter": "^7.0.4"
       },
       "devDependencies": {
-        "myst-to-tex": "^1.0.27"
+        "myst-to-tex": "^1.0.31"
       }
     },
     "mystjs/packages/jats-to-myst/node_modules/chalk": {
@@ -103,21 +103,21 @@
       }
     },
     "mystjs/packages/jtex": {
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
         "chalk": "^5.2.0",
         "commander": "^10.0.1",
         "js-yaml": "^4.1.0",
-        "myst-cli-utils": "^2.0.9",
-        "myst-common": "^1.3.0",
-        "myst-frontmatter": "^1.3.0",
-        "myst-templates": "^1.0.18",
+        "myst-cli-utils": "^2.0.10",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
+        "myst-templates": "^1.0.20",
         "node-fetch": "^3.3.1",
         "nunjucks": "^3.2.4",
         "pretty-hrtime": "^1.0.3",
-        "simple-validators": "^1.0.4"
+        "simple-validators": "^1.0.6"
       },
       "bin": {
         "jtex": "dist/jtex.cjs"
@@ -143,7 +143,7 @@
       }
     },
     "mystjs/packages/markdown-it-myst": {
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",
@@ -166,7 +166,7 @@
       }
     },
     "mystjs/packages/myst-cli": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@jupyterlab/services": "^7.0.0",
@@ -176,7 +176,7 @@
         "chalk": "^5.2.0",
         "check-node-version": "^4.2.1",
         "chokidar": "^3.5.3",
-        "citation-js-utils": "^1.2.2",
+        "citation-js-utils": "^1.2.3",
         "commander": "^10.0.1",
         "cors": "^2.8.5",
         "docx": "^7.5.0",
@@ -189,41 +189,41 @@
         "inquirer": "^9.2.17",
         "intersphinx": "^1.0.2",
         "js-yaml": "^4.1.0",
-        "jtex": "^1.0.17",
+        "jtex": "^1.0.18",
         "latest-version": "^7.0.0",
         "mdast": "^3.0.0",
         "meca": "^1.0.8",
         "mime-types": "^2.1.35",
-        "myst-cli-utils": "^2.0.9",
-        "myst-common": "^1.5.0",
-        "myst-config": "^1.5.0",
-        "myst-execute": "^0.0.7",
-        "myst-ext-card": "^1.0.6",
-        "myst-ext-exercise": "^1.0.6",
-        "myst-ext-grid": "^1.0.6",
-        "myst-ext-proof": "^1.0.9",
-        "myst-ext-reactive": "^1.0.6",
-        "myst-ext-tabs": "^1.0.6",
-        "myst-frontmatter": "^1.5.0",
-        "myst-parser": "^1.5.0",
+        "myst-cli-utils": "^2.0.10",
+        "myst-common": "^1.5.1",
+        "myst-config": "^1.5.1",
+        "myst-execute": "^0.0.8",
+        "myst-ext-card": "^1.0.7",
+        "myst-ext-exercise": "^1.0.7",
+        "myst-ext-grid": "^1.0.7",
+        "myst-ext-proof": "^1.0.10",
+        "myst-ext-reactive": "^1.0.7",
+        "myst-ext-tabs": "^1.0.7",
+        "myst-frontmatter": "^1.5.1",
+        "myst-parser": "^1.5.1",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.5.0",
-        "myst-templates": "^1.0.19",
-        "myst-to-docx": "^1.0.10",
-        "myst-to-jats": "^1.0.26",
-        "myst-to-md": "^1.0.11",
-        "myst-to-tex": "^1.0.30",
-        "myst-to-typst": "^0.0.17",
-        "myst-toc": "^0.1.1",
-        "myst-transforms": "^1.3.19",
+        "myst-spec-ext": "^1.5.1",
+        "myst-templates": "^1.0.20",
+        "myst-to-docx": "^1.0.11",
+        "myst-to-jats": "^1.0.27",
+        "myst-to-md": "^1.0.12",
+        "myst-to-tex": "^1.0.31",
+        "myst-to-typst": "^0.0.18",
+        "myst-toc": "^0.1.2",
+        "myst-transforms": "^1.3.20",
         "nanoid": "^4.0.0",
         "nbtx": "^0.2.3",
         "node-fetch": "^3.3.1",
         "p-limit": "^3.1.0",
         "redux": "^5.0.1",
-        "simple-validators": "^1.0.5",
+        "simple-validators": "^1.0.6",
         "strip-ansi": "^7.0.1",
-        "tex-to-myst": "^1.0.30",
+        "tex-to-myst": "^1.0.31",
         "unified": "^10.1.2",
         "unist-util-filter": "^4.0.0",
         "unist-util-remove": "^3.1.0",
@@ -255,7 +255,7 @@
       }
     },
     "mystjs/packages/myst-cli-utils": {
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.2.0",
@@ -560,11 +560,11 @@
       }
     },
     "mystjs/packages/myst-common": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "mdast": "^3.0.0",
-        "myst-frontmatter": "^1.5.0",
+        "myst-frontmatter": "^1.5.1",
         "myst-spec": "^0.0.5",
         "nanoid": "^4.0.0",
         "unified": "^10.1.2",
@@ -577,7 +577,7 @@
       "devDependencies": {
         "@jupyterlab/nbformat": "^3.5.2",
         "@lumino/coreutils": "^2.0.0",
-        "myst-spec-ext": "^1.5.0",
+        "myst-spec-ext": "^1.5.1",
         "unist-builder": "3.0.0"
       }
     },
@@ -608,25 +608,25 @@
       }
     },
     "mystjs/packages/myst-config": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
-        "myst-frontmatter": "^1.5.0",
-        "simple-validators": "^1.0.5"
+        "myst-frontmatter": "^1.5.1",
+        "simple-validators": "^1.0.6"
       },
       "devDependencies": {
         "moment": "^2.29.4"
       }
     },
     "mystjs/packages/myst-directives": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2",
         "csv-parse": "^5.5.5",
         "js-yaml": "^4.1.0",
-        "myst-common": "^1.5.0",
-        "myst-spec-ext": "^1.5.0",
+        "myst-common": "^1.5.1",
+        "myst-spec-ext": "^1.5.1",
         "nanoid": "^4.0.2",
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.7"
@@ -637,13 +637,13 @@
       "license": "MIT"
     },
     "mystjs/packages/myst-execute": {
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "@jupyterlab/services": "^7.0.0",
         "chalk": "^5.2.0",
-        "myst-cli-utils": "^2.0.9",
-        "myst-common": "^1.5.0",
+        "myst-cli-utils": "^2.0.10",
+        "myst-common": "^1.5.1",
         "node-fetch": "^3.3.0",
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.7",
@@ -685,75 +685,75 @@
       }
     },
     "mystjs/packages/myst-ext-card": {
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.3.0"
+        "myst-common": "^1.5.1"
       },
       "devDependencies": {
-        "myst-parser": "^1.4.0"
+        "myst-parser": "^1.5.1"
       }
     },
     "mystjs/packages/myst-ext-exercise": {
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.3.0"
+        "myst-common": "^1.5.1"
       },
       "devDependencies": {
-        "myst-parser": "^1.4.0"
+        "myst-parser": "^1.5.1"
       }
     },
     "mystjs/packages/myst-ext-grid": {
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.3.0"
+        "myst-common": "^1.5.1"
       },
       "devDependencies": {
-        "myst-parser": "^1.4.0"
+        "myst-parser": "^1.5.1"
       }
     },
     "mystjs/packages/myst-ext-proof": {
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.3.0",
+        "myst-common": "^1.5.1",
         "myst-spec": "^0.0.5"
       },
       "devDependencies": {
-        "myst-parser": "^1.4.0"
+        "myst-parser": "^1.5.1"
       }
     },
     "mystjs/packages/myst-ext-reactive": {
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.3.0"
+        "myst-common": "^1.5.1"
       },
       "devDependencies": {
-        "myst-parser": "^1.4.0"
+        "myst-parser": "^1.5.1"
       }
     },
     "mystjs/packages/myst-ext-tabs": {
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.3.0"
+        "myst-common": "^1.5.1"
       },
       "devDependencies": {
-        "myst-parser": "^1.4.0"
+        "myst-parser": "^1.5.1"
       }
     },
     "mystjs/packages/myst-frontmatter": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "credit-roles": "^2.1.0",
         "doi-utils": "^2.0.0",
-        "myst-toc": "^0.1.1",
+        "myst-toc": "^0.1.2",
         "orcid": "^1.0.0",
-        "simple-validators": "^1.0.5",
+        "simple-validators": "^1.0.6",
         "spdx-correct": "^3.2.0"
       },
       "devDependencies": {
@@ -764,7 +764,7 @@
       }
     },
     "mystjs/packages/myst-parser": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "he": "^1.2.0",
@@ -774,12 +774,12 @@
         "markdown-it-dollarmath": "^0.5.0",
         "markdown-it-footnote": "^3.0.3",
         "markdown-it-front-matter": "^0.2.3",
-        "markdown-it-myst": "1.0.7",
+        "markdown-it-myst": "1.0.8",
         "markdown-it-myst-extras": "0.3.0",
         "markdown-it-task-lists": "^2.1.1",
-        "myst-common": "^1.5.0",
-        "myst-directives": "^1.5.0",
-        "myst-roles": "^1.5.0",
+        "myst-common": "^1.5.1",
+        "myst-directives": "^1.5.1",
+        "myst-roles": "^1.5.1",
         "myst-spec": "^0.0.5",
         "unified": "^10.1.1",
         "unist-builder": "^3.0.0",
@@ -796,8 +796,8 @@
         "@types/markdown-it": "^12.2.3",
         "@types/mdast": "^3.0.10",
         "js-yaml": "^4.1.0",
-        "myst-to-html": "^1.5.0",
-        "myst-transforms": "^1.3.19",
+        "myst-to-html": "^1.5.1",
+        "myst-transforms": "^1.3.20",
         "rehype-stringify": "^9.0.3"
       }
     },
@@ -815,22 +815,22 @@
       }
     },
     "mystjs/packages/myst-roles": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.5.0",
-        "myst-spec-ext": "^1.5.0"
+        "myst-common": "^1.5.1",
+        "myst-spec-ext": "^1.5.1"
       }
     },
     "mystjs/packages/myst-spec-ext": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "myst-spec": "^0.0.5"
       }
     },
     "mystjs/packages/myst-templates": {
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -838,12 +838,12 @@
         "commander": "^10.0.1",
         "glob": "^10.3.1",
         "js-yaml": "^4.1.0",
-        "myst-cli-utils": "^2.0.9",
-        "myst-common": "^1.4.6",
-        "myst-frontmatter": "^1.4.6",
+        "myst-cli-utils": "^2.0.10",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
         "node-fetch": "^3.3.1",
         "pretty-hrtime": "^1.0.3",
-        "simple-validators": "^1.0.4"
+        "simple-validators": "^1.0.6"
       },
       "devDependencies": {
         "@types/nunjucks": "^3.2.2",
@@ -861,20 +861,20 @@
       }
     },
     "mystjs/packages/myst-to-docx": {
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
         "buffer-image-size": "^0.6.4",
         "docx": "^7.3.0",
-        "myst-common": "^1.3.0",
-        "myst-frontmatter": "^1.3.0",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.3.0",
+        "myst-spec-ext": "^1.5.1",
         "unist-util-select": "^4.0.3"
       }
     },
     "mystjs/packages/myst-to-html": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2",
@@ -884,7 +884,7 @@
         "mdast": "^3.0.0",
         "mdast-util-find-and-replace": "^2.1.0",
         "mdast-util-to-hast": "^12.3.0",
-        "myst-common": "^1.5.0",
+        "myst-common": "^1.5.1",
         "rehype-format": "^4.0.1",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
@@ -925,20 +925,20 @@
       }
     },
     "mystjs/packages/myst-to-jats": {
-      "version": "1.0.26",
+      "version": "1.0.27",
       "license": "MIT",
       "dependencies": {
-        "citation-js-utils": "^1.2.0",
+        "citation-js-utils": "^1.2.3",
         "credit-roles": "^2.1.0",
         "doi-utils": "^2.0.1",
         "jats-tags": "^1.0.8",
         "jats-utils": "^1.0.8",
         "katex": "^0.15.2",
-        "myst-common": "^1.3.0",
-        "myst-frontmatter": "^1.3.0",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.3.0",
-        "myst-transforms": "^1.3.7",
+        "myst-spec-ext": "^1.5.1",
+        "myst-transforms": "^1.3.20",
         "nbtx": "^0.2.3",
         "unified": "^10.1.2",
         "unist-util-remove": "^3.1.0",
@@ -953,7 +953,7 @@
         "@types/mdast": "^3.0.10",
         "jats-xml": "^1.0.7",
         "js-yaml": "^4.1.0",
-        "myst-cli-utils": "^2.0.9"
+        "myst-cli-utils": "^2.0.10"
       }
     },
     "mystjs/packages/myst-to-jats/node_modules/chalk": {
@@ -996,57 +996,57 @@
       }
     },
     "mystjs/packages/myst-to-md": {
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "mdast-util-gfm-footnote": "^1.0.2",
         "mdast-util-gfm-table": "^1.0.7",
         "mdast-util-to-markdown": "^1.5.0",
-        "myst-common": "^1.3.0",
-        "myst-frontmatter": "^1.3.0",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.7",
         "vfile-reporter": "^7.0.4"
       }
     },
     "mystjs/packages/myst-to-tex": {
-      "version": "1.0.30",
+      "version": "1.0.31",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.4.7",
-        "myst-ext-proof": "^1.0.9",
-        "myst-frontmatter": "^1.4.7",
-        "myst-spec-ext": "^1.4.7",
+        "myst-common": "^1.5.1",
+        "myst-ext-proof": "^1.0.10",
+        "myst-frontmatter": "^1.5.1",
+        "myst-spec-ext": "^1.5.1",
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.3",
         "vfile-reporter": "^7.0.4"
       },
       "devDependencies": {
-        "myst-parser": "^1.4.0"
+        "myst-parser": "^1.5.1"
       }
     },
     "mystjs/packages/myst-to-typst": {
-      "version": "0.0.17",
+      "version": "0.0.18",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.4.4",
-        "myst-frontmatter": "^1.4.4",
-        "myst-spec-ext": "^1.4.4",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
+        "myst-spec-ext": "^1.5.1",
         "tex-to-typst": "^0.0.5",
         "unist-util-select": "^4.0.3",
         "vfile-reporter": "^7.0.4"
       }
     },
     "mystjs/packages/myst-toc": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "simple-validators": "^1.0.4"
+        "simple-validators": "^1.0.6"
       }
     },
     "mystjs/packages/myst-transforms": {
-      "version": "1.3.19",
+      "version": "1.3.20",
       "license": "MIT",
       "dependencies": {
         "doi-utils": "^2.0.0",
@@ -1056,11 +1056,11 @@
         "js-yaml": "^4.1.0",
         "katex": "^0.15.2",
         "mdast-util-find-and-replace": "^2.1.0",
-        "myst-common": "^1.5.0",
-        "myst-frontmatter": "^1.5.0",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.5.0",
-        "myst-to-html": "1.5.0",
+        "myst-spec-ext": "^1.5.1",
+        "myst-to-html": "1.5.1",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
         "unified": "^10.0.0",
@@ -1092,7 +1092,7 @@
       }
     },
     "mystjs/packages/mystmd": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "bin": {
         "myst": "dist/myst.cjs"
@@ -1102,7 +1102,7 @@
         "commander": "^10.0.1",
         "core-js": "^3.31.1",
         "js-yaml": "^4.1.0",
-        "myst-cli": "^1.3.0"
+        "myst-cli": "^1.3.1"
       }
     },
     "mystjs/packages/mystmd/node_modules/chalk": {
@@ -1117,20 +1117,20 @@
       }
     },
     "mystjs/packages/simple-validators": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "devDependencies": {
         "moment": "^2.29.4"
       }
     },
     "mystjs/packages/tex-to-myst": {
-      "version": "1.0.30",
+      "version": "1.0.31",
       "license": "MIT",
       "dependencies": {
         "@unified-latex/unified-latex": "^1.2.2",
-        "myst-common": "^1.4.7",
-        "myst-frontmatter": "^1.4.7",
-        "myst-spec-ext": "^1.4.7",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
+        "myst-spec-ext": "^1.5.1",
         "unist-builder": "^3.0.0",
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.3",

--- a/packages/curvenote-cli/src/submissions/submit.utils.ts
+++ b/packages/curvenote-cli/src/submissions/submit.utils.ts
@@ -647,7 +647,18 @@ export async function createNewSubmission(
     session.log.debug(`new work posted with version id ${work.version_id}`);
   } else {
     session.log.debug(`posting new work...`);
-    work = await postNewWork(session, cdnKey, cdn, key);
+    try {
+      work = await postNewWork(session, cdnKey, cdn, key);
+    } catch (err) {
+      if (opts?.draft) {
+        session.log.debug(
+          `unable to create a work with key ${key} - attempting to create un-keyed work for draft submission`,
+        );
+        work = await postNewWork(session, cdnKey, cdn);
+      } else {
+        throw err;
+      }
+    }
     session.log.debug(`new work posted with id ${work.id}`);
   }
   if (!work.version_id) {

--- a/packages/curvenote-cli/src/submissions/utils.ts
+++ b/packages/curvenote-cli/src/submissions/utils.ts
@@ -92,12 +92,12 @@ export async function postNewWork(
   session: ISession,
   cdnKey: string,
   cdn: string,
-  key: string,
+  key?: string,
 ): Promise<WorkDTO> {
   const toc = tic();
 
   session.log.debug(
-    `POST to ${session.JOURNALS_URL}works with cdnKey: ${cdnKey}, cdn: ${cdn}, key: ${key}...`,
+    `POST to ${session.JOURNALS_URL}works with cdnKey: ${cdnKey}, cdn: ${cdn}${key ? `, key: ${key}` : ''}...`,
   );
   const resp = await postToJournals(session, 'works', { cdn_key: cdnKey, cdn, key });
   session.log.debug(`${resp.status} ${resp.statusText}`);
@@ -110,7 +110,8 @@ export async function postNewWork(
     session.log.debug(`Work Version Id: ${version_id}`);
     return json;
   } else {
-    throw new Error('Posting new work failed');
+    const message = ((await resp.json()) as { message?: string })?.message;
+    throw new Error(`Posting new work failed${message ? `: ${message}` : ''}`);
   }
 }
 


### PR DESCRIPTION
This PR enables creating new, un-keyed `works` when making a `draft` submission.

A bit of context...

- Currently `works` have a single owner, whereas `submissions` can be owned by a team.
- The `submission` team is granted access to create new work versions (on a work which they do not own) via an existing `submission` (the existing submission must have been originally created by the `work` owner).
- `drafts`, however, are standalone submissions - this means there is no submission-based team access. The owner of the `work` _must_ create the `draft`.
- In general, this isn't a problem - anyone who wants to create a `draft` can just create their own `work` at the same time.
- However, `works` have globally unique `keys`. This means in, say, a shared github repo which already has a `key` hard-coded, two people will have issues trying to create two separate works from the same content. Due to the duplicate `key`, the second just gets an error `"Posting new work failed"`

Now there's a few cases:
- For drafts, we can just use works without a key. This PR adds that step: if posting a new work failed due to duplicate keys, a new work is created with no key.
- After this, for the non-draft submissions, there are two cases. (1) The two users are on the same team - then, team permissions kick in on the submission and sharing a `key` is fine. (2) The users don't realize the implications of sharing a key - this PR improves error messaging so the `"Posting new work failed"` message also explains `"key is unavailable"` and hopefully the second user can just choose a different key.

I deserve a pat on the back for such a concise, easy-to-follow explanation. 😅