### PR TITLE
🔧 Update `parts` logic in check-implementations

### DIFF
--- a/.changeset/selfish-trainers-type.md
+++ b/.changeset/selfish-trainers-type.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/check-implementations": patch
+---
+
+Update parts logic in check immplementations

--- a/packages/check-implementations/src/submission/data-availability.ts
+++ b/packages/check-implementations/src/submission/data-availability.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { loadProjectFromDisk, selectFile } from 'myst-cli';
+import { loadProjectFromDisk, resolveFrontmatterParts, selectFile } from 'myst-cli';
 import { copyNode, extractPart } from 'myst-common';
 import { getCheckDefinition } from '@curvenote/check-definitions';
 import type { CheckInterface } from '../types.js';
@@ -9,9 +9,11 @@ export const dataAvailabilityExists: CheckInterface = {
   ...getCheckDefinition('data-availability-exists'),
   validate: async (session) => {
     const { file } = await loadProjectFromDisk(session);
-    const { mdast } = selectFile(session, path.resolve(file)) ?? {};
+    const { mdast, frontmatter } = selectFile(session, path.resolve(file)) ?? {};
     if (!mdast) return error('Error loading content', { file });
-    const availability = extractPart(copyNode(mdast), 'availability');
+    const availability = extractPart(copyNode(mdast), 'availability', {
+      frontmatterParts: resolveFrontmatterParts(session, frontmatter),
+    });
     if (!availability)
       return fail('No availability statement found', {
         file,


### PR DESCRIPTION
When `abstract` is included as frontmatter, rather than as a section in the text, the abstract checks fail. This started with this PR, which refactored parts to be treated as separate files and `extractPart` received a new `frontmatterParts` option: https://github.com/jupyter-book/mystmd/pull/1586

This PR consumes the addition of `frontmatterParts` which fixes the abstract checks.