### PR TITLE
Log outbound emails as messages

### DIFF
--- a/.changeset/red-berries-wink.md
+++ b/.changeset/red-berries-wink.md
@@ -1,0 +1,7 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms-core': patch
+'@curvenote/scms': patch
+---
+
+Outbound emails not logged as messages and introducing `$schema`s for JSON fields on the `Message` table entries

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev:db:migrate": "npx prisma migrate dev --schema=./prisma/schema",
     "test:db:reset": "dotenv -e .env.test -- npx prisma db push --force-reset --schema=./prisma/schema; dotenv -e .env.test -- tsx prisma/seed.test.mts",
     "config": "npx @app-config/cli@2 generate",
-    "build": "npm run config && turbo run build",
+    "build": "npm run config && turbo run build --filter='!@curvenote/scms'",
     "build:scms": "cd platform/scms && npm run build",
     "build:web": "turbo run build --filter=@curvespace/default",
     "dev:all": "turbo run dev --parallel",

--- a/packages/scms-core/src/components/InviteUserDialog.tsx
+++ b/packages/scms-core/src/components/InviteUserDialog.tsx
@@ -149,10 +149,11 @@ export function InviteUserDialog({
       setMessage('');
       handledResponseRef.current = null;
     } else if (initialEmail) {
-      // Pre-fill email when dialog opens with initialEmail
+      // Pre-fill email when dialog opens
+      // initialEmail is not in dependencies, so changes to it won't overwrite user input
       setEmail(initialEmail);
     }
-  }, [open, initialEmail]);
+  }, [open]);
 
   const handleSubmit = () => {
     const trimmedEmail = email.trim();

--- a/packages/scms-server/src/backend/context.server.ts
+++ b/packages/scms-server/src/backend/context.server.ts
@@ -324,6 +324,7 @@ export class Context implements ContextType {
   async sendEmail<T extends ResendEventType, P extends object>(
     email: TemplatedResendEmail<T, P>,
     extensionTemplates?: ExtensionEmailTemplate[],
+    module?: string,
   ) {
     if (!email.ignoreUnsubscribe && !!(await dbGetUnsubscribedEmail(email.to))) {
       console.log(`Not sending to unsubscribed email: ${email.to}`);
@@ -347,12 +348,14 @@ export class Context implements ContextType {
         resendConfig: this.$config.api?.resend,
       },
       extensionTemplates,
+      module,
     );
   }
 
   async sendEmailBatch<T extends ResendEventType, P extends object>(
     emails: TemplatedResendEmail<T, P>[],
     extensionTemplates?: ExtensionEmailTemplate[],
+    module?: string,
   ) {
     const emailBatch = (
       await Promise.all(
@@ -382,6 +385,7 @@ export class Context implements ContextType {
         resendConfig: this.$config.api?.resend,
       },
       extensionTemplates,
+      module,
     );
   }
 

--- a/packages/scms-server/src/backend/loaders/messages/db.server.ts
+++ b/packages/scms-server/src/backend/loaders/messages/db.server.ts
@@ -58,6 +58,7 @@ export async function dbGetMessages(ctx: Context, query: MessageQuery = {}): Pro
   const messages = await prisma.message.findMany({
     where,
     orderBy: { date_created: 'desc' },
+    take: 1000, // limit for now, paginate later if/when there is demand
     select: {
       id: true,
       date_created: true,

--- a/packages/scms-server/src/backend/services/emails/index.ts
+++ b/packages/scms-server/src/backend/services/emails/index.ts
@@ -1,1 +1,2 @@
 export * from './resend.server.js';
+export * from './message-schemas.js';

--- a/packages/scms-server/src/backend/services/emails/message-schemas.ts
+++ b/packages/scms-server/src/backend/services/emails/message-schemas.ts
@@ -25,7 +25,11 @@ export const OUTBOUND_EMAIL_PAYLOAD_SCHEMA = {
       type: ['string', 'null'],
       description: 'Resend API message ID if available, null otherwise',
     },
-    sentAt: { type: 'string', format: 'date-time', description: 'ISO timestamp when email was sent' },
+    sentAt: {
+      type: 'string',
+      format: 'date-time',
+      description: 'ISO timestamp when email was sent',
+    },
   },
   required: ['eventType', 'to', 'from', 'subject', 'sentAt'],
 };

--- a/packages/scms-server/src/backend/services/emails/message-schemas.ts
+++ b/packages/scms-server/src/backend/services/emails/message-schemas.ts
@@ -1,0 +1,119 @@
+/**
+ * JSON schemas for message data stored in the messages table
+ * These schemas help UI components understand the structure of message data
+ */
+
+/**
+ * Schema for outbound email payload - contains all email details being sent
+ */
+export const OUTBOUND_EMAIL_PAYLOAD_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  description:
+    'Schema for outbound email payload containing all email details being sent, including recipient, sender, subject, HTML content, and metadata.',
+  type: 'object',
+  properties: {
+    eventType: { type: 'string', description: 'The type of email event being sent' },
+    to: { type: 'string', format: 'email', description: 'Recipient email address' },
+    from: { type: 'string', description: 'Sender email address' },
+    subject: { type: 'string', description: 'Email subject line' },
+    html: { type: 'string', description: 'HTML content of the email' },
+    ignoreUnsubscribe: {
+      type: 'boolean',
+      description: 'Whether to ignore unsubscribe preferences for this email',
+    },
+    resendId: {
+      type: ['string', 'null'],
+      description: 'Resend API message ID if available, null otherwise',
+    },
+    sentAt: { type: 'string', format: 'date-time', description: 'ISO timestamp when email was sent' },
+  },
+  required: ['eventType', 'to', 'from', 'subject', 'sentAt'],
+};
+
+/**
+ * Schema for outbound email results - only contains success confirmation
+ */
+export const OUTBOUND_EMAIL_RESULTS_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  description:
+    'Schema for outbound email results containing only success confirmation information. This minimal structure indicates the email was successfully sent.',
+  type: 'object',
+  properties: {
+    status: {
+      type: 'string',
+      enum: ['SUCCESS'],
+      description: 'Status indicating the email was successfully sent',
+    },
+    resendId: {
+      type: ['string', 'null'],
+      description: 'Resend API message ID returned after successful send, null if not available',
+    },
+    sentAt: {
+      type: 'string',
+      format: 'date-time',
+      description: 'ISO timestamp when the email was successfully sent',
+    },
+  },
+  required: ['status', 'sentAt'],
+};
+
+/**
+ * Schema for inbound email payload - unknown structure (any)
+ * This indicates the payload can be any object structure
+ */
+export const INBOUND_EMAIL_PAYLOAD_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  description:
+    'Schema for inbound email payload indicating an unknown structure. The payload contains raw data from the email provider (e.g., CloudMailin) with an unpredictable structure that may vary by provider.',
+  type: 'object',
+  additionalProperties: true,
+};
+
+/**
+ * Schema for inbound email results - well-known structured data
+ */
+export const INBOUND_EMAIL_RESULTS_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  description:
+    'Schema for inbound email results containing well-known structured data extracted from the raw email payload. This normalized structure is used by UI components to display email information consistently.',
+  type: 'object',
+  properties: {
+    from: { type: 'string', description: 'Sender email address' },
+    to: { type: 'string', format: 'email', description: 'Recipient email address' },
+    subject: { type: 'string', description: 'Email subject line' },
+    receivedAt: {
+      type: 'string',
+      format: 'date-time',
+      description: 'ISO timestamp when the email was received',
+    },
+    headers: {
+      type: 'object',
+      description: 'Email headers extracted from the raw payload',
+      properties: {
+        from: { type: 'string', description: 'From header value' },
+        to: { type: 'string', description: 'To header value' },
+        subject: { type: 'string', description: 'Subject header value' },
+        date: { type: 'string', description: 'Date header value' },
+      },
+    },
+    envelope: {
+      type: 'object',
+      description: 'SMTP envelope information from the email provider',
+      properties: {
+        from: { type: 'string', description: 'Envelope from address' },
+        to: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Array of envelope to addresses',
+        },
+      },
+    },
+    plain: { type: 'string', description: 'Plain text content of the email' },
+    html: { type: 'string', description: 'HTML content of the email' },
+  },
+  required: ['from', 'subject', 'receivedAt'],
+};
+
+// Legacy exports for backward compatibility
+export const OUTBOUND_EMAIL_SCHEMA = OUTBOUND_EMAIL_PAYLOAD_SCHEMA;
+export const INBOUND_EMAIL_SCHEMA = INBOUND_EMAIL_RESULTS_SCHEMA;

--- a/packages/scms-server/src/utils.server.spec.ts
+++ b/packages/scms-server/src/utils.server.spec.ts
@@ -33,13 +33,19 @@ const MockEmptyContext = { scopes: [] as string[], user: { system_role: 'USER' }
 describe('root', () => {
   describe('buildClientNavigation', () => {
     test('should return empty array when no navigation is provided', async () => {
-      expect(await buildClientNavigation(MockEmptyContext)).toEqual([]);
+      expect(await buildClientNavigation(MockEmptyContext)).toEqual({
+        items: [],
+      });
     });
     test('should return empty array when navigation is empty', async () => {
-      expect(await buildClientNavigation(MockEmptyContext)).toEqual([]);
+      expect(await buildClientNavigation(MockEmptyContext)).toEqual({
+        items: [],
+      });
     });
     test('should return empty array when no user is defined', async () => {
-      expect(await buildClientNavigation({ scopes: [] as string[] } as Context)).toEqual([]);
+      expect(await buildClientNavigation({ scopes: [] as string[] } as Context)).toEqual({
+        items: [],
+      });
     });
     test('should allow pass through of simple options', async () => {
       expect(
@@ -151,7 +157,7 @@ describe('root', () => {
       });
     });
 
-    test('should filter our navigation items when user does not have the required scope', async () => {
+    test('should filter out navigation items when user does not have the required scope', async () => {
       const contextWithAdmin = {
         scopes: [''],
         user: {
@@ -174,16 +180,7 @@ describe('root', () => {
           ],
         }),
       ).toEqual({
-        items: [
-          { name: 'home', label: 'Home', icon: 'home', path: '/' },
-          {
-            name: 'platform',
-            label: 'Platform Admin',
-            icon: 'settings',
-            path: '/platform',
-            scopes: ['app:platform:admin'],
-          },
-        ],
+        items: [{ name: 'home', label: 'Home', icon: 'home', path: '/' }],
       });
     });
 
@@ -271,7 +268,7 @@ describe('root', () => {
             },
           ],
         }),
-      ).toEqual([]);
+      ).toEqual({ items: [] });
     });
 
     test('should filter navigation item when user is missing one of multiple required scopes', async () => {

--- a/platform/scms/app/routes/app/platform.messages.$messageId/route.tsx
+++ b/platform/scms/app/routes/app/platform.messages.$messageId/route.tsx
@@ -117,8 +117,14 @@ export default function MessageDetailPage({ loaderData }: Route.ComponentProps) 
             <div>
               <h2 className="text-2xl font-bold">{subject}</h2>
               <div>
-                {message.type === 'outbound_email' ? 'To' : 'From'}: {from}
-                {to && message.type === 'outbound_email' && ` → ${to}`}
+                {message.type === 'outbound_email' ? (
+                  <>
+                    To: {to || 'Unknown'}
+                    {from && ` (From: ${from})`}
+                  </>
+                ) : (
+                  <>From: {from}</>
+                )}
               </div>
               {date && (
                 <div>

--- a/platform/scms/app/routes/app/platform.messages/message-utils.ts
+++ b/platform/scms/app/routes/app/platform.messages/message-utils.ts
@@ -81,7 +81,13 @@ export function extractMessageEmailData(
     from = payload?.headers?.from || payload?.envelope?.from || payload?.from || 'Unknown';
     to = payload?.headers?.to || payload?.envelope?.to || payload?.to;
     date = payload?.headers?.date || payload?.envelope?.date || payload?.date;
-    body = payload?.plain || payload?.html || payload;
+    // Ensure body is always a string or undefined, never an object
+    const plainOrHtml = payload?.plain || payload?.html;
+    if (plainOrHtml && typeof plainOrHtml === 'string') {
+      body = plainOrHtml;
+    } else {
+      body = fallbackBody;
+    }
   }
 
   return {

--- a/platform/scms/app/routes/app/platform.messages/message-utils.ts
+++ b/platform/scms/app/routes/app/platform.messages/message-utils.ts
@@ -1,0 +1,98 @@
+import type { Message } from '@prisma/client';
+
+/**
+ * Extracted email data from a message for display purposes
+ */
+export interface MessageEmailData {
+  subject: string;
+  from: string;
+  to: string | undefined;
+  date: string | undefined;
+  body: string | undefined;
+}
+
+/**
+ * Extracts email display data from a message based on its type and schema availability.
+ * Handles both schema-based (new) and legacy (backward compatibility) message formats.
+ *
+ * @param message - The message to extract data from
+ * @param options - Optional configuration for fallback values
+ * @returns Extracted email data for display
+ */
+export function extractMessageEmailData(
+  message: Message,
+  options: {
+    fallbackTo?: string;
+    fallbackDate?: string;
+    fallbackBody?: string;
+  } = {},
+): MessageEmailData {
+  const payload = message.payload as any;
+  const results = message.results as any;
+  const hasPayloadSchema = payload?.$schema;
+  const hasResultsSchema = results?.$schema;
+
+  const {
+    fallbackTo = undefined,
+    fallbackDate = undefined,
+    fallbackBody = undefined,
+  } = options;
+
+  // Determine if we should use structured data from payload or results (if schema exists)
+  let subject: string;
+  let from: string;
+  let to: string | undefined;
+  let date: string | undefined;
+  let body: string | undefined;
+
+  if (message.type === 'outbound_email') {
+    // Outbound email - payload contains email details, results only has success info
+    if (hasPayloadSchema && payload) {
+      // Use payload for email details (new schema-based structure)
+      subject = payload.subject || 'No subject';
+      from = payload.from || 'Unknown';
+      to = payload.to;
+      date = payload.sentAt;
+      body = payload.html;
+    } else {
+      // Fallback to payload (backward compatibility for records without schema)
+      subject = payload.subject || 'No subject';
+      from = payload.from || 'Unknown';
+      to = payload.to || fallbackTo;
+      date = payload.sentAt || fallbackDate;
+      body = payload.html || fallbackBody;
+    }
+  } else if (message.type === 'inbound_email') {
+    // Inbound email - results has structured data, payload is unknown structure
+    if (hasResultsSchema && results) {
+      // Use results for structured data (new schema-based structure)
+      subject = results.subject || 'No subject';
+      from = results.from || 'Unknown';
+      to = results.to;
+      date = results.receivedAt;
+      body = results.plain || results.html;
+    } else {
+      // Fallback to payload (backward compatibility for existing records)
+      subject = payload.headers?.subject || payload.subject || 'No subject';
+      from = payload.headers?.from || payload.envelope?.from || payload.from || 'Unknown';
+      to = payload.headers?.to || payload.envelope?.to || payload.to;
+      date = payload.headers?.date || payload.envelope?.date || payload.date;
+      body = payload.plain || payload.html;
+    }
+  } else {
+    // Other message types - use payload
+    subject = payload.headers?.subject || payload.subject || message.id;
+    from = payload.headers?.from || payload.envelope?.from || payload.from || 'Unknown';
+    to = payload.headers?.to || payload.envelope?.to || payload.to;
+    date = payload.headers?.date || payload.envelope?.date || payload.date;
+    body = payload.plain || payload.html || payload;
+  }
+
+  return {
+    subject,
+    from,
+    to,
+    date,
+    body,
+  };
+}

--- a/platform/scms/app/routes/app/platform.messages/message-utils.ts
+++ b/platform/scms/app/routes/app/platform.messages/message-utils.ts
@@ -32,11 +32,7 @@ export function extractMessageEmailData(
   const hasPayloadSchema = payload?.$schema;
   const hasResultsSchema = results?.$schema;
 
-  const {
-    fallbackTo = undefined,
-    fallbackDate = undefined,
-    fallbackBody = undefined,
-  } = options;
+  const { fallbackTo = undefined, fallbackDate = undefined, fallbackBody = undefined } = options;
 
   // Determine if we should use structured data from payload or results (if schema exists)
   let subject: string;

--- a/platform/scms/app/routes/app/platform.messages/message-utils.ts
+++ b/platform/scms/app/routes/app/platform.messages/message-utils.ts
@@ -52,11 +52,11 @@ export function extractMessageEmailData(
       body = payload.html;
     } else {
       // Fallback to payload (backward compatibility for records without schema)
-      subject = payload.subject || 'No subject';
-      from = payload.from || 'Unknown';
-      to = payload.to || fallbackTo;
-      date = payload.sentAt || fallbackDate;
-      body = payload.html || fallbackBody;
+      subject = payload?.subject || 'No subject';
+      from = payload?.from || 'Unknown';
+      to = payload?.to || fallbackTo;
+      date = payload?.sentAt || fallbackDate;
+      body = payload?.html || fallbackBody;
     }
   } else if (message.type === 'inbound_email') {
     // Inbound email - results has structured data, payload is unknown structure
@@ -69,19 +69,19 @@ export function extractMessageEmailData(
       body = results.plain || results.html;
     } else {
       // Fallback to payload (backward compatibility for existing records)
-      subject = payload.headers?.subject || payload.subject || 'No subject';
-      from = payload.headers?.from || payload.envelope?.from || payload.from || 'Unknown';
-      to = payload.headers?.to || payload.envelope?.to || payload.to;
-      date = payload.headers?.date || payload.envelope?.date || payload.date;
-      body = payload.plain || payload.html;
+      subject = payload?.headers?.subject || payload?.subject || 'No subject';
+      from = payload?.headers?.from || payload?.envelope?.from || payload?.from || 'Unknown';
+      to = payload?.headers?.to || payload?.envelope?.to || payload?.to;
+      date = payload?.headers?.date || payload?.envelope?.date || payload?.date;
+      body = payload?.plain || payload?.html;
     }
   } else {
     // Other message types - use payload
-    subject = payload.headers?.subject || payload.subject || message.id;
-    from = payload.headers?.from || payload.envelope?.from || payload.from || 'Unknown';
-    to = payload.headers?.to || payload.envelope?.to || payload.to;
-    date = payload.headers?.date || payload.envelope?.date || payload.date;
-    body = payload.plain || payload.html || payload;
+    subject = payload?.headers?.subject || payload?.subject || message.id;
+    from = payload?.headers?.from || payload?.envelope?.from || payload?.from || 'Unknown';
+    to = payload?.headers?.to || payload?.envelope?.to || payload?.to;
+    date = payload?.headers?.date || payload?.envelope?.date || payload?.date;
+    body = payload?.plain || payload?.html || payload;
   }
 
   return {

--- a/platform/scms/app/routes/app/platform.messages/route.tsx
+++ b/platform/scms/app/routes/app/platform.messages/route.tsx
@@ -87,8 +87,14 @@ export default function SystemMessagesPage({ loaderData }: Route.ComponentProps)
               </Link>
             </div>
             <div>
-              {message.type === 'outbound_email' ? 'To' : 'From'}: {from}
-              {to && message.type === 'outbound_email' && ` → ${to}`}
+              {message.type === 'outbound_email' ? (
+                <>
+                  To: {to || 'Unknown'}
+                  {from && ` (From: ${from})`}
+                </>
+              ) : (
+                <>From: {from}</>
+              )}
             </div>
             {date && (
               <div>

--- a/platform/scms/app/routes/app/platform.messages/route.tsx
+++ b/platform/scms/app/routes/app/platform.messages/route.tsx
@@ -7,6 +7,7 @@ import {
 } from '@curvenote/scms-server';
 import { PageFrame, ui, formatDatetime } from '@curvenote/scms-core';
 import { parseMessageQuery, buildMessageQuery, type MessageQuery } from './query-parser';
+import { extractMessageEmailData } from './message-utils';
 import type { Message } from '@prisma/client';
 
 export const meta: Route.MetaFunction = () => {
@@ -66,31 +67,39 @@ export default function SystemMessagesPage({ loaderData }: Route.ComponentProps)
   const { messages, counts, query } = loaderData;
 
   const renderMessage = (message: Message) => {
-    // TODO if an inbound_email message, which is all we have right now
-    const payload = message.payload as any;
-    const date = payload.headers?.date ?? payload.envelope?.date ?? payload.date;
+    const { subject, from, to, date, body } = extractMessageEmailData(message, {
+      fallbackTo: 'Unknown',
+      fallbackDate: 'Unknown',
+      fallbackBody: 'Unknown',
+    });
+
     return (
       <>
         {/* Message Info */}
-        <div className="flex flex-col flex-1 min-w-0 gap-2">
+        <div className="flex flex-col flex-1 gap-2 min-w-0">
           <div className="flex flex-col gap-1">
             <div>
               <Link
                 to={`/app/platform/messages/${message.id}`}
-                className="flex-shrink-0 block text-lg font-semibold text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                className="block flex-shrink-0 text-lg font-semibold text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
               >
-                {payload.headers?.subject ??
-                  payload.envelope?.from ??
-                  payload.subject ??
-                  message.id}
+                {subject}
               </Link>
             </div>
             <div>
-              From: {payload.headers?.from ?? payload.envelope?.from ?? payload.from ?? 'Unknown'}
+              {message.type === 'outbound_email' ? 'To' : 'From'}: {from}
+              {to && message.type === 'outbound_email' && ` → ${to}`}
             </div>
-            {date && <div>Date: {date}</div>}
+            {date && (
+              <div>
+                {message.type === 'outbound_email' ? 'Sent' : 'Received'}: {formatDatetime(date)}
+              </div>
+            )}
             <div className="text-sm text-gray-600 dark:text-gray-400">
-              <div>Received: {formatDatetime(message.date_created)}</div>
+              <div>
+                {message.type === 'outbound_email' ? 'Created' : 'Received'}:{' '}
+                {formatDatetime(message.date_created)}
+              </div>
             </div>
             <div className="flex flex-wrap gap-2 my-2">
               <ui.Badge variant="outline">{message.module}</ui.Badge>
@@ -98,15 +107,15 @@ export default function SystemMessagesPage({ loaderData }: Route.ComponentProps)
               <ui.Badge variant={getStatusVariant(message.status)}>{message.status}</ui.Badge>
             </div>
           </div>
-          <div className="text-sm text-gray-600 dark:text-gray-400">
-            <div className="mt-1 overflow-hidden font-mono text-xs">
-              {truncatePayload(payload.plain ?? payload)}
+          {body && (
+            <div className="text-sm text-gray-600 dark:text-gray-400">
+              <div className="overflow-hidden mt-1 font-mono text-xs">{truncatePayload(body)}</div>
             </div>
-          </div>
+          )}
         </div>
 
         {/* Actions */}
-        <div className="flex justify-end flex-shrink-0 w-32">
+        <div className="flex flex-shrink-0 justify-end w-32">
           <Link to={`/app/platform/messages/${message.id}`}>
             <ui.Button variant="outline" size="sm" className="w-full">
               View Details
@@ -185,8 +194,8 @@ export default function SystemMessagesPage({ loaderData }: Route.ComponentProps)
   return (
     <PageFrame
       title="System Messages"
-      description="Message processing logs and system events"
-      className="max-w-screen-xl mx-auto"
+      description="Message processing logs and system events (1000 most recent messages)."
+      className="mx-auto max-w-screen-xl"
     >
       <ui.FilterableList
         searchComponent={


### PR DESCRIPTION
- **🪵 better changelog**
- **📕enabling changesets**
- **❓add configrable help button in primary navigation**
- **📧 extend invite user dialog to accept an optional email address**
- **✉️ log outbound emails as messages**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces structured logging for outbound emails and enhances admin visibility of message data.
> 
> - Add logging of outbound emails to `Message` table in `resend.server.ts` (single and batch) with `module` propagation; includes `$schema`-annotated `payload/results` using `OUTBOUND_EMAIL_*_SCHEMA`
> - Export new `message-schemas` and use them to standardize message data; keep legacy compatibility
> - Update admin routes to display messages with schema-aware views: new `extractMessageEmailData` util, structured vs raw JSON sections, improved metadata and formatting
> - Cap `dbGetMessages` to the 1000 most recent; update list description accordingly
> - Adjust `Context.sendEmail[Batch]` to accept `module` and pass through; minor UI/test tweaks (`InviteUserDialog` dependency fix; navigation tests updated); tweak root build script to skip `@curvenote/scms`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23a814c8c7e010cce4905ff0b105d3209824bf97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->