### PR TITLE
🌌 a `zarr` directive

### DIFF
--- a/.changeset/rich-parents-lie.md
+++ b/.changeset/rich-parents-lie.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli-plugin": patch
+---
+
+Adding a zarr directive for simplied access to mulitple zarr viewers

--- a/packages/cli-plugin/src/directives/any/zarr.ts
+++ b/packages/cli-plugin/src/directives/any/zarr.ts
@@ -1,0 +1,86 @@
+import type { DirectiveSpec } from 'myst-common';
+import { u } from 'unist-builder';
+import { makePlaceholder, validateStringOptions } from '../../utils.js';
+
+// TODO: talk to package manager
+const VIZARR_URL = 'https://curvenote.github.io/widgets/widgets/vizarr-viewer.js';
+
+export const zarrViewer: DirectiveSpec = {
+  name: 'zarr',
+  doc: 'Embed a Zarr image viewer',
+  arg: {
+    type: String,
+    required: true,
+    doc: 'A URL to the Zarr file',
+  },
+  options: {
+    class: {
+      type: String,
+      required: false,
+      doc: 'Tailwind classes to apply to the container element',
+    },
+    styles: {
+      type: String,
+      required: false,
+      doc: 'URL to the CSS file',
+    },
+    viewer: {
+      type: String,
+      required: false,
+      doc: 'The viewer to use (default: "vizarr")',
+    },
+    height: {
+      type: String,
+      required: false,
+      doc: 'The height of the embedded viewer container set via style',
+    },
+  },
+  validate(data, vfile) {
+    // TODO: validate the URL for the esm
+    validateStringOptions(vfile, 'arg', data.arg);
+    if (data.options?.class) validateStringOptions(vfile, 'class', data.options?.class);
+    if (data.options?.veiwer) validateStringOptions(vfile, 'viewer', data.options?.viewer);
+    if (data.options?.height) validateStringOptions(vfile, 'height', data.options?.height);
+    if (
+      !data.options?.viewer &&
+      ((data.options?.viewer as string) ?? '').length > 0 &&
+      data.options?.viewer !== 'vizarr'
+    ) {
+      vfile.message(`Invalid viewer supplied: ${data.options?.viewer}.`);
+    }
+    return data;
+  },
+  run(data, _vfile, _opts) {
+    const viewer = data.options?.viewer ?? 'vizarr';
+
+    let viewerUrl = VIZARR_URL; // default
+    switch (viewer) {
+      case 'vizarr':
+      default:
+        viewerUrl = VIZARR_URL;
+    }
+
+    console.log('viewerUrl', viewerUrl);
+    console.log('data.arg', data.arg);
+
+    const block = u(
+      'block',
+      {
+        kind: 'any:bundle',
+        data: {
+          import: viewerUrl,
+          class: data.options?.class ?? '',
+          styles: '',
+          json: {
+            directive: 'zarr',
+            source: data.arg,
+            height: data.options?.height ?? '600px',
+          },
+        },
+      },
+      makePlaceholder(data, data.arg as string),
+    );
+
+    return [block];
+  },
+};

--- a/packages/cli-plugin/src/index.ts
+++ b/packages/cli-plugin/src/index.ts
@@ -2,10 +2,11 @@ import type { MystPlugin } from 'myst-common';
 import { articlesDirective } from './directives/articles.js';
 import { collectionsDirective } from './directives/collections.js';
 import { anyBundle } from './directives/any/bundle.js';
+import { zarrViewer } from './directives/any/zarr.js';
 
 const plugin: MystPlugin = {
   name: 'Curvenote Plugin',
-  directives: [articlesDirective, collectionsDirective, anyBundle],
+  directives: [articlesDirective, collectionsDirective, anyBundle, zarrViewer],
   roles: [],
   transforms: [],
 };


### PR DESCRIPTION
Imagining a single convenience directive that can provide a number of zarr viewers and wraps the tricker `js:widget` details. 
