### PR TITLE
Move to `scms.curvenote.*`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,7 @@
   ],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "dev",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.changeset/curly-sides-swim.md
+++ b/.changeset/curly-sides-swim.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/cli': patch
+---
+
+Changed default configuration to use `scms` subdomain

--- a/.changeset/curly-sides-swim.md
+++ b/.changeset/curly-sides-swim.md
@@ -1,5 +1,6 @@
 ---
 '@curvenote/cli': patch
+'curvenote': patch
 ---
 
 Changed default configuration to use `scms` subdomain

--- a/packages/curvenote-cli/src/session/utils/makeDefaultConfig.ts
+++ b/packages/curvenote-cli/src/session/utils/makeDefaultConfig.ts
@@ -1,12 +1,12 @@
 import type { CLIConfigData } from '../types.js';
 
-const DEFAULT_PLATFORM_API_URL = 'https://sites.curvenote.com/v1';
-const DEFAULT_PLATFORM_APP_URL = 'https://sites.curvenote.com';
+const DEFAULT_PLATFORM_API_URL = 'https://scms.curvenote.com/v1';
+const DEFAULT_PLATFORM_APP_URL = 'https://scms.curvenote.com';
 export const DEFAULT_EDITOR_API_URL = 'https://api.curvenote.com';
 const DEFAULT_EDITOR_URL = 'https://curvenote.com';
 
-const STAGING_PLATFORM_API_URL = 'https://sites.curvenote.dev/v1';
-const STAGING_PLATFORM_APP_URL = 'https://sites.curvenote.dev';
+const STAGING_PLATFORM_API_URL = 'https://scms.curvenote.dev/v1';
+const STAGING_PLATFORM_APP_URL = 'https://scms.curvenote.dev';
 const STAGING_EDITOR_API_URL = 'https://api.curvenote.one';
 const STAGING_EDITOR_URL = 'https://curvenote.one';
 


### PR DESCRIPTION
- **🌳 change base branch**
- **🔗 change default config urls**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves platform endpoints to the new `scms` subdomain and updates release config.
> 
> - Update default `PLATFORM_API_URL`/`PLATFORM_APP_URL` in `makeDefaultConfig.ts` from `sites.*` to `scms.*` for production and staging
> - Change Changesets `config.json` `baseBranch` from `main` to `dev`
> - Add Changeset to publish patch versions for `@curvenote/cli` and `curvenote` noting the URL change
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19c2342b0981e44f994aa00a19d3a6dea8b539c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->