### PR TITLE
🐛 Add missing slash to /my/ urls

### DIFF
--- a/.changeset/breezy-roses-search.md
+++ b/.changeset/breezy-roses-search.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Add missing slash to /my/ url

--- a/packages/curvenote-cli/src/submissions/list.ts
+++ b/packages/curvenote-cli/src/submissions/list.ts
@@ -77,7 +77,7 @@ export async function list(session: ISession, opts: { venue?: string }) {
 
   const submissions = (await getFromJournals(
     session,
-    `my/submissions/`,
+    `/my/submissions/`,
   )) as MySubmissionsListingDTO;
   if (!submissions.items.length) {
     session.log.info(`🫙 You have no submissions.`);

--- a/packages/curvenote-cli/src/works/utils.ts
+++ b/packages/curvenote-cli/src/works/utils.ts
@@ -32,8 +32,8 @@ export function workKeyFromConfig(session: ISession) {
  */
 export async function getWorkFromKey(session: ISession, key: string) {
   try {
-    session.log.debug(`GET from journals API my/works?key=${key}`);
-    const resp = await getFromJournals(session, `my/works?key=${key}`);
+    session.log.debug(`GET from journals API /my/works?key=${key}`);
+    const resp = await getFromJournals(session, `/my/works?key=${key}`);
     return resp.items[0];
   } catch {
     return undefined;


### PR DESCRIPTION
A bunch of leading slashes needed to be added to URL paths in this PR: https://github.com/curvenote/curvenote/pull/665 where the session api url was modified. This PR just adds a couple more that were missed.