### PR TITLE
 Backing out of `$Enum` usage

### DIFF
--- a/ee/sites/src/hooks/useJobPolling.ts
+++ b/ee/sites/src/hooks/useJobPolling.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { $Enums } from '@curvenote/scms-db';
+import { JobStatus } from '@curvenote/scms-db';
 import { usePolling } from '@curvenote/scms-core';
 import type { JobDTO } from '@curvenote/common';
 import type { WorkflowTransition } from '@curvenote/scms-core';
@@ -29,7 +29,7 @@ export function useJobPolling({
   const shouldPoll = activeTransition?.requiresJob && jobId;
 
   const shouldStopPolling = useCallback((job: JobDTO) => {
-    return job.status === $Enums.JobStatus.COMPLETED || job.status === $Enums.JobStatus.FAILED;
+    return job.status === JobStatus.COMPLETED || job.status === JobStatus.FAILED;
   }, []);
 
   const handleJobComplete = useCallback(

--- a/ee/sites/src/routes/$siteName.collections.$collectionName/db.server.ts
+++ b/ee/sites/src/routes/$siteName.collections.$collectionName/db.server.ts
@@ -1,7 +1,7 @@
 import { uuidv7 as uuid } from 'uuidv7';
 import { formatDate } from '@curvenote/common';
 import { getPrismaClient } from '@curvenote/scms-server';
-import { $Enums } from '@curvenote/scms-db';
+import { ActivityType } from '@curvenote/scms-db';
 import { coerceToObject, httpError, delay } from '@curvenote/scms-core';
 
 /**
@@ -54,7 +54,7 @@ export async function safeCollectionContentUpdate(
                 id: userId,
               },
             },
-            activity_type: $Enums.ActivityType.COLLECTION_UPDATED,
+            activity_type: ActivityType.COLLECTION_UPDATED,
             collection: {
               connect: {
                 id: collectionId,
@@ -106,7 +106,7 @@ export async function dbUpdateCollectionName(name: string, collectionId: string,
             id: userId,
           },
         },
-        activity_type: $Enums.ActivityType.COLLECTION_UPDATED,
+        activity_type: ActivityType.COLLECTION_UPDATED,
         collection: {
           connect: {
             id: collectionId,
@@ -146,7 +146,7 @@ export async function dbUpdateCollectionDefault(
             id: userId,
           },
         },
-        activity_type: $Enums.ActivityType.COLLECTION_UPDATED,
+        activity_type: ActivityType.COLLECTION_UPDATED,
         collection: {
           connect: {
             id: collectionId,
@@ -187,7 +187,7 @@ export async function dbUpdateCollectionDefault(
                   id: userId,
                 },
               },
-              activity_type: $Enums.ActivityType.COLLECTION_UPDATED,
+              activity_type: ActivityType.COLLECTION_UPDATED,
               collection: {
                 connect: {
                   id,
@@ -227,7 +227,7 @@ export async function dbCreateCollectionKind(kindId: string, collectionId: strin
             id: userId,
           },
         },
-        activity_type: $Enums.ActivityType.COLLECTION_UPDATED,
+        activity_type: ActivityType.COLLECTION_UPDATED,
         collection: {
           connect: {
             id: collectionId,
@@ -267,7 +267,7 @@ export async function dbDeleteCollectionKind(kindId: string, collectionId: strin
             id: userId,
           },
         },
-        activity_type: $Enums.ActivityType.COLLECTION_UPDATED,
+        activity_type: ActivityType.COLLECTION_UPDATED,
         collection: {
           connect: {
             id: collectionId,
@@ -309,7 +309,7 @@ export async function dbUpdateCollectionOpen(value: boolean, collectionId: strin
             id: userId,
           },
         },
-        activity_type: $Enums.ActivityType.COLLECTION_UPDATED,
+        activity_type: ActivityType.COLLECTION_UPDATED,
         collection: {
           connect: {
             id: collectionId,
@@ -336,7 +336,7 @@ export async function dbDeleteCollection(collectionId: string, userId: string) {
             id: userId,
           },
         },
-        activity_type: $Enums.ActivityType.COLLECTION_DELETED,
+        activity_type: ActivityType.COLLECTION_DELETED,
         collection: {
           connect: {
             id: collectionId,
@@ -386,7 +386,7 @@ export async function dbUpdateCollectionParent(
             id: userId,
           },
         },
-        activity_type: $Enums.ActivityType.COLLECTION_UPDATED,
+        activity_type: ActivityType.COLLECTION_UPDATED,
         collection: {
           connect: {
             id: collectionId,

--- a/ee/sites/src/routes/$siteName.inbox/db.server.ts
+++ b/ee/sites/src/routes/$siteName.inbox/db.server.ts
@@ -1,6 +1,6 @@
 import type { SiteContext } from '@curvenote/scms-server';
 import { jobs, sites, getPrismaClient } from '@curvenote/scms-server';
-import { $Enums } from '@curvenote/scms-db';
+import { JobStatus } from '@curvenote/scms-db';
 import { getWorkflow, KnownJobTypes } from '@curvenote/scms-core';
 
 /**
@@ -14,7 +14,7 @@ export async function dbGetInboxSubmissions(ctx: SiteContext) {
     ctx,
     ctx.site.id,
     [KnownJobTypes.PUBLISH, KnownJobTypes.UNPUBLISH],
-    [$Enums.JobStatus.RUNNING],
+    [JobStatus.RUNNING],
   );
 
   // this will fix inbox temporarily, but we need to address the active version selection

--- a/ee/sites/src/routes/$siteName.kinds.$kindName/db.server.ts
+++ b/ee/sites/src/routes/$siteName.kinds.$kindName/db.server.ts
@@ -2,7 +2,7 @@ import { uuidv7 as uuid } from 'uuidv7';
 import { formatDate } from '@curvenote/common';
 import { getPrismaClient } from '@curvenote/scms-server';
 import { coerceToList, coerceToObject, httpError, delay } from '@curvenote/scms-core';
-import { $Enums } from '@curvenote/scms-db';
+import { ActivityType } from '@curvenote/scms-db';
 import { submissionRuleChecks, type Check } from '@curvenote/check-definitions';
 
 /**
@@ -55,7 +55,7 @@ export async function safeKindContentUpdate(
                 id: userId,
               },
             },
-            activity_type: $Enums.ActivityType.KIND_UPDATED,
+            activity_type: ActivityType.KIND_UPDATED,
             kind: {
               connect: {
                 id: kindId,
@@ -107,7 +107,7 @@ export async function dbUpdateKindName(name: string, kindId: string, userId: str
             id: userId,
           },
         },
-        activity_type: $Enums.ActivityType.KIND_UPDATED,
+        activity_type: ActivityType.KIND_UPDATED,
         kind: {
           connect: {
             id: kindId,
@@ -148,7 +148,7 @@ export async function dbUpdateKindDefault(
             id: userId,
           },
         },
-        activity_type: $Enums.ActivityType.KIND_UPDATED,
+        activity_type: ActivityType.KIND_UPDATED,
         kind: {
           connect: {
             id: kindId,
@@ -189,7 +189,7 @@ export async function dbUpdateKindDefault(
                   id: userId,
                 },
               },
-              activity_type: $Enums.ActivityType.KIND_UPDATED,
+              activity_type: ActivityType.KIND_UPDATED,
               kind: {
                 connect: {
                   id,
@@ -257,7 +257,7 @@ export async function safeKindChecksUpdate(
                 id: userId,
               },
             },
-            activity_type: $Enums.ActivityType.KIND_UPDATED,
+            activity_type: ActivityType.KIND_UPDATED,
             kind: {
               connect: {
                 id: kindId,

--- a/ee/sites/src/routes/$siteName.kinds/db.server.ts
+++ b/ee/sites/src/routes/$siteName.kinds/db.server.ts
@@ -1,7 +1,7 @@
 import { uuidv7 as uuid } from 'uuidv7';
 import { formatDate } from '@curvenote/common';
 import { getPrismaClient, sites } from '@curvenote/scms-server';
-import { $Enums } from '@curvenote/scms-db';
+import { ActivityType } from '@curvenote/scms-db';
 
 export async function dbDeleteKind(kindId: string, siteId: string, userId: string) {
   const prisma = await getPrismaClient();
@@ -17,7 +17,7 @@ export async function dbDeleteKind(kindId: string, siteId: string, userId: strin
             id: userId,
           },
         },
-        activity_type: $Enums.ActivityType.KIND_DELETED,
+        activity_type: ActivityType.KIND_DELETED,
         kind: {
           connect: {
             id: kindId,
@@ -58,7 +58,7 @@ export async function dbDeleteKind(kindId: string, siteId: string, userId: strin
                 id: userId,
               },
             },
-            activity_type: $Enums.ActivityType.KIND_UPDATED,
+            activity_type: ActivityType.KIND_UPDATED,
             kind: {
               connect: {
                 id: newDefault.id,
@@ -129,7 +129,7 @@ export async function dbCreateKind(
             id: userId,
           },
         },
-        activity_type: $Enums.ActivityType.KIND_CREATED,
+        activity_type: ActivityType.KIND_CREATED,
         kind: {
           connect: {
             id: kindId,

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/ActivityFeed.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/ActivityFeed.tsx
@@ -1,10 +1,10 @@
 import { formatDistance } from 'date-fns';
 import { Activity } from 'lucide-react';
 import type { SubmissionDTO, SubmissionActivityDTO } from '@curvenote/common';
-import type { $Enums } from '@curvenote/scms-db';
+import type { ActivityType } from '@curvenote/scms-db';
 import { SectionWithHeading, primitives, formatDate } from '@curvenote/scms-core';
 
-const ACTIVITY_TYPES: Record<$Enums.ActivityType, string> = {
+const ACTIVITY_TYPES: Record<ActivityType, string> = {
   NEW_SUBMISSION: 'New submission',
   SUBMISSION_KIND_CHANGE: 'Submission kind changed',
   SUBMISSION_DATE_CHANGE: 'Submission publication date changed',
@@ -64,7 +64,7 @@ function ActivityItemBody({ activity }: { activity: SubmissionActivityDTO }) {
       className={`flex col-span-3 whitespace-nowrap before:block before:h-full before:w-1 before:rounded-full ${tagColor} before:content-['']`}
     >
       <div className="pl-2">
-        <p className="font-medium">{ACTIVITY_TYPES[activity_type as $Enums.ActivityType]}</p>
+        <p className="font-medium">{ACTIVITY_TYPES[activity_type as ActivityType]}</p>
         {additionalInfo}
         <primitives.Caption>{activity_by.name}</primitives.Caption>
       </div>

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/actionHelpers.server.ts
@@ -5,7 +5,7 @@ import { getPrismaClient } from '@curvenote/scms-server';
 import { isSafeSlug, looksLikeUUID, formatZodError, TrackEvent } from '@curvenote/scms-core';
 import { z } from 'zod';
 import { zfd } from 'zod-form-data';
-import { $Enums } from '@curvenote/scms-db';
+import { ActivityType } from '@curvenote/scms-db';
 import type { SiteContextWithUser } from '@curvenote/scms-server';
 
 export async function actionSetPrimarySlug(
@@ -409,7 +409,7 @@ export async function actionUpdateDatePublished(
             id: submission_id,
           },
         },
-        activity_type: $Enums.ActivityType.SUBMISSION_DATE_CHANGE,
+        activity_type: ActivityType.SUBMISSION_DATE_CHANGE,
         date_published,
       },
       include: {

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/route.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/route.tsx
@@ -43,7 +43,7 @@ import {
   loadMagicLinks,
 } from './magicLinks.server.js';
 import type { Slug } from '@curvenote/scms-db';
-import { $Enums } from '@curvenote/scms-db';
+import { JobStatus } from '@curvenote/scms-db';
 import { useEffect, useState } from 'react';
 import { ActivityFeed } from './ActivityFeed.js';
 import { Versions } from './Versions.js';
@@ -138,7 +138,7 @@ export const loader = async (args: LoaderFunctionArgs): Promise<LoaderData> => {
     ctx,
     ctx.site.id,
     [KnownJobTypes.PUBLISH, KnownJobTypes.UNPUBLISH],
-    [$Enums.JobStatus.RUNNING],
+    [JobStatus.RUNNING],
   );
 
   const [submissionVersions, jobsListing, magicLinks] = await Promise.all([

--- a/ee/sites/src/routes/$siteName.submissions._index/db.server.ts
+++ b/ee/sites/src/routes/$siteName.submissions._index/db.server.ts
@@ -1,7 +1,7 @@
 import type { SiteContext } from '@curvenote/scms-server';
 import { createPreviewToken, getPrismaClient, sites, jobs } from '@curvenote/scms-server';
 import type { Prisma } from '@curvenote/scms-db';
-import { $Enums } from '@curvenote/scms-db';
+import { JobStatus } from '@curvenote/scms-db';
 import { getWorkflow, KnownJobTypes } from '@curvenote/scms-core';
 
 /**
@@ -98,6 +98,6 @@ export async function dbQueryJobs(ctx: SiteContext) {
     ctx,
     ctx.site.id,
     [KnownJobTypes.PUBLISH, KnownJobTypes.UNPUBLISH],
-    [$Enums.JobStatus.RUNNING],
+    [JobStatus.RUNNING],
   );
 }

--- a/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
@@ -2,7 +2,7 @@ import { data } from 'react-router';
 import { zfd } from 'zod-form-data';
 import { z } from 'zod';
 import type { SiteUser, User } from '@curvenote/scms-db';
-import { $Enums } from '@curvenote/scms-db';
+import { SiteRole } from '@curvenote/scms-db';
 import type { SiteContextWithUser, SiteContext } from '@curvenote/scms-server';
 import {
   dbAddSiteUserRole,
@@ -24,7 +24,7 @@ const UpdateSiteRoleObject = {
 async function getUserWithRoles<T>(
   ctx: SiteContext,
   formData: FormData,
-  dbUpdate: (role: $Enums.SiteRole, userWithRoles: User, requestedRole?: SiteUser) => Promise<T>,
+  dbUpdate: (role: SiteRole, userWithRoles: User, requestedRole?: SiteUser) => Promise<T>,
 ) {
   const UpdateSiteRoleSchema = zfd.formData(UpdateSiteRoleObject);
   let payload;
@@ -138,7 +138,7 @@ export async function actionRevokeUserRole(ctx: SiteContext, formData: FormData)
     if (!requestedRole) {
       return { message: 'ok', info: 'user does not have specified role' };
     }
-    if (role === $Enums.SiteRole.ADMIN && ctx.user?.id === userWithRoles.id) {
+    if (role === SiteRole.ADMIN && ctx.user?.id === userWithRoles.id) {
       return data(
         { message: 'unprocessable content', error: 'cannot revoke your own admin permissions' },
         { status: 422 },

--- a/ee/sites/src/routes/$siteName.users/db.server.ts
+++ b/ee/sites/src/routes/$siteName.users/db.server.ts
@@ -1,9 +1,9 @@
 import { uuidv7 as uuid } from 'uuidv7';
-import type { Prisma, $Enums } from '@curvenote/scms-db';
+import type { SiteRole } from '@curvenote/scms-db';
 import { formatDate } from '@curvenote/common';
 import { getPrismaClient } from '@curvenote/scms-server';
 
-export async function dbAddSiteUserRole(siteId: string, userId: string, role: $Enums.SiteRole) {
+export async function dbAddSiteUserRole(siteId: string, userId: string, role: SiteRole) {
   const prisma = await getPrismaClient();
   const timestamp = formatDate();
   return prisma.siteUser.create({
@@ -19,7 +19,7 @@ export async function dbAddSiteUserRole(siteId: string, userId: string, role: $E
   });
 }
 
-export async function dbRemoveSiteUserRole(siteId: string, userId: string, role: $Enums.SiteRole) {
+export async function dbRemoveSiteUserRole(siteId: string, userId: string, role: SiteRole) {
   const prisma = await getPrismaClient();
   return prisma.siteUser.deleteMany({
     where: {

--- a/packages/scms-core/src/backend/loaders/jobs/types.ts
+++ b/packages/scms-core/src/backend/loaders/jobs/types.ts
@@ -1,16 +1,16 @@
-import type { $Enums } from '@curvenote/scms-db';
+import type { JobStatus } from '@curvenote/scms-db';
 
 export type CreateJob = {
   id: string;
   job_type: string;
   payload: Record<string, any>;
-  status?: $Enums.JobStatus;
+  status?: JobStatus;
   message?: string;
   results?: Record<string, any>;
 };
 
 export type UpdateJob = {
-  status: $Enums.JobStatus;
+  status: JobStatus;
   message?: string;
   results?: Record<string, any>;
 };

--- a/packages/scms-core/src/utils/analytics.ts
+++ b/packages/scms-core/src/utils/analytics.ts
@@ -1,5 +1,5 @@
 import { useMyUser } from '../providers/MyUserProvider.js';
-import { $Enums } from '@curvenote/scms-db';
+import { SystemRole } from '@curvenote/scms-db';
 
 export type EventOptions = {
   anonymous?: boolean;
@@ -9,12 +9,9 @@ export type EventOptions = {
 /**
  * Check if the current user has admin privileges
  */
-export function isAdmin(user?: { system_role: $Enums.SystemRole | string } | null): boolean {
+export function isAdmin(user?: { system_role: SystemRole | string } | null): boolean {
   if (!user) return false;
-  return (
-    user.system_role === $Enums.SystemRole.ADMIN ||
-    user.system_role === $Enums.SystemRole.PLATFORM_ADMIN
-  );
+  return user.system_role === SystemRole.ADMIN || user.system_role === SystemRole.PLATFORM_ADMIN;
 }
 
 /**

--- a/packages/scms-core/src/utils/status.ts
+++ b/packages/scms-core/src/utils/status.ts
@@ -1,4 +1,4 @@
-import { $Enums } from '@curvenote/scms-db';
+import { JobStatus } from '@curvenote/scms-db';
 
 export function getStatusButtonClasses(status: string | undefined) {
   if (!status)
@@ -29,26 +29,26 @@ export function getStatusButtonClasses(status: string | undefined) {
   }
 }
 
-export function getStatusDotClasses(status: $Enums.JobStatus | string) {
+export function getStatusDotClasses(status: JobStatus | string) {
   switch (status) {
     case 'INCOMPLETE':
     case 'DRAFT':
-    case $Enums.JobStatus.QUEUED:
+    case JobStatus.QUEUED:
     case 'RETRACTED':
     case 'UNPUBLISHED':
       return 'bg-neutral-400';
     case 'IN_REVIEW':
     case 'APPROVED':
       return 'bg-sky-500';
-    case $Enums.JobStatus.RUNNING:
+    case JobStatus.RUNNING:
     case 'PENDING':
     case 'PUBLISHING':
     case 'UNPUBLISHING':
       return 'bg-orange-500';
-    case $Enums.JobStatus.COMPLETED:
+    case JobStatus.COMPLETED:
     case 'PUBLISHED':
       return 'bg-green-500';
-    case $Enums.JobStatus.FAILED:
+    case JobStatus.FAILED:
     case 'REJECTED':
       return 'bg-red-500';
   }

--- a/packages/scms-server/src/api.schemas.ts
+++ b/packages/scms-server/src/api.schemas.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-named-as-default-member */
 import type { ZodError } from 'zod';
 import { z } from 'zod';
-import { $Enums } from '@curvenote/scms-db';
+import { JobStatus } from '@curvenote/scms-db';
 import type { ClientExtension, ServerExtension } from '@curvenote/scms-core';
 import { httpError, KnownJobTypes } from '@curvenote/scms-core';
 import { registerExtensionJobs } from './modules/extensions/jobs.js';
@@ -122,8 +122,8 @@ export async function createJobPostBodySchema(extensions: ClientExtension[]) {
 }
 
 export const UpdateJobPatchBodySchema = z.object({
-  status: z.nativeEnum($Enums.JobStatus, {
-    error: () => `status must be ${Object.values($Enums.JobStatus).join(', ')}`,
+  status: z.nativeEnum(JobStatus, {
+    error: () => `status must be ${Object.values(JobStatus).join(', ')}`,
   }),
   message: z
     .string({

--- a/packages/scms-server/src/backend/access.server.ts
+++ b/packages/scms-server/src/backend/access.server.ts
@@ -2,7 +2,7 @@ import { uuidv7 } from 'uuidv7';
 import { getPrismaClient } from './prisma.server.js';
 import { getUserScopesSet } from './scopes.helpers.server.js';
 import type { PrismaClient, Access, User } from '@curvenote/scms-db';
-import { $Enums } from '@curvenote/scms-db';
+import { ActivityType } from '@curvenote/scms-db';
 
 export interface AccessGrants {
   scopes: string[];
@@ -49,7 +49,7 @@ export async function createAccess(params: CreateAccessParams): Promise<Access> 
         date_created: now,
         date_modified: now,
         activity_by_id: params.ownerId,
-        activity_type: $Enums.ActivityType.ACCESS_GRANTED,
+        activity_type: ActivityType.ACCESS_GRANTED,
         access_id: access.id,
         user_id: params.receiverId,
       },
@@ -178,7 +178,7 @@ export async function revokeAccess(accessId: string, performedByUserId?: string)
         date_created: now,
         date_modified: now,
         activity_by_id: performedByUserId || access.owner_id, // The person who performed the revocation
-        activity_type: $Enums.ActivityType.ACCESS_REVOKED,
+        activity_type: ActivityType.ACCESS_REVOKED,
         access_id: accessId,
         user_id: access.receiver_id, // The user who had access revoked
       },

--- a/packages/scms-server/src/backend/context.site.server.ts
+++ b/packages/scms-server/src/backend/context.site.server.ts
@@ -5,7 +5,7 @@ import { getSitePublicKey } from './sign.private.server.js';
 import jwt from 'jsonwebtoken';
 import { withAppContext, withContext, Context } from './context.server.js';
 import { dbGetSite, formatSiteDTO, type DBO as SiteDBO } from './loaders/sites/get.server.js';
-import { $Enums } from '@curvenote/scms-db';
+import { SiteRole, SystemRole } from '@curvenote/scms-db';
 import type { AllTrackEvent } from '@curvenote/scms-core';
 import { hasSiteScope } from './roles.server.js';
 import { getUserScopesSet, userHasSiteScope } from './scopes.helpers.server.js';
@@ -156,7 +156,7 @@ export function addPublicSiteRoles(user: MyUserDBO, site: SiteDBO) {
       date_modified: timestamp,
       user_id: user.id,
       site_id: site.id,
-      role: $Enums.SiteRole.PUBLIC,
+      role: SiteRole.PUBLIC,
       site,
     });
   }
@@ -167,7 +167,7 @@ export function addPublicSiteRoles(user: MyUserDBO, site: SiteDBO) {
       date_modified: timestamp,
       user_id: user.id,
       site_id: site.id,
-      role: $Enums.SiteRole.UNRESTRICTED,
+      role: SiteRole.UNRESTRICTED,
       site,
     });
   }
@@ -195,12 +195,12 @@ export async function withAppSiteContext<T extends LoaderFunctionArgs | ActionFu
   addPublicSiteRoles(ctx.user, site);
 
   // User has no permission on the site
-  if (ctx.user.system_role !== $Enums.SystemRole.ADMIN && ctx.user.site_roles.length === 0) {
+  if (ctx.user.system_role !== SystemRole.ADMIN && ctx.user.site_roles.length === 0) {
     throw throwRedirectOr404(opts);
   }
   // User does not have a correct scope on the site
   if (
-    ctx.user.system_role !== $Enums.SystemRole.ADMIN &&
+    ctx.user.system_role !== SystemRole.ADMIN &&
     !scopes.find((scope) => userHasSiteScope(ctx.user, scope, site.id))
   ) {
     console.warn(
@@ -243,7 +243,7 @@ export async function withAPISiteContext<T extends LoaderFunctionArgs | ActionFu
     const token = authString.split('Bearer ')[1];
     try {
       await siteCtx.verifySiteToken(token);
-      if (scopes.find((scope) => hasSiteScope($Enums.SiteRole.PUBLIC, scope))) return siteCtx;
+      if (scopes.find((scope) => hasSiteScope(SiteRole.PUBLIC, scope))) return siteCtx;
     } catch (e: any) {
       console.error('Error verifying site token', e);
     }
@@ -256,7 +256,7 @@ export async function withAPISiteContext<T extends LoaderFunctionArgs | ActionFu
 
   addPublicSiteRoles(ctx.user, site);
   // User has no permission on the site
-  if (ctx.user.system_role !== $Enums.SystemRole.ADMIN && ctx.user.site_roles.length === 0) {
+  if (ctx.user.system_role !== SystemRole.ADMIN && ctx.user.site_roles.length === 0) {
     throw error404();
   }
   // User does not have a correct scope on the site

--- a/packages/scms-server/src/backend/context.work.server.ts
+++ b/packages/scms-server/src/backend/context.work.server.ts
@@ -10,7 +10,7 @@ import {
   getCanonicalOrLatestVersion,
 } from './loaders/works/get.server.js';
 import { getUserScopesSet, userHasWorkScope } from './scopes.helpers.server.js';
-import { $Enums } from '@curvenote/scms-db';
+import { SystemRole } from '@curvenote/scms-db';
 import type { MyUserDBO } from './db.types.js';
 import type { AllTrackEvent } from '@curvenote/scms-core';
 
@@ -148,7 +148,7 @@ export async function withAppWorkContext<T extends LoaderFunctionArgs | ActionFu
   // Check if user is disabled - treat as authentication failure
   if (ctx.user.disabled) throw error401();
   // User has no permission on the work
-  if (ctx.user.system_role !== $Enums.SystemRole.ADMIN && ctx.user.work_roles.length === 0) {
+  if (ctx.user.system_role !== SystemRole.ADMIN && ctx.user.work_roles.length === 0) {
     throw throwRedirectOr404(opts);
   }
   // User does not have a correct scope on the work

--- a/packages/scms-server/src/backend/db.server.ts
+++ b/packages/scms-server/src/backend/db.server.ts
@@ -8,8 +8,8 @@ import type {
   WorkDBO,
   WorkVersionDBO,
 } from './db.types.js';
-import { Prisma, SubmissionVersion, WorkVersion } from '@curvenote/scms-db';
-import { ActivityType, WorkRole } from '@curvenote/scms-db';
+import type { SubmissionVersion, WorkVersion } from '@curvenote/scms-db';
+import { Prisma, ActivityType, WorkRole } from '@curvenote/scms-db';
 import { error401, httpError, WorkContents, TrackEvent, scopes } from '@curvenote/scms-core';
 import { userHasScope } from './scopes.helpers.server.js';
 import { uuidv7 } from 'uuidv7';

--- a/packages/scms-server/src/backend/db.server.ts
+++ b/packages/scms-server/src/backend/db.server.ts
@@ -8,8 +8,8 @@ import type {
   WorkDBO,
   WorkVersionDBO,
 } from './db.types.js';
-import type { SubmissionVersion, WorkVersion, PrismaClient } from '@curvenote/scms-db';
-import { $Enums, Prisma } from '@curvenote/scms-db';
+import { Prisma, SubmissionVersion, WorkVersion } from '@curvenote/scms-db';
+import { ActivityType, WorkRole } from '@curvenote/scms-db';
 import { error401, httpError, WorkContents, TrackEvent, scopes } from '@curvenote/scms-core';
 import { userHasScope } from './scopes.helpers.server.js';
 import { uuidv7 } from 'uuidv7';
@@ -280,7 +280,7 @@ export async function $updateSubmissionVersion(
           },
         },
         status: data.status,
-        activity_type: $Enums.ActivityType.SUBMISSION_VERSION_STATUS_CHANGE,
+        activity_type: ActivityType.SUBMISSION_VERSION_STATUS_CHANGE,
       },
       include: {
         kind: true,
@@ -364,7 +364,7 @@ export async function updateSubmissionKind(
             id: updated.versions[0].id,
           },
         },
-        activity_type: $Enums.ActivityType.SUBMISSION_KIND_CHANGE,
+        activity_type: ActivityType.SUBMISSION_KIND_CHANGE,
         kind: {
           connect: {
             id: kindId ?? existing.kind.id,
@@ -441,7 +441,7 @@ export async function dbCreateDraftWork(
               date_created,
               date_modified: date_created,
               user_id: ctx.user.id,
-              role: $Enums.WorkRole.OWNER,
+              role: WorkRole.OWNER,
             },
           ],
         },
@@ -462,7 +462,7 @@ export async function dbCreateDraftWork(
             id: ctx.user.id,
           },
         },
-        activity_type: $Enums.ActivityType.NEW_WORK,
+        activity_type: ActivityType.NEW_WORK,
         work: {
           connect: {
             id: workId,
@@ -604,7 +604,7 @@ export async function dbCreateDraftSubmission(
             id: user.id,
           },
         },
-        activity_type: $Enums.ActivityType.NEW_SUBMISSION,
+        activity_type: ActivityType.NEW_SUBMISSION,
         submission: {
           connect: {
             id: submissionId,

--- a/packages/scms-server/src/backend/db.types.ts
+++ b/packages/scms-server/src/backend/db.types.ts
@@ -1,4 +1,4 @@
-import type { $Enums, Prisma } from '@curvenote/scms-db';
+import type { SiteRole, Prisma } from '@curvenote/scms-db';
 
 export type {
   Site as SiteDBO,
@@ -179,6 +179,6 @@ export type MystWorkVersion = CreateWorkVersion & {
 
 export type MyUserDBO = UserWithRolesDBO;
 
-export type UserSiteDBO = Prisma.SiteGetPayload<any> & { role: $Enums.SiteRole | null };
+export type UserSiteDBO = Prisma.SiteGetPayload<any> & { role: SiteRole | null };
 
 export type JobDBO = Prisma.JobGetPayload<any>;

--- a/packages/scms-server/src/backend/loaders/activity.server.ts
+++ b/packages/scms-server/src/backend/loaders/activity.server.ts
@@ -1,10 +1,10 @@
 import { uuidv7 } from 'uuidv7';
 import { getPrismaClient } from '../prisma.server.js';
-import type { $Enums } from '@curvenote/scms-db';
+import type { ActivityType } from '@curvenote/scms-db';
 
 export interface LogActivityData {
   activityBy: string;
-  activityType: $Enums.ActivityType;
+  activityType: ActivityType;
   submissionId?: string;
   submissionVersionId?: string;
   kindId?: string;

--- a/packages/scms-server/src/backend/loaders/jobs/count.server.ts
+++ b/packages/scms-server/src/backend/loaders/jobs/count.server.ts
@@ -1,8 +1,8 @@
-import type { $Enums, Prisma } from '@curvenote/scms-db';
+import type { JobStatus, Prisma } from '@curvenote/scms-db';
 import type { Context } from '../../context.server.js';
 import { getPrismaClient } from '../../prisma.server.js';
 
-async function dbCountJobs(siteId: string, types: string[], statuses?: $Enums.JobStatus[]) {
+async function dbCountJobs(siteId: string, types: string[], statuses?: JobStatus[]) {
   const where: Prisma.JobWhereInput = {
     job_type: {
       in: types,
@@ -27,7 +27,7 @@ export default async function (
   ctx: Context,
   siteId: string,
   types: string[],
-  statuses?: $Enums.JobStatus[],
+  statuses?: JobStatus[],
 ) {
   return await dbCountJobs(siteId, types, statuses);
 }

--- a/packages/scms-server/src/backend/loaders/jobs/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/jobs/get.server.ts
@@ -1,4 +1,4 @@
-import { $Enums } from '@curvenote/scms-db';
+import { JobStatus } from '@curvenote/scms-db';
 import type { Context } from '@curvenote/scms-core';
 import type { JobDTO } from '@curvenote/common';
 import { getPrismaClient } from '../../prisma.server.js';
@@ -20,7 +20,7 @@ export function formatJobDTO(ctx: Context, job: DBO): JobDTO {
   let signature: string | undefined;
   if (
     job.job_type === 'CHECK' &&
-    job.status === $Enums.JobStatus.COMPLETED &&
+    job.status === JobStatus.COMPLETED &&
     payload.journal &&
     results?.submissionId
   ) {

--- a/packages/scms-server/src/backend/loaders/jobs/handlers/db.server.ts
+++ b/packages/scms-server/src/backend/loaders/jobs/handlers/db.server.ts
@@ -1,4 +1,4 @@
-import { $Enums, Prisma } from '@curvenote/scms-db';
+import { JobStatus, Prisma } from '@curvenote/scms-db';
 import { getPrismaClient } from '../../../prisma.server.js';
 import { formatDate } from '@curvenote/common';
 import type { CreateJob, UpdateJob } from '@curvenote/scms-core';
@@ -12,7 +12,7 @@ export async function dbCreateJob({ id, job_type, payload, status, results, mess
       date_created,
       date_modified: date_created,
       job_type,
-      status: status ?? $Enums.JobStatus.QUEUED,
+      status: status ?? JobStatus.QUEUED,
       payload: payload === null ? Prisma.JsonNull : payload,
       results: results == null ? Prisma.JsonNull : results,
       messages: message ? [message] : [],

--- a/packages/scms-server/src/backend/loaders/jobs/handlers/publish.server.ts
+++ b/packages/scms-server/src/backend/loaders/jobs/handlers/publish.server.ts
@@ -1,6 +1,6 @@
 import type { Context } from '../../../context.server.js';
 import type { CreateJob, SubmissionPublishedEmailProps } from '@curvenote/scms-core';
-import { $Enums } from '@curvenote/scms-db';
+import { JobStatus } from '@curvenote/scms-db';
 import { dbCreateJob, dbUpdateJob } from './db.server.js';
 import type { StorageBackend } from '../../../storage/backend.server.js';
 import { createFolder } from '../../../storage/folder.server.js';
@@ -52,7 +52,7 @@ export async function publishHandler(
     throw httpError(500, 'Storage backend is required for publish operations');
   }
 
-  const created = await dbCreateJob({ ...data, status: $Enums.JobStatus.RUNNING });
+  const created = await dbCreateJob({ ...data, status: JobStatus.RUNNING });
   // currently implemented as a long running task in the job response handler
   // must complete before a response is sent, could be moved to another endpoint if needed
   // as we create a job to start with clients/callers can fire-and-forget if they choose
@@ -68,7 +68,7 @@ export async function publishHandler(
     const message = `Folder does not exist ${cdn}/${key}`;
     console.warn(message);
     await dbUpdateJob(created.id, {
-      status: $Enums.JobStatus.FAILED,
+      status: JobStatus.FAILED,
       message,
       results: { files_transfered: false },
     });
@@ -87,7 +87,7 @@ export async function publishHandler(
     await folder.copy({ bucket: KnownBuckets.pub, path: key });
     results = { files_transfered: true };
     await dbUpdateJob(created.id, {
-      status: $Enums.JobStatus.RUNNING,
+      status: JobStatus.RUNNING,
       message: 'Files transferred to new location',
       results,
     });
@@ -95,7 +95,7 @@ export async function publishHandler(
     const message = 'Error copying folder';
     console.log(message, error);
     await dbUpdateJob(created.id, {
-      status: $Enums.JobStatus.FAILED,
+      status: JobStatus.FAILED,
       message,
       results,
     });
@@ -122,7 +122,7 @@ export async function publishHandler(
     const message = 'Error updating submission status';
     console.log(message, error);
     await dbUpdateJob(created.id, {
-      status: $Enums.JobStatus.FAILED,
+      status: JobStatus.FAILED,
       message,
       results,
     });
@@ -190,7 +190,7 @@ export async function publishHandler(
   }
   results = { ...results, submission_updated: true, date_published_updated: !!date_published };
   const job = await dbUpdateJob(created.id, {
-    status: $Enums.JobStatus.COMPLETED,
+    status: JobStatus.COMPLETED,
     message: 'Publishing complete.',
     results,
   });

--- a/packages/scms-server/src/backend/loaders/jobs/handlers/unpublish.server.ts
+++ b/packages/scms-server/src/backend/loaders/jobs/handlers/unpublish.server.ts
@@ -3,7 +3,7 @@ import { dbCreateJob, dbUpdateJob } from './db.server.js';
 import { validate } from '../../../../api.schemas.js';
 import type { PublishJobResults } from './schemas.server.js';
 import { CreatePublishJobPayloadSchema } from './schemas.server.js';
-import { $Enums } from '@curvenote/scms-db';
+import { JobStatus } from '@curvenote/scms-db';
 import type { StorageBackend } from '../../../storage/index.js';
 import { KnownBuckets } from '../../../storage/constants.server.js';
 import { httpError } from '@curvenote/scms-core';
@@ -30,7 +30,7 @@ export async function unpublishHandler(
     throw httpError(500, 'Storage backend is required for unpublish operations');
   }
 
-  const created = await dbCreateJob({ ...data, status: $Enums.JobStatus.RUNNING });
+  const created = await dbCreateJob({ ...data, status: JobStatus.RUNNING });
 
   // setup storage
   const sourceBucket = storageBackend.knownBucketFromCDN(cdn);
@@ -44,7 +44,7 @@ export async function unpublishHandler(
     const pubExists = await pubFolder.exists();
     if (pubExists) {
       await dbUpdateJob(created.id, {
-        status: $Enums.JobStatus.RUNNING,
+        status: JobStatus.RUNNING,
         message: 'Found the work version in the pub bucket',
         results,
       });
@@ -58,7 +58,7 @@ export async function unpublishHandler(
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (error) {
           return dbUpdateJob(created.id, {
-            status: $Enums.JobStatus.FAILED,
+            status: JobStatus.FAILED,
             message: 'Error removing public copy',
             results,
           });
@@ -70,7 +70,7 @@ export async function unpublishHandler(
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (error) {
           return dbUpdateJob(created.id, {
-            status: $Enums.JobStatus.FAILED,
+            status: JobStatus.FAILED,
             message: 'Error moving public copy to prv bucket',
             results,
           });
@@ -78,13 +78,13 @@ export async function unpublishHandler(
       }
       results.files_transfered = true;
       await dbUpdateJob(created.id, {
-        status: $Enums.JobStatus.RUNNING,
+        status: JobStatus.RUNNING,
         message: 'Files transferred to new location',
         results,
       });
     } else {
       await dbUpdateJob(created.id, {
-        status: $Enums.JobStatus.RUNNING,
+        status: JobStatus.RUNNING,
         message: 'No work version found in the pub bucket',
         results,
       });
@@ -95,7 +95,7 @@ export async function unpublishHandler(
         const message =
           'Cannot Unpublish - No copy of the work version exists in the pub or prv bucket';
         await dbUpdateJob(created.id, {
-          status: $Enums.JobStatus.FAILED,
+          status: JobStatus.FAILED,
           message,
           results,
         });
@@ -103,7 +103,7 @@ export async function unpublishHandler(
       }
       results.files_transfered = true;
       await dbUpdateJob(created.id, {
-        status: $Enums.JobStatus.RUNNING,
+        status: JobStatus.RUNNING,
         message: 'Work version found in prv bucket',
         results,
       });
@@ -128,7 +128,7 @@ export async function unpublishHandler(
     const message = 'Error updating submission status';
     console.log(message, error);
     await dbUpdateJob(created.id, {
-      status: $Enums.JobStatus.FAILED,
+      status: JobStatus.FAILED,
       message,
       results,
     });
@@ -153,7 +153,7 @@ export async function unpublishHandler(
 
   results = { ...results, submission_updated: true };
   return dbUpdateJob(created.id, {
-    status: $Enums.JobStatus.COMPLETED,
+    status: JobStatus.COMPLETED,
     message: 'Unpublishing complete.',
     results,
   });

--- a/packages/scms-server/src/backend/loaders/jobs/handlers/utils.server.ts
+++ b/packages/scms-server/src/backend/loaders/jobs/handlers/utils.server.ts
@@ -1,4 +1,4 @@
-import { $Enums } from '@curvenote/scms-db';
+import { JobStatus } from '@curvenote/scms-db';
 import { dbUpdateJob } from './db.server.js';
 import { error401, httpError, site } from '@curvenote/scms-core';
 import { getPrismaClient } from '../../../prisma.server.js';
@@ -31,7 +31,7 @@ export async function updateCdnOnWorkVersion(
     if (!wv) throw Error('Work Version not updated');
     results = { ...results, work_version_updated: true, cdn: newCdn };
     await dbUpdateJob(jobId, {
-      status: $Enums.JobStatus.RUNNING,
+      status: JobStatus.RUNNING,
       message: 'Files transferred to new location',
       results,
     });
@@ -39,7 +39,7 @@ export async function updateCdnOnWorkVersion(
     const message = 'Error updating work version';
     console.log(message, error);
     await dbUpdateJob(jobId, {
-      status: $Enums.JobStatus.FAILED,
+      status: JobStatus.FAILED,
       message,
       results,
     });

--- a/packages/scms-server/src/backend/loaders/jobs/list.server.ts
+++ b/packages/scms-server/src/backend/loaders/jobs/list.server.ts
@@ -1,4 +1,4 @@
-import type { $Enums, Prisma } from '@curvenote/scms-db';
+import type { JobStatus, Prisma } from '@curvenote/scms-db';
 import type { Context } from '../../context.server.js';
 import { formatJobDTO } from './get.server.js';
 import { getPrismaClient } from '../../prisma.server.js';
@@ -6,7 +6,7 @@ import { getPrismaClient } from '../../prisma.server.js';
 async function dbListJobs(
   siteId: string,
   types: string[],
-  statuses?: $Enums.JobStatus[],
+  statuses?: JobStatus[],
   take?: number,
   skip?: number,
 ) {
@@ -41,7 +41,7 @@ export default async function (
   ctx: Context,
   siteId: string,
   types: string[],
-  statuses?: $Enums.JobStatus[],
+  statuses?: JobStatus[],
   take?: number,
   skip?: number,
 ) {

--- a/packages/scms-server/src/backend/loaders/sites/submissions/create.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/create.server.ts
@@ -4,7 +4,7 @@ import { getPrismaClient } from '../../../prisma.server.js';
 import { formatSubmissionDTO } from './get.server.js';
 import { formatDate } from '@curvenote/common';
 import type { UserDBO } from '../../../db.types.js';
-import { $Enums } from '@curvenote/scms-db';
+import { ActivityType } from '@curvenote/scms-db';
 import { uuidv7 as uuid } from 'uuidv7';
 import type { SiteContext } from '../../../context.site.server.js';
 import { SlackEventType } from '../../../services/slack.server.js';
@@ -144,7 +144,7 @@ export async function dbCreateNewSubmission(
             id: sv.id,
           },
         },
-        activity_type: $Enums.ActivityType.NEW_SUBMISSION,
+        activity_type: ActivityType.NEW_SUBMISSION,
         status: sv.status,
         work_version: {
           connect: {

--- a/packages/scms-server/src/backend/loaders/sites/submissions/slugs.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/slugs.server.ts
@@ -1,5 +1,5 @@
 import type { Prisma } from '@curvenote/scms-db';
-import { $Enums } from '@curvenote/scms-db';
+import { SlugStrategy } from '@curvenote/scms-db';
 import type { SiteContext } from '../../../context.site.server.js';
 import { userHasScope } from '../../../scopes.helpers.server.js';
 import { error401, scopes } from '@curvenote/scms-core';
@@ -59,7 +59,7 @@ export async function apply(
   if (!userHasScope(ctx.user, scopes.site.submissions.update, ctx.site.name))
     return error401('Unauthorized - cannot update slug');
   const doi = submissionVersion.work_version.doi ?? submissionVersion.submission.work?.doi;
-  if (ctx.site.slug_strategy === $Enums.SlugStrategy.NONE || doi == null) return null;
+  if (ctx.site.slug_strategy === SlugStrategy.NONE || doi == null) return null;
   const numSlugs = await dbCountSlugsForSubmission(submissionVersion.submission.id);
   if (numSlugs > 0) return null;
 

--- a/packages/scms-server/src/backend/loaders/sites/submissions/versions/create.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/versions/create.server.ts
@@ -3,7 +3,7 @@ import { error401, TrackEvent } from '@curvenote/scms-core';
 import { getPrismaClient } from '../../../../prisma.server.js';
 import { formatSubmissionVersionDTO } from './get.server.js';
 import { formatDate } from '@curvenote/common';
-import { $Enums } from '@curvenote/scms-db';
+import { ActivityType } from '@curvenote/scms-db';
 import { uuidv7 as uuid } from 'uuidv7';
 import type { SiteContext } from '../../../../context.site.server.js';
 import { dbGetWorkflowForSubmission } from '../../../../../workflow/utils.server.js';
@@ -96,7 +96,7 @@ export async function dbCreateNewSubmissionVersionOnExistingSubmission(
             id: sv.id,
           },
         },
-        activity_type: $Enums.ActivityType.SUBMISSION_VERSION_ADDED,
+        activity_type: ActivityType.SUBMISSION_VERSION_ADDED,
         status: sv.status,
         work_version: {
           connect: {

--- a/packages/scms-server/src/backend/loaders/sites/submissions/versions/transition.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/versions/transition.server.ts
@@ -1,4 +1,4 @@
-import { $Enums } from '@curvenote/scms-db';
+import { ActivityType } from '@curvenote/scms-db';
 import {
   error401,
   error403,
@@ -136,7 +136,7 @@ async function startJobBasedTransition(
         date_created: timestamp,
         date_modified: timestamp,
         activity_by_id: ctx.user!.id,
-        activity_type: $Enums.ActivityType.SUBMISSION_VERSION_TRANSITION_STARTED,
+        activity_type: ActivityType.SUBMISSION_VERSION_TRANSITION_STARTED,
         submission_id: existing.submission.id,
         submission_version_id: existing.id,
         transition,
@@ -220,7 +220,7 @@ async function performSimpleTransition(
         date_created: timestamp,
         date_modified: timestamp,
         activity_by_id: ctx.user!.id,
-        activity_type: $Enums.ActivityType.SUBMISSION_VERSION_STATUS_CHANGE,
+        activity_type: ActivityType.SUBMISSION_VERSION_STATUS_CHANGE,
         submission_id: existing.submission.id,
         submission_version_id: existing.id,
         status: targetStateName,

--- a/packages/scms-server/src/backend/loaders/sites/update.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/update.server.ts
@@ -1,7 +1,7 @@
 import { uuidv7 as uuid } from 'uuidv7';
 import { formatDate } from '@curvenote/common';
 import { getPrismaClient } from '../../prisma.server.js';
-import { $Enums } from '@curvenote/scms-db';
+import { ActivityType } from '@curvenote/scms-db';
 import type { SiteContext } from '../../context.site.server.js';
 import { error401, error404 } from '@curvenote/scms-core';
 import { formatSiteWithContentDTO } from './get.server.js';
@@ -52,7 +52,7 @@ export async function dbUpdateSiteContent(userId: string, name: string, content:
             id: updated.id,
           },
         },
-        activity_type: $Enums.ActivityType.SITE_CONTENT_UPDATED,
+        activity_type: ActivityType.SITE_CONTENT_UPDATED,
       },
     });
     return updated.content?.versions[0];

--- a/packages/scms-server/src/backend/loaders/works/create.server.ts
+++ b/packages/scms-server/src/backend/loaders/works/create.server.ts
@@ -15,7 +15,7 @@ import { getSignedCDNQuery } from '../../sign.private.server.js';
 import { error401, ensureTrailingSlash, WorkContents, TrackEvent } from '@curvenote/scms-core';
 import { formatWorkDTO } from './get.server.js';
 import type { Prisma } from '@curvenote/scms-db';
-import { $Enums } from '@curvenote/scms-db';
+import { WorkRole, ActivityType } from '@curvenote/scms-db';
 
 type PageLoader = NonNullable<Awaited<ReturnType<typeof getPage>>>;
 
@@ -133,7 +133,7 @@ export async function dbCreateWorkAndVersion(
                   id: owner.id,
                 },
               },
-              role: $Enums.WorkRole.OWNER,
+              role: WorkRole.OWNER,
             },
           ],
         },
@@ -155,7 +155,7 @@ export async function dbCreateWorkAndVersion(
             id: owner.id,
           },
         },
-        activity_type: $Enums.ActivityType.NEW_WORK,
+        activity_type: ActivityType.NEW_WORK,
         work: {
           connect: {
             id: workId,

--- a/packages/scms-server/src/backend/loaders/works/versions/create.server.ts
+++ b/packages/scms-server/src/backend/loaders/works/versions/create.server.ts
@@ -6,7 +6,7 @@ import { getPrismaClient } from '../../../prisma.server.js';
 import { error401, error404, site } from '@curvenote/scms-core';
 import { dbGetWorkForUser, formatWorkDTO, getWorkFromSubmission } from '../get.server.js';
 import { getCreateWorkVersionDataFromMyst } from '../create.server.js';
-import { $Enums } from '@curvenote/scms-db';
+import { ActivityType } from '@curvenote/scms-db';
 
 export async function dbCreateWorkVersionAndUpdateWork(
   workId: string,
@@ -55,7 +55,7 @@ export async function dbCreateWorkVersionAndUpdateWork(
         id: uuid(),
         date_created,
         date_modified: date_created,
-        activity_type: $Enums.ActivityType.WORK_VERSION_ADDED,
+        activity_type: ActivityType.WORK_VERSION_ADDED,
         activity_by: {
           connect: {
             id: userId,

--- a/packages/scms-server/src/backend/roles.server.ts
+++ b/packages/scms-server/src/backend/roles.server.ts
@@ -1,16 +1,16 @@
-import { $Enums } from '@curvenote/scms-db';
+import { SystemRole, SiteRole, WorkRole } from '@curvenote/scms-db';
 import { system, site, work, app } from '@curvenote/scms-core';
 
-const SYSTEM_ROLES: Record<$Enums.SystemRole, Set<string>> = {
-  [$Enums.SystemRole.SERVICE]: new Set([system.admin]), // in future service accounts will have limited scope, that's the whole point
-  [$Enums.SystemRole.ADMIN]: new Set([system.admin]),
-  [$Enums.SystemRole.PLATFORM_ADMIN]: new Set([app.platform.admin]),
-  [$Enums.SystemRole.USER]: new Set([work.create, work.list]),
-  [$Enums.SystemRole.ANON]: new Set([]),
+const SYSTEM_ROLES: Record<SystemRole, Set<string>> = {
+  [SystemRole.SERVICE]: new Set([system.admin]), // in future service accounts will have limited scope, that's the whole point
+  [SystemRole.ADMIN]: new Set([system.admin]),
+  [SystemRole.PLATFORM_ADMIN]: new Set([app.platform.admin]),
+  [SystemRole.USER]: new Set([work.create, work.list]),
+  [SystemRole.ANON]: new Set([]),
 };
 
-const SITE_ROLES: Record<$Enums.SiteRole, Set<string>> = {
-  [$Enums.SiteRole.ADMIN]: new Set([
+const SITE_ROLES: Record<SiteRole, Set<string>> = {
+  [SiteRole.ADMIN]: new Set([
     site.list,
     site.read,
     site.update,
@@ -41,7 +41,7 @@ const SITE_ROLES: Record<$Enums.SiteRole, Set<string>> = {
     site.users.update,
     site.users.delete,
   ]),
-  [$Enums.SiteRole.EDITOR]: new Set([
+  [SiteRole.EDITOR]: new Set([
     site.list,
     site.read,
     site.details,
@@ -57,7 +57,7 @@ const SITE_ROLES: Record<$Enums.SiteRole, Set<string>> = {
     site.users.list,
     site.users.read,
   ]),
-  [$Enums.SiteRole.SUBMITTER]: new Set([
+  [SiteRole.SUBMITTER]: new Set([
     site.list,
     site.read,
     site.details,
@@ -70,10 +70,10 @@ const SITE_ROLES: Record<$Enums.SiteRole, Set<string>> = {
     site.submissions.create,
     site.submissions.versions.create,
   ]),
-  [$Enums.SiteRole.REVIEWER]: new Set([site.read]),
-  [$Enums.SiteRole.AUTHOR]: new Set([site.read]),
-  [$Enums.SiteRole.PUBLIC]: new Set([site.read]),
-  [$Enums.SiteRole.UNRESTRICTED]: new Set([
+  [SiteRole.REVIEWER]: new Set([site.read]),
+  [SiteRole.AUTHOR]: new Set([site.read]),
+  [SiteRole.PUBLIC]: new Set([site.read]),
+  [SiteRole.UNRESTRICTED]: new Set([
     site.read,
     site.kinds.list,
     site.kinds.read,
@@ -83,8 +83,8 @@ const SITE_ROLES: Record<$Enums.SiteRole, Set<string>> = {
   ]),
 };
 
-const WORK_ROLES: Record<$Enums.WorkRole, Set<string>> = {
-  [$Enums.WorkRole.OWNER]: new Set([
+const WORK_ROLES: Record<WorkRole, Set<string>> = {
+  [WorkRole.OWNER]: new Set([
     work.read,
     work.update,
     work.submissions.list,
@@ -98,7 +98,7 @@ const WORK_ROLES: Record<$Enums.WorkRole, Set<string>> = {
     work.checks.read,
     work.checks.dispatch,
   ]),
-  [$Enums.WorkRole.CONTRIBUTOR]: new Set([
+  [WorkRole.CONTRIBUTOR]: new Set([
     work.read,
     work.update,
     work.submissions.list,
@@ -109,33 +109,33 @@ const WORK_ROLES: Record<$Enums.WorkRole, Set<string>> = {
     work.users.read,
     work.checks.read,
   ]),
-  [$Enums.WorkRole.VIEWER]: new Set([work.read]),
+  [WorkRole.VIEWER]: new Set([work.read]),
 };
 
-export function hasScopeViaSystemRole(role: $Enums.SystemRole, scope: string): boolean {
+export function hasScopeViaSystemRole(role: SystemRole, scope: string): boolean {
   return SYSTEM_ROLES[role]?.has(scope) ?? false;
 }
 
-export function hasSiteScope(role: $Enums.SiteRole, scope: string): boolean {
+export function hasSiteScope(role: SiteRole, scope: string): boolean {
   const s = scope;
   const has = SITE_ROLES[role]?.has(s) ?? false;
   return has;
 }
 
-export function hasWorkScope(role: $Enums.WorkRole, scope: string): boolean {
+export function hasWorkScope(role: WorkRole, scope: string): boolean {
   const s = scope;
   const has = WORK_ROLES[role]?.has(s) ?? false;
   return has;
 }
 
-export function getSystemRoleScopes(role: $Enums.SystemRole): string[] {
+export function getSystemRoleScopes(role: SystemRole): string[] {
   return Array.from(SYSTEM_ROLES[role]);
 }
 
-export function getSiteRoleScopes(role: $Enums.SiteRole): string[] {
+export function getSiteRoleScopes(role: SiteRole): string[] {
   return Array.from(SITE_ROLES[role]);
 }
 
-export function getWorkRoleScopes(role: $Enums.WorkRole): string[] {
+export function getWorkRoleScopes(role: WorkRole): string[] {
   return Array.from(WORK_ROLES[role]);
 }

--- a/packages/scms-server/src/backend/scopes.helpers.server.spec.ts
+++ b/packages/scms-server/src/backend/scopes.helpers.server.spec.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, test, expect } from 'vitest';
-import { $Enums } from '@curvenote/scms-db';
+import { SiteRole, SystemRole } from '@curvenote/scms-db';
 import { userHasScope, userHasScopes } from './scopes.helpers.server.js';
 import { site } from '@curvenote/scms-core';
 
@@ -19,7 +19,7 @@ function roleWithScopes(scopes: string[]) {
   return { role: { scopes } } as any;
 }
 
-function siteRole(siteName: string, role: $Enums.SiteRole) {
+function siteRole(siteName: string, role: SiteRole) {
   return { site: { name: siteName }, role } as any;
 }
 
@@ -29,7 +29,7 @@ describe('userHasScope', () => {
   });
 
   test('returns true for system admin regardless of requested scope', () => {
-    const user = createUser({ system_role: $Enums.SystemRole.ADMIN });
+    const user = createUser({ system_role: SystemRole.ADMIN });
     expect(userHasScope(user, 'anything')).toBe(true);
   });
 
@@ -58,14 +58,14 @@ describe('userHasScope', () => {
 
   test('returns false for site: scope when site_roles do not match site name', () => {
     const user = createUser({
-      site_roles: [siteRole('othersite', $Enums.SiteRole.ADMIN)],
+      site_roles: [siteRole('othersite', SiteRole.ADMIN)],
     });
     expect(userHasScope(user, `${site.read}:mysite`)).toBe(false);
   });
 
   test('returns true for site: scope (inferred) when matching site role has raw scope', () => {
     const user = createUser({
-      site_roles: [siteRole('mysite', $Enums.SiteRole.EDITOR)],
+      site_roles: [siteRole('mysite', SiteRole.EDITOR)],
     });
     expect(userHasScope(user, `${site.read}:mysite`)).toBe(true);
   });
@@ -73,21 +73,21 @@ describe('userHasScope', () => {
   test('returns false for site: scope (inferred) when matching site role lacks raw scope', () => {
     const user = createUser({
       // REVIEWER only has site.read, so choose a scope they don't have, e.g., site.update
-      site_roles: [siteRole('mysite', $Enums.SiteRole.REVIEWER)],
+      site_roles: [siteRole('mysite', SiteRole.REVIEWER)],
     });
     expect(userHasScope(user, `${site.update}:mysite`)).toBe(false);
   });
 
   test('handles malformed site: scopes (no site suffix) by returning false', () => {
     const user = createUser({
-      site_roles: [siteRole('mysite', $Enums.SiteRole.EDITOR)],
+      site_roles: [siteRole('mysite', SiteRole.EDITOR)],
     });
     expect(userHasScope(user, site.read)).toBe(false);
   });
 
   test('returns true for site override branch when siteName is provided and raw scope matches', () => {
     const user = createUser({
-      site_roles: [siteRole('mysite', $Enums.SiteRole.EDITOR)],
+      site_roles: [siteRole('mysite', SiteRole.EDITOR)],
     });
     // siteName override provided; scope is treated as raw
     expect(userHasScope(user, site.read, 'mysite')).toBe(true);
@@ -95,14 +95,14 @@ describe('userHasScope', () => {
 
   test('returns false for site override branch when raw scope does not match', () => {
     const user = createUser({
-      site_roles: [siteRole('mysite', $Enums.SiteRole.REVIEWER)],
+      site_roles: [siteRole('mysite', SiteRole.REVIEWER)],
     });
     expect(userHasScope(user, site.update, 'mysite')).toBe(false);
   });
 
   test('does not strip suffix in override branch; passing suffixed scope with override returns false', () => {
     const user = createUser({
-      site_roles: [siteRole('mysite', $Enums.SiteRole.EDITOR)],
+      site_roles: [siteRole('mysite', SiteRole.EDITOR)],
     });
     // We pass a suffixed scope while also providing a siteName; code treats scope as raw
     expect(userHasScope(user, `${site.read}:othersite`, 'mysite')).toBe(false);
@@ -113,7 +113,7 @@ describe('userHasScopes', () => {
   test('returns true when all requested scopes are satisfied', () => {
     const user = createUser({
       roles: [roleWithScopes(['x', 'y'])],
-      site_roles: [siteRole('mysite', $Enums.SiteRole.EDITOR)],
+      site_roles: [siteRole('mysite', SiteRole.EDITOR)],
     });
     expect(userHasScopes(user, ['x', `${site.read}:mysite`])).toBe(true);
   });

--- a/packages/scms-server/src/backend/scopes.helpers.server.ts
+++ b/packages/scms-server/src/backend/scopes.helpers.server.ts
@@ -1,4 +1,4 @@
-import type { $Enums } from '@curvenote/scms-db';
+import type { WorkRole } from '@curvenote/scms-db';
 import type { UserDBO, UserWithRolesDBO } from './db.types.js';
 import { system } from '@curvenote/scms-core';
 import {
@@ -133,7 +133,7 @@ export function getUserScopesSet(user: UserWithRolesDBO): Set<string> {
 export function userHasWorkScope(
   user:
     | (UserDBO & {
-        work_roles: { work_id: string; user_id: string; role: $Enums.WorkRole }[];
+        work_roles: { work_id: string; user_id: string; role: WorkRole }[];
       })
     | undefined,
   scope: string,

--- a/platform/scms/app/routes/api/v1.jobs.$jobId.tsx
+++ b/platform/scms/app/routes/api/v1.jobs.$jobId.tsx
@@ -7,7 +7,7 @@ import {
   validate,
 } from '@curvenote/scms-server';
 import { error401, error404, httpError } from '@curvenote/scms-core';
-import { $Enums } from '@curvenote/scms-db';
+import { JobStatus } from '@curvenote/scms-db';
 
 export async function loader(args: Route.LoaderArgs) {
   const ctx = await withContext(args);
@@ -31,7 +31,7 @@ export async function action(args: Route.ActionArgs) {
 
   if (!job) throw error404(`Job not found ${jobId}`);
 
-  if (job.status === $Enums.JobStatus.COMPLETED || job.status === $Enums.JobStatus.FAILED) {
+  if (job.status === JobStatus.COMPLETED || job.status === JobStatus.FAILED) {
     const statusText = `Cannot update ${job.status} job`;
     throw httpError(400, statusText);
   }

--- a/platform/scms/app/routes/api/v1.sites.$siteName.submissions.$submissionId.status.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.submissions.$submissionId.status.tsx
@@ -9,7 +9,7 @@ import {
 } from '@curvenote/scms-server';
 import { type ActionFunctionArgs } from 'react-router';
 import { z } from 'zod';
-import { $Enums } from '@curvenote/scms-db';
+import { JobStatus } from '@curvenote/scms-db';
 import { site, error401 } from '@curvenote/scms-core';
 import { extensions } from '../../extensions/server';
 
@@ -45,7 +45,7 @@ export async function action(args: ActionFunctionArgs) {
   });
 
   // The handshake token must also declare a running jobId that corresponds to the submission in the path
-  if (!job || job.status !== $Enums.JobStatus.RUNNING) {
+  if (!job || job.status !== JobStatus.RUNNING) {
     throw error401('Unauthorized');
   }
   if (!job.SubmissionVersion || job.SubmissionVersion.submission.id !== ctx.submission.id) {

--- a/platform/scms/app/routes/app/discovery.people/UserCard.tsx
+++ b/platform/scms/app/routes/app/discovery.people/UserCard.tsx
@@ -1,6 +1,6 @@
 import { primitives, ui, formatDate } from '@curvenote/scms-core';
 import { Star, Mail, Building2 } from 'lucide-react';
-import type { $Enums } from '@curvenote/scms-db';
+import type { SystemRole } from '@curvenote/scms-db';
 
 type User = {
   id: string;
@@ -9,7 +9,7 @@ type User = {
   username: string | null;
   primaryProvider: string | null;
   display_name: string | null;
-  system_role: $Enums.SystemRole;
+  system_role: SystemRole;
   site_roles: Array<{
     id: string;
     date_created: string;

--- a/platform/scms/app/routes/app/platform.users/db.server.ts
+++ b/platform/scms/app/routes/app/platform.users/db.server.ts
@@ -1,6 +1,6 @@
 import { getPrismaClient } from '@curvenote/scms-server';
 import { KnownResendEvents } from '@curvenote/scms-core';
-import { $Enums } from '@curvenote/scms-db';
+import { ActivityType } from '@curvenote/scms-db';
 import { uuidv7 as uuid } from 'uuidv7';
 import type { SecureContext } from '@curvenote/scms-server';
 
@@ -113,8 +113,8 @@ export async function dbToggleUserDisabled(
         date_modified: dateCreated,
         activity_by_id: activityByUserId,
         activity_type: disabled
-          ? $Enums.ActivityType.USER_DISABLED
-          : $Enums.ActivityType.USER_ENABLED,
+          ? ActivityType.USER_DISABLED
+          : ActivityType.USER_ENABLED,
         user_id: id,
         status: disabled ? 'DISABLED' : 'ENABLED',
       },
@@ -144,7 +144,7 @@ export async function dbApproveUser(userId: string, activityByUserId: string) {
         date_created: dateCreated,
         date_modified: dateCreated,
         activity_by_id: activityByUserId,
-        activity_type: $Enums.ActivityType.USER_APPROVED,
+        activity_type: ActivityType.USER_APPROVED,
         user_id: userId,
         status: 'APPROVED',
       },
@@ -175,7 +175,7 @@ export async function dbRejectUser(userId: string, activityByUserId: string) {
         date_created: dateCreated,
         date_modified: dateCreated,
         activity_by_id: activityByUserId,
-        activity_type: $Enums.ActivityType.USER_REJECTED,
+        activity_type: ActivityType.USER_REJECTED,
         user_id: userId,
         status: 'REJECTED',
       },

--- a/platform/scms/app/routes/app/platform.users/db.server.ts
+++ b/platform/scms/app/routes/app/platform.users/db.server.ts
@@ -112,9 +112,7 @@ export async function dbToggleUserDisabled(
         date_created: dateCreated,
         date_modified: dateCreated,
         activity_by_id: activityByUserId,
-        activity_type: disabled
-          ? ActivityType.USER_DISABLED
-          : ActivityType.USER_ENABLED,
+        activity_type: disabled ? ActivityType.USER_DISABLED : ActivityType.USER_ENABLED,
         user_id: id,
         status: disabled ? 'DISABLED' : 'ENABLED',
       },

--- a/platform/scms/app/routes/app/system.migrate/db.server.ts
+++ b/platform/scms/app/routes/app/system.migrate/db.server.ts
@@ -1,4 +1,4 @@
-import { $Enums } from '@curvenote/scms-db';
+import { WorkRole } from '@curvenote/scms-db';
 import { uuidv7 } from 'uuidv7';
 import { getPrismaClient } from '@curvenote/scms-server';
 
@@ -98,7 +98,7 @@ export async function dbCreateWorkUsers(
       date_modified: work.date_created,
       work_id: work.id,
       user_id: work.created_by_id,
-      role: $Enums.WorkRole.OWNER,
+      role: WorkRole.OWNER,
     },
   });
 }

--- a/platform/scms/app/routes/app/system.submissions/route.tsx
+++ b/platform/scms/app/routes/app/system.submissions/route.tsx
@@ -21,7 +21,7 @@ import {
   dbUpdateDatePublishedFromVersion,
   dbUpdateDatePublishedFromWork,
 } from './db.server';
-import { $Enums } from '@curvenote/scms-db';
+import { WorkRole } from '@curvenote/scms-db';
 import { firstPublishedVersionDateCreated, lastPublishedVersionWorkDate } from './utils';
 import { SiteSelect, WorkInfo } from './ui';
 import { uuidv7 } from 'uuidv7';
@@ -55,7 +55,7 @@ export async function action(args: Route.ActionArgs) {
   } else if (formAction === 'add-work-user') {
     const workId = formData.get('workId') as string;
     const userId = formData.get('userId') as string;
-    const role = formData.get('role') as $Enums.WorkRole;
+    const role = formData.get('role') as WorkRole;
 
     const prisma = await getPrismaClient();
 
@@ -112,7 +112,7 @@ export async function action(args: Route.ActionArgs) {
       return data({ error: 'Work user not found' }, { status: 404 });
     }
 
-    if (workUser.role === $Enums.WorkRole.OWNER && workUser.work.work_users.length <= 1) {
+    if (workUser.role === WorkRole.OWNER && workUser.work.work_users.length <= 1) {
       return data({ error: 'Cannot remove the last owner' }, { status: 400 });
     }
 

--- a/platform/scms/app/routes/app/system.submissions/ui.tsx
+++ b/platform/scms/app/routes/app/system.submissions/ui.tsx
@@ -3,7 +3,7 @@ import { useFetcher } from 'react-router';
 import { X } from 'lucide-react';
 import { ui } from '@curvenote/scms-core';
 import type { SiteDTO } from '@curvenote/common';
-import { $Enums } from '@curvenote/scms-db';
+import { WorkRole } from '@curvenote/scms-db';
 
 interface WorkInfoProps {
   work: {
@@ -16,7 +16,7 @@ interface WorkInfoProps {
         display_name: string | null;
         email: string | null;
       };
-      role: $Enums.WorkRole;
+      role: WorkRole;
     }>;
   };
   users: Array<{
@@ -31,7 +31,7 @@ export function WorkInfo({ work, users }: WorkInfoProps): JSX.Element {
     work_users?: Array<{
       id: string;
       user: { id: string; display_name: string | null; email: string | null };
-      role: $Enums.WorkRole;
+      role: WorkRole;
     }>;
     error?: string;
   }>();
@@ -64,10 +64,10 @@ export function WorkInfo({ work, users }: WorkInfoProps): JSX.Element {
             <div className="font-medium">Users:</div>
             <ul className="list-disc list-inside">
               {workUsers.map((workUser) => {
-                const isOwner = workUser.role === $Enums.WorkRole.OWNER;
+                const isOwner = workUser.role === WorkRole.OWNER;
                 const isOnlyOwner =
                   isOwner &&
-                  workUsers.filter((wu) => wu.role === $Enums.WorkRole.OWNER).length === 1;
+                  workUsers.filter((wu) => wu.role === WorkRole.OWNER).length === 1;
                 const userName = workUser.user.display_name || workUser.user.email;
 
                 return (
@@ -113,7 +113,7 @@ export function WorkInfo({ work, users }: WorkInfoProps): JSX.Element {
               required
             >
               <option value="">Role</option>
-              {Object.values($Enums.WorkRole).map((role) => (
+              {Object.values(WorkRole).map((role) => (
                 <option key={role} value={role}>
                   {role}
                 </option>

--- a/platform/scms/app/routes/app/system.submissions/ui.tsx
+++ b/platform/scms/app/routes/app/system.submissions/ui.tsx
@@ -66,8 +66,7 @@ export function WorkInfo({ work, users }: WorkInfoProps): JSX.Element {
               {workUsers.map((workUser) => {
                 const isOwner = workUser.role === WorkRole.OWNER;
                 const isOnlyOwner =
-                  isOwner &&
-                  workUsers.filter((wu) => wu.role === WorkRole.OWNER).length === 1;
+                  isOwner && workUsers.filter((wu) => wu.role === WorkRole.OWNER).length === 1;
                 const userName = workUser.user.display_name || workUser.user.email;
 
                 return (

--- a/platform/scms/app/routes/app/system.users/SystemUserListItem.tsx
+++ b/platform/scms/app/routes/app/system.users/SystemUserListItem.tsx
@@ -2,7 +2,7 @@ import { ui, formatDatetime } from '@curvenote/scms-core';
 import { Copy } from 'lucide-react';
 import { useState, useEffect, useCallback } from 'react';
 import { useFetcher } from 'react-router';
-import type { $Enums } from '@curvenote/scms-db';
+import type { SystemRole } from '@curvenote/scms-db';
 import type { SystemUserDTO } from './db.server';
 
 interface SystemUserCardProps {
@@ -74,7 +74,7 @@ type ActionResponse = {
 
 export function SystemUserListItem({ user, currentUserId }: SystemUserCardProps) {
   const fetcher = useFetcher<ActionResponse>();
-  const [selectedRole, setSelectedRole] = useState<$Enums.SystemRole>(user.system_role);
+  const [selectedRole, setSelectedRole] = useState<SystemRole>(user.system_role);
 
   const isCurrentUser = user.id === currentUserId;
   const isLoading = fetcher.state !== 'idle';
@@ -115,7 +115,7 @@ export function SystemUserListItem({ user, currentUserId }: SystemUserCardProps)
   }, [fetcher.data, selectedRole, getDisplayName, getRoleDisplayName]);
 
   const handleRoleChange = (newRole: string) => {
-    const roleValue = newRole as $Enums.SystemRole;
+    const roleValue = newRole as SystemRole;
     setSelectedRole(roleValue);
 
     const formData = new FormData();

--- a/platform/scms/app/routes/app/system.users/db.server.ts
+++ b/platform/scms/app/routes/app/system.users/db.server.ts
@@ -1,5 +1,5 @@
 import { getPrismaClient } from '@curvenote/scms-server';
-import { $Enums } from '@curvenote/scms-db';
+import { SystemRole } from '@curvenote/scms-db';
 
 export type SystemUserDTO = Awaited<ReturnType<typeof dbGetSystemUsers>>[0];
 
@@ -30,7 +30,7 @@ export async function dbUpdateUserSystemRole(userId: string, systemRole: string)
   const prisma = await getPrismaClient();
 
   // Validate the system role
-  const validRoles = Object.values($Enums.SystemRole) as string[];
+  const validRoles = Object.values(SystemRole) as string[];
   if (!validRoles.includes(systemRole)) {
     throw new Error('Invalid system role');
   }
@@ -38,7 +38,7 @@ export async function dbUpdateUserSystemRole(userId: string, systemRole: string)
   return prisma.user.update({
     where: { id: userId },
     data: {
-      system_role: systemRole as $Enums.SystemRole,
+      system_role: systemRole as SystemRole,
       date_modified: new Date().toISOString(),
     },
     select: {

--- a/platform/scms/app/routes/app/works.$workId.users/actionHelpers.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.users/actionHelpers.server.ts
@@ -2,7 +2,7 @@ import { data } from 'react-router';
 import { zfd } from 'zod-form-data';
 import { z } from 'zod';
 import type { User, WorkUser } from '@curvenote/scms-db';
-import { $Enums } from '@curvenote/scms-db';
+import { WorkRole } from '@curvenote/scms-db';
 import {
   dbAddWorkUserRole,
   dbGetUserByEmail,
@@ -28,7 +28,7 @@ async function getUserWithRolesByEmail(
   ctx: WorkContext,
   formData: FormData,
   dbUpdate: (
-    role: $Enums.WorkRole,
+    role: WorkRole,
     userWithRoles: User,
     requestedRole?: WorkUser,
   ) => Promise<{ message: string; error?: string; status?: number }>,
@@ -56,7 +56,7 @@ async function getUserWithRolesById(
   ctx: WorkContext,
   formData: FormData,
   dbUpdate: (
-    role: $Enums.WorkRole,
+    role: WorkRole,
     userWithRoles: User,
     requestedRole?: WorkUser,
   ) => Promise<{ message: string; error?: string; status?: number }>,
@@ -148,7 +148,7 @@ export async function actionRevokeUserRole(ctx: WorkContext, formData: FormData)
       if (!requestedRole) {
         return { message: 'ok', info: 'user does not have specified role' };
       }
-      if (role === $Enums.WorkRole.OWNER && ctx.user?.id === userWithRoles.id) {
+      if (role === WorkRole.OWNER && ctx.user?.id === userWithRoles.id) {
         return {
           message: 'unprocessable content',
           error: 'cannot revoke your own owner permissions',

--- a/platform/scms/app/routes/app/works.$workId.users/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.users/db.server.ts
@@ -1,8 +1,8 @@
 import { uuidv7 as uuid } from 'uuidv7';
-import type { $Enums } from '@curvenote/scms-db';
+import type { WorkRole } from '@curvenote/scms-db';
 import { getPrismaClient } from '@curvenote/scms-server';
 
-export async function dbAddWorkUserRole(workId: string, userId: string, role: $Enums.WorkRole) {
+export async function dbAddWorkUserRole(workId: string, userId: string, role: WorkRole) {
   const prisma = await getPrismaClient();
   const timestamp = new Date().toISOString();
   return prisma.workUser.create({
@@ -18,7 +18,7 @@ export async function dbAddWorkUserRole(workId: string, userId: string, role: $E
   });
 }
 
-export async function dbRemoveWorkUserRole(workId: string, userId: string, role: $Enums.WorkRole) {
+export async function dbRemoveWorkUserRole(workId: string, userId: string, role: WorkRole) {
   const prisma = await getPrismaClient();
   return prisma.workUser.deleteMany({
     where: {

--- a/platform/scms/app/routes/app/works._index/ClientListingHelpers.tsx
+++ b/platform/scms/app/routes/app/works._index/ClientListingHelpers.tsx
@@ -1,4 +1,4 @@
-import type { $Enums } from '@curvenote/scms-db';
+import type { WorkRole } from '@curvenote/scms-db';
 import type { WorkCardDBO } from './WorkListItem';
 import { ui } from '@curvenote/scms-core';
 
@@ -6,7 +6,7 @@ import { ui } from '@curvenote/scms-core';
  * Type for works with user role information
  */
 export type WorkWithRole = WorkCardDBO & {
-  userRole: $Enums.WorkRole | 'ORPHANED';
+  userRole: WorkRole | 'ORPHANED';
   // Add computed fields for filter counting
   sites: string[];
 };
@@ -14,7 +14,7 @@ export type WorkWithRole = WorkCardDBO & {
 /**
  * Role mapping to friendly labels for group headers
  */
-export const ROLE_LABELS: Record<$Enums.WorkRole | 'ORPHANED', string> = {
+export const ROLE_LABELS: Record<WorkRole | 'ORPHANED', string> = {
   OWNER: 'Owned By Me',
   CONTRIBUTOR: 'Contributing To',
   VIEWER: 'Viewing',
@@ -25,7 +25,7 @@ export const ROLE_LABELS: Record<$Enums.WorkRole | 'ORPHANED', string> = {
  * Role precedence order for sorting groups
  * Using string prefixes that will sort correctly alphabetically
  */
-export const ROLE_ORDER: Record<$Enums.WorkRole | 'ORPHANED', string> = {
+export const ROLE_ORDER: Record<WorkRole | 'ORPHANED', string> = {
   OWNER: '1-OWNER',
   CONTRIBUTOR: '2-CONTRIBUTOR',
   VIEWER: '3-VIEWER',
@@ -169,7 +169,7 @@ export function filterWorks(
 export function getRoleLabel(role: string): string {
   // Extract the actual role from the sortable key (e.g., "1-OWNER" -> "OWNER")
   const actualRole = role.includes('-') ? role.split('-')[1] : role;
-  return ROLE_LABELS[actualRole as $Enums.WorkRole | 'ORPHANED'] || actualRole;
+  return ROLE_LABELS[actualRole as WorkRole | 'ORPHANED'] || actualRole;
 }
 
 /**

--- a/platform/scms/app/routes/app/works._index/db.server.ts
+++ b/platform/scms/app/routes/app/works._index/db.server.ts
@@ -1,5 +1,5 @@
 import { getPrismaClient, Folder, StorageBackend, KnownBuckets } from '@curvenote/scms-server';
-import type { $Enums, WorkVersion } from '@curvenote/scms-db';
+import type { WorkRole, WorkVersion } from '@curvenote/scms-db';
 import type { SecureContext } from '@curvenote/scms-server';
 
 export async function dbGetWorksAndSubmissionVersions(userId: string) {
@@ -67,7 +67,7 @@ export async function dbGetWorksAndSubmissionVersions(userId: string) {
   return works.map((work) => {
     // Get the highest precedence role: OWNER > CONTRIBUTOR > VIEWER
     const userRoles = work.work_users.map((wu) => wu.role);
-    let userRole: $Enums.WorkRole | 'ORPHANED' = 'ORPHANED';
+    let userRole: WorkRole | 'ORPHANED' = 'ORPHANED';
 
     if (userRoles.includes('OWNER')) {
       userRole = 'OWNER';

--- a/platform/scms/app/routes/build.$jobId.tsx
+++ b/platform/scms/app/routes/build.$jobId.tsx
@@ -22,7 +22,7 @@ import {
   KnownJobTypes,
 } from '@curvenote/scms-core';
 import { CurvenoteLogo, CurvenoteText } from '@curvenote/icons';
-import type { $Enums } from '@curvenote/scms-db';
+import type { JobStatus } from '@curvenote/scms-db';
 import { Checks } from '@curvenote/check-ui';
 import { Theme, ThemeProvider } from '@myst-theme/providers';
 import { DEFAULT_RENDERERS } from 'myst-to-react';
@@ -340,7 +340,7 @@ export default function BuildScreen({ loaderData }: Route.ComponentProps) {
                       <div
                         className={cn(
                           'inline-block w-2 h-2 bg-green-600 rounded-full',
-                          getStatusDotClasses(job.status as $Enums.JobStatus),
+                          getStatusDotClasses(job.status as JobStatus),
                         )}
                       />
                       {job.status}

--- a/platform/scms/tests/e2e/e2e.spec.ts
+++ b/platform/scms/tests/e2e/e2e.spec.ts
@@ -6,7 +6,7 @@ import { load } from 'js-yaml';
 import { loadValidatedConfig } from '@app-config/config';
 import { createTestUser, generateTestToken } from './helpers';
 import type { UserDBO } from '@curvenote/scms-server';
-import { $Enums } from '@curvenote/scms-db';
+import { SystemRole, SiteRole, WorkRole } from '@curvenote/scms-db';
 
 const PORT = '3032';
 
@@ -158,7 +158,7 @@ type TestFile = {
   url?: string;
   method?: string;
   status?: number;
-  system_role?: $Enums.SystemRole;
+  system_role?: SystemRole;
   site_roles?: { name: string; role: string }[];
   roles?: string[]; // Array of role names to assign to the user
   headers?: Record<string, string>;
@@ -422,11 +422,11 @@ function runTestCases(tests: TestFile[]) {
           if (site_roles && site_roles.length > 0) {
             userOptions.siteRoles = site_roles.map((sr) => ({
               siteName: sr.name,
-              role: $Enums.SiteRole[sr.role as keyof typeof $Enums.SiteRole],
+              role: SiteRole[sr.role as keyof typeof SiteRole],
             }));
           }
 
-          testUser = await createTestUser(system_role ?? $Enums.SystemRole.USER, {
+          testUser = await createTestUser(system_role ?? SystemRole.USER, {
             ...userOptions,
             roles,
           });

--- a/platform/scms/tests/e2e/helpers.ts
+++ b/platform/scms/tests/e2e/helpers.ts
@@ -1,21 +1,16 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { expect } from 'vitest';
 import jwt from 'jsonwebtoken';
-import type { $Enums } from '@curvenote/scms-db';
-import { JobStatus, PrismaClient, SystemRole } from '@prisma/client';
+import type { SiteRole } from '@curvenote/scms-db';
+import { JobStatus, SystemRole, getLowLevelPrismaClient } from '@curvenote/scms-db';
 import { createSessionToken } from '@curvenote/scms-server';
 import { KnownJobTypes } from '@curvenote/scms-core';
 import { loadValidatedConfig } from '@app-config/config';
 import type { UserDBO } from '@curvenote/scms-server';
 
-// Initialize Prisma with test database configuration
-const prisma = new PrismaClient({
-  datasources: {
-    db: {
-      url: process.env.DATABASE_URL,
-    },
-  },
-});
+// Initialize Prisma with test database configuration using scms-db
+// getLowLevelPrismaClient uses a singleton pattern, so we resolve it once
+const prisma = await getLowLevelPrismaClient();
 
 // Log database connection on initialization
 console.log('Initializing Prisma with database URL:', process.env.DATABASE_URL);
@@ -316,7 +311,7 @@ export async function createTestUser(
   options: {
     pending?: boolean;
     disabled?: boolean;
-    siteRoles?: { siteName: string; role: $Enums.SiteRole }[];
+    siteRoles?: { siteName: string; role: SiteRole }[];
     roles?: string[]; // Array of role names to assign to the user
   } = {},
 ) {
@@ -441,7 +436,7 @@ export async function createTestUserWithPlatformAdminRole(
   options: {
     pending?: boolean;
     disabled?: boolean;
-    siteRoles?: { siteName: string; role: $Enums.SiteRole }[];
+    siteRoles?: { siteName: string; role: SiteRole }[];
   } = {},
 ) {
   return createTestUser(SystemRole.USER, {


### PR DESCRIPTION
We started using `$Enum` as part of the Prisma v7 port, going back to use the enums directly.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches from Prisma `$Enums` to direct enum imports across core, server, app, and tests to simplify typing and comparisons.
> 
> - Replace `$Enums.*` with named enums like `JobStatus`, `ActivityType`, `SystemRole`, `SiteRole`, `WorkRole`, `SlugStrategy` in loaders, contexts, routes, UI, and zod schemas
> - Update job polling/status utilities and API schemas to use `JobStatus`; adjust activity logging to `ActivityType`
> - Tests now use `getLowLevelPrismaClient` and typed enum roles; minor refactors in role/scope helpers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29a9913dce40ce6b58f5cb2a54a0146d7dca6b4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->