### PR TITLE
🔓 Enable template download with no token

### DIFF
--- a/.changeset/eighty-eagles-judge.md
+++ b/.changeset/eighty-eagles-judge.md
@@ -1,0 +1,5 @@
+---
+"curvenote": patch
+---
+
+Add env variables for myst whitelabeling

--- a/.changeset/quiet-nails-brush.md
+++ b/.changeset/quiet-nails-brush.md
@@ -1,0 +1,5 @@
+---
+"@curvenote/cli": patch
+---
+
+Enable template download with no token

--- a/packages/curvenote-cli/src/session/session.ts
+++ b/packages/curvenote-cli/src/session/session.ts
@@ -46,6 +46,7 @@ import {
   checkForPlatformAPIClientVersionRejection,
   withQuery,
   checkForCurvenoteAPIClientVersionRejection,
+  DEFAULT_EDITOR_API_URL,
 } from './utils/index.js';
 import jwt from 'jsonwebtoken';
 import { getLogLevel } from './utils/getLogLevel.js';
@@ -126,7 +127,8 @@ export class Session implements ISession {
       this.proxyAgent = new HttpsProxyAgent(proxyUrl);
     }
 
-    this.API_URL = 'NOTSET';
+    // We are still setting this as some of the myst-cli functions rely on it
+    this.API_URL = DEFAULT_EDITOR_API_URL;
 
     this.store = createStore(rootReducer);
     // Allow the latest version to be loaded
@@ -265,7 +267,7 @@ export class Session implements ISession {
           this.log.debug(`Configuration set: "${JSON.stringify(this.$config, null, 2)}".`);
 
           // We are still setting this as some of the myst-cli functions rely on it
-          this.API_URL = this.$config?.editorApiUrl ?? 'INVALID';
+          this.API_URL = this.$config?.editorApiUrl ?? DEFAULT_EDITOR_API_URL;
 
           return;
         }
@@ -284,7 +286,7 @@ export class Session implements ISession {
     this.log.debug(`Configuration set: "${JSON.stringify(this.$config, null, 2)}".\n`);
 
     // We are still setting this as some of the myst-cli functions rely on it
-    this.API_URL = this.$config?.editorApiUrl ?? 'INVALID';
+    this.API_URL = this.$config?.editorApiUrl ?? DEFAULT_EDITOR_API_URL;
   }
 
   showUpgradeNotice() {

--- a/packages/curvenote-cli/src/session/utils/makeDefaultConfig.ts
+++ b/packages/curvenote-cli/src/session/utils/makeDefaultConfig.ts
@@ -2,7 +2,7 @@ import type { CLIConfigData } from '../types.js';
 
 const DEFAULT_PLATFORM_API_URL = 'https://sites.curvenote.com/v1';
 const DEFAULT_PLATFORM_APP_URL = 'https://sites.curvenote.com';
-const DEFAULT_EDITOR_API_URL = 'https://api.curvenote.com';
+export const DEFAULT_EDITOR_API_URL = 'https://api.curvenote.com';
 const DEFAULT_EDITOR_URL = 'https://curvenote.com';
 
 const STAGING_PLATFORM_API_URL = 'https://sites.curvenote.dev/v1';

--- a/packages/curvenote/src/index.ts
+++ b/packages/curvenote/src/index.ts
@@ -14,6 +14,12 @@ import { addSiteCLI } from './sites.js';
 
 (process as any).noDeprecation = true;
 
+// Set whitelabeling
+process.env.MYSTMD_READABLE_NAME = 'Curvenote';
+process.env.MYSTMD_BINARY_NAME = 'curvenote';
+process.env.MYSTMD_NPM_BINARY_NAME = 'curvenote';
+process.env.MYSTMD_NPM_PACKAGE_NAME = 'curvenote';
+
 const program = new Command();
 addSyncCLI(program);
 addWebCLI(program);


### PR DESCRIPTION
This sets default `API_URL` for template download, enabling `curvenote start` without a token.

Addresses #721 