### PR TITLE
🔧 Fix Duplicate Keys

### DIFF
--- a/.changeset/bright-knives-throw.md
+++ b/.changeset/bright-knives-throw.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-core': patch
+---
+
+Fixes duplicate keys when no section names are provided in the secondary menu data

--- a/packages/scms-core/src/components/navigation/SecondaryNav.tsx
+++ b/packages/scms-core/src/components/navigation/SecondaryNav.tsx
@@ -75,7 +75,7 @@ export function SecondaryNav({
       <div className="overflow-y-auto overflow-x-hidden h-full grow scrollbar scrollbar-thin scrollbar-track-stone-100 scrollbar-thumb-stone-500 dark:scrollbar-track-stone-800 dark:scrollbar-thumb-stone-400">
         {contents.map(({ sectionName, menus }, index) => (
           <ul
-            key={sectionName ?? menus.map((m) => m.name ?? m.url).join('-') ?? `section-${index}`}
+            key={sectionName ?? (menus.map((m) => m.name ?? m.url).join('-') || `section-${index}`)}
           >
             <>
               {open && sectionName && (

--- a/packages/scms-core/src/components/navigation/SecondaryNav.tsx
+++ b/packages/scms-core/src/components/navigation/SecondaryNav.tsx
@@ -73,8 +73,8 @@ export function SecondaryNav({
         </div>
       )}
       <div className="h-full overflow-x-hidden overflow-y-auto grow scrollbar scrollbar-thin scrollbar-track-stone-100 scrollbar-thumb-stone-500 dark:scrollbar-track-stone-800 dark:scrollbar-thumb-stone-400">
-        {contents.map(({ sectionName, menus }) => (
-          <ul key={sectionName ?? menus.reduce((acc, i) => `${acc}-${i}`, '')}>
+        {contents.map(({ sectionName, menus }, index) => (
+          <ul key={sectionName ?? menus.map((m) => m.name || m.url).join('-') || `section-${index}`}>
             <>
               {open && sectionName && (
                 <li className="px-5">

--- a/packages/scms-core/src/components/navigation/SecondaryNav.tsx
+++ b/packages/scms-core/src/components/navigation/SecondaryNav.tsx
@@ -35,9 +35,9 @@ export function SecondaryNav({
         <>
           {branding.url ? (
             <div className="pt-[60px]">
-              <a className="flex flex-col items-center justify-center" href={branding.url}>
+              <a className="flex flex-col justify-center items-center" href={branding.url}>
                 <SiteLogo
-                  className="object-cover h-10 mb-4"
+                  className="object-cover mb-4 h-10"
                   alt={title ?? ''}
                   logo={branding.logo}
                   logo_dark={branding.logo_dark}
@@ -51,7 +51,7 @@ export function SecondaryNav({
             <div className="flex flex-col justify-center items-center pt-[60px]">
               {branding.logo && (
                 <SiteLogo
-                  className="object-cover h-10 mb-4"
+                  className="object-cover mb-4 h-10"
                   alt={title ?? ''}
                   logo={branding.logo}
                   logo_dark={branding.logo_dark}
@@ -72,9 +72,11 @@ export function SecondaryNav({
           {subtitle && <div className="py-1 font-normal txt-base">{subtitle}</div>}
         </div>
       )}
-      <div className="h-full overflow-x-hidden overflow-y-auto grow scrollbar scrollbar-thin scrollbar-track-stone-100 scrollbar-thumb-stone-500 dark:scrollbar-track-stone-800 dark:scrollbar-thumb-stone-400">
+      <div className="overflow-y-auto overflow-x-hidden h-full grow scrollbar scrollbar-thin scrollbar-track-stone-100 scrollbar-thumb-stone-500 dark:scrollbar-track-stone-800 dark:scrollbar-thumb-stone-400">
         {contents.map(({ sectionName, menus }, index) => (
-          <ul key={sectionName ?? menus.map((m) => m.name || m.url).join('-') || `section-${index}`}>
+          <ul
+            key={sectionName ?? menus.map((m) => m.name ?? m.url).join('-') ?? `section-${index}`}
+          >
             <>
               {open && sectionName && (
                 <li className="px-5">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents React key collisions in the secondary navigation when `sectionName` is missing.
> 
> - In `SecondaryNav.tsx`, compute `ul` keys from `menus.map(m => m.name ?? m.url).join('-')` with `section-${index}` fallback, instead of relying on `sectionName` or a reducer that could duplicate
> - Minor className/scroll container ordering adjustments
> - Add patch changeset for `@curvenote/scms-core` noting the duplicate key fix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc406640ee7cb713a1320243ba139ffb996c0b2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->