### PR TITLE
🗂 Support nested index pages in cdn loader

### DIFF
--- a/.changeset/forty-maps-brake.md
+++ b/.changeset/forty-maps-brake.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cdn": patch
+---
+
+Support nested index pages in cdn loader

--- a/packages/cdn/src/loaders.ts
+++ b/packages/cdn/src/loaders.ts
@@ -334,7 +334,7 @@ export async function getPage(
     },
   );
   if (!loader) throw responseNoArticle();
-  const footer = getFooterLinks(config, project.slug, slug);
+  const footer = getFooterLinks(config, project.slug, loader.slug);
   return { ...loader, footer, domain: opts?.domain as string, project: project.slug as string };
 }
 

--- a/packages/cdn/src/loaders.ts
+++ b/packages/cdn/src/loaders.ts
@@ -320,11 +320,15 @@ export async function getPage(
   if (!config) throw responseNoSite();
   const project = getProject(config, projectName);
   if (!project) throw responseNoArticle();
-  const slug = opts?.loadIndexPage || opts?.slug == null ? project.index : opts.slug;
+  let slug = opts?.loadIndexPage || opts?.slug == null ? project.index : opts.slug;
   const loader = await getData(baseUrl, config, project.slug, slug, location.query, opts).catch(
-    (e) => {
-      console.error(e);
-      return null;
+    async (e) => {
+      slug = `${slug}.index`;
+      return getData(baseUrl, config, project.slug, slug, location.query, opts).catch(() => {
+        // log error from original slug if both error
+        console.error(e);
+        return null;
+      });
     },
   );
   if (!loader) throw responseNoArticle();

--- a/packages/cdn/src/loaders.ts
+++ b/packages/cdn/src/loaders.ts
@@ -326,7 +326,7 @@ export async function getPage(
   if (!config) throw responseNoSite();
   const project = getProject(config, projectName);
   if (!project) throw responseNoArticle();
-  const slug = opts?.loadIndexPage || opts?.slug == null ? project.index : opts.slug;
+  const slug = opts?.loadIndexPage || !opts?.slug ? project.index : opts.slug;
   const loader = await getData(baseUrl, config, project.slug, slug, location.query, opts).catch(
     (e) => {
       console.error(e);


### PR DESCRIPTION
This adds support for folder structure index slugs by trying to load both `slug` and `slug.index` in `getPage`.

For example if you have `/my/dir/index.md`, it will be served at the url `/my/dir` but the slug will be `my.dir.index`, so when you try to load the page from the URL, you will need to try both `my.dir` and `my.dir.index`.

We also should cut a release of `cdn` package so the new `getMystSearchJson` function is available to consume in themes.