### PR TITLE
🙈 Enable anonymous api GET requests to enable public venue `checks`

### DIFF
--- a/.changeset/two-mails-rule.md
+++ b/.changeset/two-mails-rule.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Enable anonymous api get requests

--- a/packages/curvenote-cli/src/session/types.ts
+++ b/packages/curvenote-cli/src/session/types.ts
@@ -62,6 +62,7 @@ export type CLIConfigData = {
   tempCdnUrl: string;
   publicCdnUrl: string;
   deploymentCdnUrl: string;
+  anonymous?: boolean;
 };
 
 export type ISession = IMystSession & {

--- a/packages/curvenote-cli/src/session/utils/makeDefaultConfig.ts
+++ b/packages/curvenote-cli/src/session/utils/makeDefaultConfig.ts
@@ -23,7 +23,7 @@ const LOCAL_EDITOR_URL = 'http://localhost:3000';
  * @param opts
  * @returns
  */
-export function makeDefaultConfig(audience: string): CLIConfigData {
+export function makeDefaultConfig(audience?: string): CLIConfigData {
   let apiUrl = DEFAULT_PLATFORM_API_URL;
   let adminUrl = DEFAULT_PLATFORM_APP_URL;
   let editorApiUrl = DEFAULT_EDITOR_API_URL;
@@ -34,8 +34,8 @@ export function makeDefaultConfig(audience: string): CLIConfigData {
   let deploymentCdnUrl = 'https://cdn.curvenote.com';
 
   if (
-    audience.startsWith(STAGING_EDITOR_API_URL) ||
-    audience.startsWith(STAGING_PLATFORM_API_URL)
+    audience?.startsWith(STAGING_EDITOR_API_URL) ||
+    audience?.startsWith(STAGING_PLATFORM_API_URL)
   ) {
     apiUrl = STAGING_PLATFORM_API_URL;
     adminUrl = STAGING_PLATFORM_APP_URL;
@@ -46,8 +46,8 @@ export function makeDefaultConfig(audience: string): CLIConfigData {
     publicCdnUrl = 'https://cdn.curvenote.dev';
     deploymentCdnUrl = 'https://cdn.curvenote.dev';
   } else if (
-    audience.startsWith(LOCAL_EDITOR_API_URL) ||
-    audience.startsWith(LOCAL_PLATFORM_API_URL)
+    audience?.startsWith(LOCAL_EDITOR_API_URL) ||
+    audience?.startsWith(LOCAL_PLATFORM_API_URL)
   ) {
     apiUrl = LOCAL_PLATFORM_API_URL;
     adminUrl = LOCAL_PLATFORM_APP_URL;


### PR DESCRIPTION
When unauthenticated `curvenote check` runs some default hardcoded checks, but if a user wants to run venue-specific checks `curvenote check <venue>` fails, even if the venue is public. This is because all journal api requests are prevented when no token is set.

The CLI messaging made this particularly problematic: right at the beginning, there is a "you are unauthenticated" warning, then the build/checks seem to continue, then it says "venue not found" because there is a try/catch around the api request failure. At first, I was thinking we need to update that to "you must be authenticated to run checks against venue" so the user knows the problem is auth, not incorrect venue.

However, then I was questioning - Why can't we just run checks against public venues, even when unauthenticated? That would allow users to run `curvenote check` sooner.

So, in this PR, I'm enabling unauthenticated `checks` by allowing unauthenticated `GET`s to the journal api.