### PR TITLE
🎟️ enable session tokens to be used to create sessions and operate

### DIFF
--- a/.changeset/fuzzy-news-lay.md
+++ b/.changeset/fuzzy-news-lay.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Modifying session creation flow to allow valid session tokens to be used, not just user tokens.

--- a/packages/curvenote-cli/src/session/session.ts
+++ b/packages/curvenote-cli/src/session/session.ts
@@ -49,7 +49,6 @@ import {
 import jwt from 'jsonwebtoken';
 import { getLogLevel } from './utils/getLogLevel.js';
 import { checkUserTokenStatus } from './auth/checkUserTokenStatus.js';
-import e from 'cors';
 
 const LOCALHOSTS = ['localhost', '127.0.0.1', '::1'];
 

--- a/packages/curvenote-cli/src/session/session.ts
+++ b/packages/curvenote-cli/src/session/session.ts
@@ -47,9 +47,9 @@ import {
   checkForCurvenoteAPIClientVersionRejection,
 } from './utils/index.js';
 import jwt from 'jsonwebtoken';
-import chalk from 'chalk';
 import { getLogLevel } from './utils/getLogLevel.js';
 import { checkUserTokenStatus } from './auth/checkUserTokenStatus.js';
+import e from 'cors';
 
 const LOCALHOSTS = ['localhost', '127.0.0.1', '::1'];
 
@@ -99,11 +99,18 @@ export class Session implements ISession {
 
     if (token) {
       const { decoded } = decodeTokenAndCheckExpiry(token, session.$logger, false);
-      session.log.debug('Creating session with token (decoded):');
-      session.log.debug(JSON.stringify(decoded, null, 2));
+      session.log.debug('Decoded token', JSON.stringify(decoded, null, 2));
 
-      session.setUserToken({ token, decoded });
-      await session.refreshSessionToken();
+      if (decoded.iss.endsWith('/session')) {
+        session.log.debug('Creating session with token (session):');
+        session.$activeTokens.session = { token, decoded };
+      } else {
+        session.log.debug('Creating session with token (decoded):');
+        session.log.debug(JSON.stringify(decoded, null, 2));
+        session.setUserToken({ token, decoded });
+        await session.refreshSessionToken();
+      }
+
       await session.configure();
     }
 


### PR DESCRIPTION
This [re]enables use of the client library in cases where it if being operated on behalf of the user, through an existing short lived session token e.g. build pdf and launchpad container services.
