### PR TITLE
🐌 just `cn`

### DIFF
--- a/.changeset/violet-avocados-kiss.md
+++ b/.changeset/violet-avocados-kiss.md
@@ -1,0 +1,5 @@
+---
+"curvenote": minor
+---
+
+Add `cn` as an additional cli entrypoint

--- a/package-lock.json
+++ b/package-lock.json
@@ -18831,6 +18831,7 @@
         "jsdom": "^19.0.0"
       },
       "bin": {
+        "cn": "dist/curvenote.cjs",
         "curvenote": "dist/curvenote.cjs"
       },
       "devDependencies": {

--- a/packages/curvenote/package.json
+++ b/packages/curvenote/package.json
@@ -17,7 +17,10 @@
   "files": [
     "dist"
   ],
-  "bin": "./dist/curvenote.cjs",
+  "bin": {
+    "curvenote": "./dist/curvenote.cjs",
+    "cn": "./dist/curvenote.cjs"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/curvenote/curvenote.git"


### PR DESCRIPTION
```
Usage: cn [options] [command]

Options:
  -v, --version                      Print the current version of curvenote
  -d, --debug                        Log out any errors to the console.
  -h, --help                         display help for command

Commands:
  init [options]                     Initialize a Curvenote project
  clone [options] [remote] [folder]  Clone a Curvenote project
  pull [options] [path]              Pull all remote information for a Curvenote project
  build [options] [files...]         Build PDF, LaTeX, Word and website exports from MyST files
  start [options]                    Start the current project as a website
  deploy [options]                   Deploy content to https://*.curve.space or your own domain
  clean [options] [files...]         Remove exports, temp files and installed templates
  token|auth                         Set or delete a token to access the Curvenote API
  check [options] [venue]            Run checks from plugins or example checks on your MyST project
  works                              Create and manage your Works
  submit [options] [venue]           Submit your work to a Venue
  submission|sub                     Manage your submission(s)
  help [command]                     display help for command
```