### PR TITLE
🔧 Update CDN functions from myst-theme and depend on these

### DIFF
--- a/.changeset/eighty-roses-tan.md
+++ b/.changeset/eighty-roses-tan.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cdn": patch
+---
+
+Update CDN functions from myst-theme and depend on these

--- a/package-lock.json
+++ b/package-lock.json
@@ -22161,17 +22161,6 @@
         "node": ">=16"
       }
     },
-    "packages/cdn/node_modules/@curvenote/common": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@curvenote/common/-/common-0.2.13.tgz",
-      "integrity": "sha512-6l5IMBMjdFvE8/2THdBdx3u4IxhIszYcRnq6mKT/yh7PxWzfpZzhSuynbnEKPP97JishMM7SpD71ELZMZ9tlfg==",
-      "license": "MIT",
-      "dependencies": {
-        "@curvenote/blocks": "^1.5.29",
-        "myst-common": "^1.7.4",
-        "myst-config": "^1.7.4"
-      }
-    },
     "packages/cdn/node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,7 +167,7 @@
       }
     },
     "mystmd/packages/myst-cli": {
-      "version": "1.3.22",
+      "version": "1.3.23",
       "license": "MIT",
       "dependencies": {
         "@jupyterlab/services": "^7.0.0",
@@ -197,9 +197,10 @@
         "meca": "^1.0.8",
         "mime-types": "^2.1.35",
         "myst-cli-utils": "^2.0.11",
-        "myst-common": "^1.7.7",
-        "myst-config": "^1.7.7",
+        "myst-common": "^1.7.8",
+        "myst-config": "^1.7.8",
         "myst-execute": "^0.1.2",
+        "myst-ext-button": "^0.0.1",
         "myst-ext-card": "^1.0.9",
         "myst-ext-exercise": "^1.0.9",
         "myst-ext-grid": "^1.0.9",
@@ -207,10 +208,10 @@
         "myst-ext-proof": "^1.0.12",
         "myst-ext-reactive": "^1.0.9",
         "myst-ext-tabs": "^1.0.9",
-        "myst-frontmatter": "^1.7.7",
-        "myst-parser": "^1.5.10",
+        "myst-frontmatter": "^1.7.8",
+        "myst-parser": "^1.5.11",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.7.7",
+        "myst-spec-ext": "^1.7.8",
         "myst-templates": "^1.0.23",
         "myst-to-docx": "^1.0.13",
         "myst-to-jats": "^1.0.32",
@@ -218,7 +219,7 @@
         "myst-to-tex": "^1.0.41",
         "myst-to-typst": "^0.0.30",
         "myst-toc": "^0.1.2",
-        "myst-transforms": "^1.3.30",
+        "myst-transforms": "^1.3.31",
         "nanoid": "^4.0.0",
         "nbtx": "^0.2.3",
         "node-fetch": "^3.3.1",
@@ -563,11 +564,11 @@
       }
     },
     "mystmd/packages/myst-common": {
-      "version": "1.7.7",
+      "version": "1.7.8",
       "license": "MIT",
       "dependencies": {
         "mdast": "^3.0.0",
-        "myst-frontmatter": "^1.7.7",
+        "myst-frontmatter": "^1.7.8",
         "myst-spec": "^0.0.5",
         "nanoid": "^4.0.0",
         "unified": "^10.1.2",
@@ -580,7 +581,7 @@
       "devDependencies": {
         "@jupyterlab/nbformat": "^3.5.2",
         "@lumino/coreutils": "^2.0.0",
-        "myst-spec-ext": "^1.7.7",
+        "myst-spec-ext": "^1.7.8",
         "unist-builder": "3.0.0"
       }
     },
@@ -597,11 +598,11 @@
       }
     },
     "mystmd/packages/myst-config": {
-      "version": "1.7.7",
+      "version": "1.7.8",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.7.7",
-        "myst-frontmatter": "^1.7.7",
+        "myst-common": "^1.7.8",
+        "myst-frontmatter": "^1.7.8",
         "simple-validators": "^1.1.0"
       },
       "devDependencies": {
@@ -609,14 +610,14 @@
       }
     },
     "mystmd/packages/myst-directives": {
-      "version": "1.5.10",
+      "version": "1.5.11",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2",
         "csv-parse": "^5.5.5",
         "js-yaml": "^4.1.0",
-        "myst-common": "^1.7.6",
-        "myst-spec-ext": "^1.7.6",
+        "myst-common": "^1.7.8",
+        "myst-spec-ext": "^1.7.8",
         "nanoid": "^4.0.2",
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.7"
@@ -672,6 +673,17 @@
       },
       "engines": {
         "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "mystmd/packages/myst-ext-button": {
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "myst-common": "^1.7.8",
+        "myst-spec-ext": "^1.7.8"
+      },
+      "devDependencies": {
+        "myst-parser": "^1.5.11"
       }
     },
     "mystmd/packages/myst-ext-card": {
@@ -746,7 +758,7 @@
       }
     },
     "mystmd/packages/myst-frontmatter": {
-      "version": "1.7.7",
+      "version": "1.7.8",
       "license": "MIT",
       "dependencies": {
         "credit-roles": "^2.1.0",
@@ -764,8 +776,21 @@
         "node-fetch": "^3.3.2"
       }
     },
+    "mystmd/packages/myst-migrate": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "unist-util-select": "^4.0.3",
+        "unist-util-visit": "^4.1.2",
+        "vfile": "^5.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "devDependencies": {
+        "@jupyterlab/nbformat": "^3.5.2"
+      }
+    },
     "mystmd/packages/myst-parser": {
-      "version": "1.5.10",
+      "version": "1.5.11",
       "license": "MIT",
       "dependencies": {
         "he": "^1.2.0",
@@ -778,9 +803,9 @@
         "markdown-it-myst": "1.0.10",
         "markdown-it-myst-extras": "0.3.0",
         "markdown-it-task-lists": "^2.1.1",
-        "myst-common": "^1.7.6",
-        "myst-directives": "^1.5.10",
-        "myst-roles": "^1.5.10",
+        "myst-common": "^1.7.8",
+        "myst-directives": "^1.5.11",
+        "myst-roles": "^1.5.11",
         "myst-spec": "^0.0.5",
         "unified": "^10.1.1",
         "unist-builder": "^3.0.0",
@@ -797,21 +822,21 @@
         "@types/markdown-it": "^12.2.3",
         "@types/mdast": "^3.0.10",
         "js-yaml": "^4.1.0",
-        "myst-to-html": "^1.5.10",
-        "myst-transforms": "^1.3.29",
+        "myst-to-html": "^1.5.11",
+        "myst-transforms": "^1.3.31",
         "rehype-stringify": "^9.0.3"
       }
     },
     "mystmd/packages/myst-roles": {
-      "version": "1.5.10",
+      "version": "1.5.11",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^1.7.6",
-        "myst-spec-ext": "^1.7.6"
+        "myst-common": "^1.7.8",
+        "myst-spec-ext": "^1.7.8"
       }
     },
     "mystmd/packages/myst-spec-ext": {
-      "version": "1.7.7",
+      "version": "1.7.8",
       "license": "MIT",
       "dependencies": {
         "myst-spec": "^0.0.5"
@@ -862,7 +887,7 @@
       }
     },
     "mystmd/packages/myst-to-html": {
-      "version": "1.5.10",
+      "version": "1.5.11",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2",
@@ -872,7 +897,7 @@
         "mdast": "^3.0.0",
         "mdast-util-find-and-replace": "^2.1.0",
         "mdast-util-to-hast": "^12.3.0",
-        "myst-common": "^1.7.6",
+        "myst-common": "^1.7.8",
         "rehype-format": "^4.0.1",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
@@ -1056,7 +1081,7 @@
       }
     },
     "mystmd/packages/myst-transforms": {
-      "version": "1.3.30",
+      "version": "1.3.31",
       "license": "MIT",
       "dependencies": {
         "doi-utils": "^2.0.4",
@@ -1066,11 +1091,11 @@
         "js-yaml": "^4.1.0",
         "katex": "^0.15.2",
         "mdast-util-find-and-replace": "^2.1.0",
-        "myst-common": "^1.7.7",
-        "myst-frontmatter": "^1.7.7",
+        "myst-common": "^1.7.8",
+        "myst-frontmatter": "^1.7.8",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.7.7",
-        "myst-to-html": "1.5.10",
+        "myst-spec-ext": "^1.7.8",
+        "myst-to-html": "1.5.11",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
         "unified": "^10.0.0",
@@ -1089,7 +1114,7 @@
       }
     },
     "mystmd/packages/mystmd": {
-      "version": "1.3.22",
+      "version": "1.3.23",
       "license": "MIT",
       "bin": {
         "myst": "dist/myst.cjs"
@@ -1099,7 +1124,7 @@
         "commander": "^10.0.1",
         "core-js": "^3.31.1",
         "js-yaml": "^4.1.0",
-        "myst-cli": "^1.3.22"
+        "myst-cli": "^1.3.23"
       }
     },
     "mystmd/packages/mystmd/node_modules/chalk": {
@@ -14409,6 +14434,10 @@
       "resolved": "mystmd/packages/myst-execute",
       "link": true
     },
+    "node_modules/myst-ext-button": {
+      "resolved": "mystmd/packages/myst-ext-button",
+      "link": true
+    },
     "node_modules/myst-ext-card": {
       "resolved": "mystmd/packages/myst-ext-card",
       "link": true
@@ -14439,6 +14468,10 @@
     },
     "node_modules/myst-frontmatter": {
       "resolved": "mystmd/packages/myst-frontmatter",
+      "link": true
+    },
+    "node_modules/myst-migrate": {
+      "resolved": "mystmd/packages/myst-migrate",
       "link": true
     },
     "node_modules/myst-parser": {
@@ -22111,11 +22144,11 @@
       "dependencies": {
         "@curvenote/common": "^0.2.13",
         "cache-manager": "^5.2.3",
-        "doi-utils": "^2.0.2",
-        "myst-common": "^1.7.4",
-        "myst-config": "^1.7.4",
-        "myst-frontmatter": "^1.7.4",
-        "myst-spec-ext": "^1.7.4",
+        "doi-utils": "^2.0.4",
+        "myst-common": "^1.7.8",
+        "myst-config": "^1.7.8",
+        "myst-frontmatter": "^1.7.8",
+        "myst-spec-ext": "^1.7.8",
         "nbtx": "^0.2.3",
         "node-cache": "^5.1.2",
         "node-fetch": "^2.7.0"
@@ -22126,6 +22159,17 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "packages/cdn/node_modules/@curvenote/common": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@curvenote/common/-/common-0.2.13.tgz",
+      "integrity": "sha512-6l5IMBMjdFvE8/2THdBdx3u4IxhIszYcRnq6mKT/yh7PxWzfpZzhSuynbnEKPP97JishMM7SpD71ELZMZ9tlfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@curvenote/blocks": "^1.5.29",
+        "myst-common": "^1.7.4",
+        "myst-config": "^1.7.4"
       }
     },
     "packages/cdn/node_modules/node-fetch": {

--- a/packages/cdn/package.json
+++ b/packages/cdn/package.json
@@ -25,11 +25,11 @@
   "dependencies": {
     "@curvenote/common": "^0.2.13",
     "cache-manager": "^5.2.3",
-    "doi-utils": "^2.0.2",
-    "myst-common": "^1.7.4",
-    "myst-config": "^1.7.4",
-    "myst-frontmatter": "^1.7.4",
-    "myst-spec-ext": "^1.7.4",
+    "doi-utils": "^2.0.4",
+    "myst-common": "^1.7.8",
+    "myst-config": "^1.7.8",
+    "myst-frontmatter": "^1.7.8",
+    "myst-spec-ext": "^1.7.8",
     "nbtx": "^0.2.3",
     "node-cache": "^5.1.2",
     "node-fetch": "^2.7.0"

--- a/packages/cdn/src/errors.server.ts
+++ b/packages/cdn/src/errors.server.ts
@@ -1,4 +1,4 @@
-import { ErrorStatus } from '@myst-theme/common';
+import { ErrorStatus } from './types.js';
 import type { Response as NodeFetchResponse } from 'node-fetch';
 
 export function responseNoSite(): Response {

--- a/packages/cdn/src/loaders.ts
+++ b/packages/cdn/src/loaders.ts
@@ -2,15 +2,14 @@ import fetch from 'node-fetch';
 import { doi } from 'doi-utils';
 import type { SiteManifest } from 'myst-config';
 import {
-  type PageLoader,
   getFooterLinks,
   getProject,
   updatePageStaticLinksInplace,
   updateSiteManifestStaticLinksInplace,
-} from '@myst-theme/common';
+} from './utils.js';
 import type { Host, SiteDTO, WorkDTO, HostSpec, SiteWorkListingDTO } from '@curvenote/common';
 import { responseError, responseNoArticle, responseNoSite } from './errors.server.js';
-import type { Cache } from './types.js';
+import type { Cache, PageLoader } from './types.js';
 
 interface CdnRouter {
   cdn?: string; // this is the cdn key

--- a/packages/cdn/src/types.ts
+++ b/packages/cdn/src/types.ts
@@ -27,6 +27,7 @@ export type Heading = {
   short_title?: string;
   level: number | 'index';
   group?: string;
+  enumerator?: string;
 };
 
 export type SiteLoader = {

--- a/packages/cdn/src/utils.ts
+++ b/packages/cdn/src/utils.ts
@@ -4,6 +4,7 @@ import type { SiteManifest } from 'myst-config';
 import { selectAll } from 'unist-util-select';
 import type { Image as ImageSpec, Link as LinkSpec } from 'myst-spec';
 import type { FooterLinks, Heading, NavigationLink, PageLoader } from './types.js';
+import { slugToUrl, type GenericParent } from 'myst-common';
 
 type Image = ImageSpec & { urlOptimized?: string };
 type Link = LinkSpec & { static?: boolean };
@@ -37,12 +38,14 @@ export function getProjectHeadings(
       slug: project.index,
       path: project.slug ? `/${project.slug}` : '/',
       level: 'index',
+      enumerator: project.enumerator,
     },
     ...project.pages.map((p) => {
       if (!('slug' in p)) return p;
+      const slug = slugToUrl(p.slug);
       return {
         ...p,
-        path: projectSlug && project.slug ? `/${project.slug}/${p.slug}` : `/${p.slug}`,
+        path: projectSlug && project.slug ? `/${project.slug}/${slug}` : `/${slug}`,
       };
     }),
   ];
@@ -92,6 +95,33 @@ export function getFooterLinks(
 
 type UpdateUrl = (url: string) => string;
 
+function updateMdastStaticLinksInplace(mdast: GenericParent, updateUrl: UpdateUrl) {
+  // Fix all of the images to point to the CDN
+  const images = selectAll('image', mdast) as Image[];
+  images.forEach((node) => {
+    node.url = updateUrl(node.url);
+    if (node.urlOptimized) {
+      node.urlOptimized = updateUrl(node.urlOptimized);
+    }
+  });
+  const links = selectAll('link,linkBlock,card', mdast) as Link[];
+  const staticLinks = links?.filter((node) => node.static);
+  staticLinks.forEach((node) => {
+    // These are static links to thinks like PDFs or other referenced files
+    node.url = updateUrl(node.url);
+  });
+  const outputs = selectAll('output', mdast) as Output[];
+  outputs.forEach((node) => {
+    if (!node.data) return;
+    walkOutputs(node.data, (obj) => {
+      // The path will be defined from output of myst
+      // Here we are re-assigning it to the current domain
+      if (!obj.path) return;
+      obj.path = updateUrl(obj.path);
+    });
+  });
+}
+
 export function updateSiteManifestStaticLinksInplace(
   data: SiteManifest,
   updateUrl: UpdateUrl,
@@ -134,6 +164,11 @@ export function updateSiteManifestStaticLinksInplace(
   if (data.options.logo) data.options.logo = updateUrl(data.options.logo);
   if (data.options.logo_dark) data.options.logo_dark = updateUrl(data.options.logo_dark);
   if (data.options.favicon) data.options.favicon = updateUrl(data.options.favicon);
+  if (data.parts) {
+    Object.values(data.parts).forEach(({ mdast }) => {
+      updateMdastStaticLinksInplace(mdast, updateUrl);
+    });
+  }
   // Update the thumbnails to point at the CDN
   data.projects?.forEach((project) => {
     if (project.banner) project.banner = updateUrl(project.banner);
@@ -159,6 +194,11 @@ export function updateSiteManifestStaticLinksInplace(
         if (page.thumbnail) page.thumbnail = updateUrl(page.thumbnail);
         if (page.thumbnailOptimized) page.thumbnailOptimized = updateUrl(page.thumbnailOptimized);
       });
+    if (project.parts) {
+      Object.values(project.parts).forEach(({ mdast }) => {
+        updateMdastStaticLinksInplace(mdast, updateUrl);
+      });
+    }
   });
   return data;
 }
@@ -190,30 +230,7 @@ export function updatePageStaticLinksInplace(data: PageLoader, updateUrl: Update
   }
   const allMdastTrees = [data, ...Object.values(data.frontmatter?.parts ?? {})];
   allMdastTrees.forEach(({ mdast }) => {
-    // Fix all of the images to point to the CDN
-    const images = selectAll('image', mdast) as Image[];
-    images.forEach((node) => {
-      node.url = updateUrl(node.url);
-      if (node.urlOptimized) {
-        node.urlOptimized = updateUrl(node.urlOptimized);
-      }
-    });
-    const links = selectAll('link,linkBlock,card', mdast) as Link[];
-    const staticLinks = links?.filter((node) => node.static);
-    staticLinks.forEach((node) => {
-      // These are static links to thinks like PDFs or other referenced files
-      node.url = updateUrl(node.url);
-    });
-    const outputs = selectAll('output', mdast) as Output[];
-    outputs.forEach((node) => {
-      if (!node.data) return;
-      walkOutputs(node.data, (obj) => {
-        // The path will be defined from output of myst
-        // Here we are re-assigning it to the current domain
-        if (!obj.path) return;
-        obj.path = updateUrl(obj.path);
-      });
-    });
+    updateMdastStaticLinksInplace(mdast, updateUrl);
   });
   return data;
 }


### PR DESCRIPTION
This copies in the latest versions of the util functions from `@myst-theme/common` and updates imports to pull from here rather than `myst-theme`.

For now, this is a bit aspirational - now, the functions here and in myst-theme are identical, but this allows us to upgrade curvenote separately first, then pull in changes to myst-theme later.