### PR TITLE
🎁 Write source folder to cdn when pushing work

### DIFF
--- a/.changeset/long-actors-attack.md
+++ b/.changeset/long-actors-attack.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Write source zip to cdn when pushing work

--- a/package-lock.json
+++ b/package-lock.json
@@ -22421,6 +22421,7 @@
         "@reduxjs/toolkit": "^1.7.2",
         "@scienceicons/myst": "^1.0.4",
         "@wordpress/wordcount": "3.40.0",
+        "adm-zip": "^0.5.10",
         "bottleneck": "^2.19.5",
         "chalk": "^5.2.0",
         "check-node-version": "^4.2.1",

--- a/packages/curvenote-cli/package.json
+++ b/packages/curvenote-cli/package.json
@@ -53,6 +53,7 @@
     "@reduxjs/toolkit": "^1.7.2",
     "@scienceicons/myst": "^1.0.4",
     "@wordpress/wordcount": "3.40.0",
+    "adm-zip": "^0.5.10",
     "bottleneck": "^2.19.5",
     "chalk": "^5.2.0",
     "check-node-version": "^4.2.1",


### PR DESCRIPTION
This reuses the MECA build process to create a folder with `source` files (pulled out of the MECA `bundle/` folder). This new `source/` folder gets added to the `site/` folder and uploaded during `curvenote work push`.