### PR TITLE
🌎 Allow works to be pushed to public CDN

### DIFF
--- a/.changeset/lovely-bobcats-notice.md
+++ b/.changeset/lovely-bobcats-notice.md
@@ -1,0 +1,6 @@
+---
+"@curvenote/cli": patch
+"curvenote": patch
+---
+
+Allow works to be pushed to public CDN

--- a/packages/curvenote-cli/src/works/types.ts
+++ b/packages/curvenote-cli/src/works/types.ts
@@ -1,4 +1,8 @@
-import type { BaseLog, IdAndDate } from '../logs/types.js';
+import type { BaseLog, IdAndDate, BaseOpts } from '../logs/types.js';
+
+export type PushOpts = BaseOpts & {
+  public?: boolean;
+};
 
 export type WorkPushLog = BaseLog & {
   work?: IdAndDate;

--- a/packages/curvenote/src/works.ts
+++ b/packages/curvenote/src/works.ts
@@ -17,6 +17,7 @@ function makeWorksListCLI(program: Command) {
 function makeWorksPushCLI(program: Command) {
   const command = new Command('push')
     .description('Push a new Work or a new version of an existing Work')
+    .option('--public', 'Push to the public CDN instead of the private CDN')
     .action(clirun(works.push, { program, requireSiteConfig: true }));
   return command;
 }


### PR DESCRIPTION
This just adds a `--public` flag to the `curvenote work push` command. If the flag is provided, the work is pushed directly to the public CDN and may be used, for example, as public landing content for a Site.