### PR TITLE
🪪 add submission version id to `SiteWorkDTO`

### DIFF
--- a/.changeset/tidy-eggs-attack.md
+++ b/.changeset/tidy-eggs-attack.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/common": patch
+---
+
+Extending `SiteWorkDTO` with Submission Version Id.

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -135,6 +135,7 @@ export type WorkVersion = {
  */
 export type SiteWorkDTO = Pick<SubmissionDTO, 'slug' | 'kind'> &
   Work & {
+    submission_version_id: string;
     links: {
       self: string;
       config: string;


### PR DESCRIPTION
To enable tracking of submission version in front end, as slugs can change.
