### PR TITLE
📆 Set date published and 🔧 Use both /my/ and /sites/ APIs for finding submissions

### DIFF
--- a/.changeset/chilly-falcons-sort.md
+++ b/.changeset/chilly-falcons-sort.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Allow date to be set on publish

--- a/.changeset/rare-houses-breathe.md
+++ b/.changeset/rare-houses-breathe.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Look at site and my APIs for my submissions

--- a/packages/curvenote-cli/src/submissions/status.ts
+++ b/packages/curvenote-cli/src/submissions/status.ts
@@ -15,6 +15,13 @@ type StatusOptions = {
   date?: boolean | string;
 };
 
+export function hyphenatedFromDate(date: Date) {
+  const year = date.getFullYear().toString();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 async function updateStatus(
   action: STATUS_ACTIONS,
   session: ISession,
@@ -51,7 +58,13 @@ async function updateStatus(
   session.log.debug(`Found existing submission with key/id: ${key}/${existing.id}`);
   let date: string | undefined;
   if (action === 'publish' && opts.date) {
-    date = opts.date === true ? existing.date : opts.date;
+    if (typeof opts.date === 'string') {
+      date = opts.date;
+    } else if (existing.date) {
+      date = hyphenatedFromDate(new Date(existing.date));
+    } else {
+      session.log.warn('No alternative publish date provided; using today');
+    }
   }
   try {
     await patchUpdateSubmissionStatus(session, venue, existing.links.self, action, date);

--- a/packages/curvenote-cli/src/submissions/status.ts
+++ b/packages/curvenote-cli/src/submissions/status.ts
@@ -12,6 +12,7 @@ import { keyFromTransferFile } from './utils.transfer.js';
 
 type StatusOptions = {
   force?: boolean;
+  date?: boolean | string;
 };
 
 async function updateStatus(
@@ -48,9 +49,12 @@ async function updateStatus(
     process.exit(1);
   }
   session.log.debug(`Found existing submission with key/id: ${key}/${existing.id}`);
-
+  let date: string | undefined;
+  if (action === 'publish' && opts.date) {
+    date = opts.date === true ? existing.date : opts.date;
+  }
   try {
-    await patchUpdateSubmissionStatus(session, venue, existing.links.self, action);
+    await patchUpdateSubmissionStatus(session, venue, existing.links.self, action, date);
   } catch (e: any) {
     if (!opts.force) throw e;
     session.log.warn(`⚠️  ${e.message}`);

--- a/packages/curvenote-cli/src/submissions/submit.ts
+++ b/packages/curvenote-cli/src/submissions/submit.ts
@@ -102,7 +102,7 @@ export async function submit(session: ISession, venue: string, opts?: SubmitOpts
       const exists = await checkForSubmissionKeyInUse(session, venue, key);
       if (exists) {
         session.log.warn(
-          `⛔️ This work has already been submitted to "${venue}", but you don't have permission to access that submission.`,
+          `⛔️ This work has already been submitted to a Curvenote site, but you don't have permission to access that submission.`,
         );
         session.log.info(
           'If you still want to make a new submission, you may explicitly add flag "--new"',

--- a/packages/curvenote-cli/src/submissions/utils.ts
+++ b/packages/curvenote-cli/src/submissions/utils.ts
@@ -252,6 +252,7 @@ export async function patchUpdateSubmissionStatus(
   venue: string,
   submissionUrl: string,
   action: STATUS_ACTIONS,
+  date?: string,
 ) {
   const toc = tic();
   session.log.debug(`GET to ${submissionUrl}...`);
@@ -261,12 +262,7 @@ export async function patchUpdateSubmissionStatus(
     throw new Error(`Action "${action}" not available for submission`);
   }
   session.log.debug(`PUT to ${updateUrl}...`);
-  const resp = await postToUrl(
-    session,
-    updateUrl,
-    {}, // Currently takes no body
-    { method: 'PUT' },
-  );
+  const resp = await postToUrl(session, updateUrl, { date }, { method: 'PUT' });
   session.log.debug(`${resp.status} ${resp.statusText}`);
   if (resp.ok) {
     const json = (await resp.json()) as SubmissionDTO;

--- a/packages/curvenote/src/submissions.ts
+++ b/packages/curvenote/src/submissions.ts
@@ -54,6 +54,12 @@ function makeSubmissionPublishCLI(program: Command) {
         'If the publish action is not available, do not throw an error',
       ).default(false),
     )
+    .addOption(
+      new Option(
+        '--date [value]',
+        'Set different publish date than today. If no argument is provided for this option, frontmatter date will be used.',
+      ),
+    )
     .action(clirun(submissions.publish, { program, requireSiteConfig: true }));
   return command;
 }


### PR DESCRIPTION
This PR includes 2 totally separate features 😕:

1. `date_published` may now be set explicitly the first time a submission is published from the CLI. If it is not set, the frontmatter `date` will be used. If that doesn't exist, it will fall back to the original behaviour of using "today"
2. the Curvenote API has changed so users may no longer access their submissions to a site via `/sites/<site>/submissions` - that endpoint is restricted to site admins. This means when checking for existing submissions to a site we also must use `/my/submissions`.