### PR TITLE
🚩 improve the fallback venue error message env based token checks

### DIFF
--- a/.changeset/olive-apples-hug.md
+++ b/.changeset/olive-apples-hug.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/cli': patch
+---
+
+Improved cli message when submission fails and added additional initial check on token validity when configured via the environment.

--- a/packages/curvenote-cli/src/session/auth/checkUserTokenStatus.ts
+++ b/packages/curvenote-cli/src/session/auth/checkUserTokenStatus.ts
@@ -15,9 +15,9 @@ export async function checkUserTokenStatus(session: ISession) {
     session.log.error('No active token found');
     return;
   }
-  session.log.debug(`Token issued by ${active?.api}`); // active api == audience
 
   const { decoded, expired } = decodeTokenAndCheckExpiry(active?.token, session.log, false, 'user');
+  session.log.debug(`Token issued by ${active?.api}`); // active api == audience
 
   let revoked = false;
   if (expired !== true) {
@@ -50,4 +50,6 @@ export async function checkUserTokenStatus(session: ISession) {
     const loginVerifiedMessage = `Login as ${name} <${me.data.email}> verified by ${model.$createUrl()}`;
     session.log.info(loginVerifiedMessage);
   }
+
+  return true;
 }

--- a/packages/curvenote-cli/src/session/session.ts
+++ b/packages/curvenote-cli/src/session/session.ts
@@ -514,6 +514,10 @@ export async function getSession(
   let session;
   try {
     session = await Session.create(data.current, { logger });
+    if (data.environment) {
+      logger.warn('Checking user token...');
+      await checkUserTokenStatus(session);
+    }
   } catch (error) {
     logger.error((error as Error).message);
     process.exit(1);

--- a/packages/curvenote-cli/src/session/tokens.ts
+++ b/packages/curvenote-cli/src/session/tokens.ts
@@ -118,5 +118,15 @@ export function summarizeAsString({ note, username, email, api }: Omit<TokenData
 export function getCurrentTokenRecord(tokens?: ReturnType<typeof getTokens>) {
   const data = tokens ?? getTokens();
   if (!data.current) return;
+  if (data.environment) {
+    const { decoded } = decodeTokenAndCheckExpiry(data.current, chalkLogger(LogLevel.info));
+    return {
+      token: data.current,
+      api: decoded.aud,
+      email: decoded.email,
+      username: decoded.name ?? decoded.user_id,
+      note: 'From environment variable',
+    };
+  }
   return data.saved?.find(({ token }) => token === data.current);
 }

--- a/packages/curvenote-cli/src/submissions/submit.utils.ts
+++ b/packages/curvenote-cli/src/submissions/submit.utils.ts
@@ -1,14 +1,7 @@
-import {
-  buildSite,
-  clean,
-  collectAllBuildExportOptions,
-  localArticleExport,
-  selectors,
-} from 'myst-cli';
-import path from 'node:path';
+import { selectors } from 'myst-cli';
 import { v4 as uuid } from 'uuid';
 import type { ISession } from '../session/types.js';
-import { addOxaTransformersToOpts, confirmOrExit } from '../utils/utils.js';
+import { confirmOrExit } from '../utils/utils.js';
 import chalk from 'chalk';
 import { format } from 'date-fns';
 import {
@@ -409,8 +402,10 @@ export async function checkVenueSubmitAccess(session: ISession, venue: string) {
     if (submit) return true;
     session.log.debug('You do not have permission to submit to this venue.');
     throw new Error('You do not have permission to submit to this venue.');
-  } catch (err) {
+  } catch (err: any) {
     session.log.info(`${chalk.red(`🚦 venue "${venue}" is not accepting submissions.`)}`);
+    session.log.info(`${chalk.gray(`🤖 API Response: ${err.message}`)}`);
+    session.log.debug(JSON.stringify(err, null, 2));
     process.exit(1);
   }
 }
@@ -454,7 +449,7 @@ export async function getVenueCollections(
   const openCollections = collections.items.filter((c) => c.open);
 
   if (openCollections.length === 0) {
-    session.log.info(`${chalk.red(`🚦 venue "${venue}" is not accepting submissions.`)}`);
+    session.log.info(`${chalk.red(`🚦 venue "${venue}" has no open collections.`)}`);
     if (requireOpenCollections) process.exit(1);
   } else if (openCollections.length > 1) {
     session.log.info(


### PR DESCRIPTION
Will print additional info for the "Venue not accepting" error message, and only uses thst in one place now. Additional improvements to ensure validaity and print additional information when CURVENOTE_TOKEN is used to set the token, as on CI.
