### PR TITLE
✨Better loading bar

### DIFF
--- a/.changeset/hip-eagles-nail.md
+++ b/.changeset/hip-eagles-nail.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-core': patch
+'@curvenote/scms': patch
+---
+
+Improvements to loading bar navigation

--- a/packages/scms-core/src/components/LoadingBar.tsx
+++ b/packages/scms-core/src/components/LoadingBar.tsx
@@ -78,14 +78,14 @@ export function LoadingBar({ fetcher }: { fetcher?: FetcherWithComponents<any> }
   return (
     <>
       <div className="absolute top-0 right-0 left-0 z-50">
-    <div
+        <div
           className={classNames('min-w-[10px] bg-blue-500 origin-left', {
             'animate-load': !isPulseState && showLoading,
             'h-[3px]': !isPulseState && showLoading,
             'h-[5px]': isPulseState && showLoading,
             'w-full animate-pulse': isPulseState && showLoading,
           })}
-    />
+        />
       </div>
     </>
   );

--- a/packages/scms-core/src/components/LoadingBar.tsx
+++ b/packages/scms-core/src/components/LoadingBar.tsx
@@ -52,8 +52,7 @@ export function LoadingBar({ fetcher }: { fetcher?: FetcherWithComponents<any> }
   const pulseTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
-    if (showLoading && isLoading && !isPulseState) {
-      setIsPulseState(false);
+    if (showLoading && !isPulseState) {
       pulseTimeoutRef.current = setTimeout(() => {
         setIsPulseState(true);
       }, 5000);
@@ -66,7 +65,7 @@ export function LoadingBar({ fetcher }: { fetcher?: FetcherWithComponents<any> }
     }
 
     return () => {
-      if (pulseTimeoutRef.current && !isLoading) {
+      if (pulseTimeoutRef.current) {
         clearTimeout(pulseTimeoutRef.current);
         pulseTimeoutRef.current = null;
       }

--- a/packages/scms-core/src/components/LoadingBar.tsx
+++ b/packages/scms-core/src/components/LoadingBar.tsx
@@ -50,8 +50,22 @@ export function LoadingBar({ fetcher }: { fetcher?: FetcherWithComponents<any> }
   const { isLoading, showLoading } = useLoading(fetcher);
   const [isPulseState, setIsPulseState] = useState(false);
   const pulseTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const prevIsLoadingRef = useRef(isLoading);
 
   useEffect(() => {
+    // Reset pulse state when a new loading cycle begins (isLoading transitions from false to true)
+    // This handles the case where loads happen in quick succession and showLoading never becomes false
+    if (isLoading && !prevIsLoadingRef.current && isPulseState) {
+      setIsPulseState(false);
+      if (pulseTimeoutRef.current) {
+        clearTimeout(pulseTimeoutRef.current);
+        pulseTimeoutRef.current = null;
+      }
+    }
+
+    // Update previous isLoading value
+    prevIsLoadingRef.current = isLoading;
+
     if (showLoading && !isPulseState) {
       pulseTimeoutRef.current = setTimeout(() => {
         setIsPulseState(true);
@@ -70,7 +84,7 @@ export function LoadingBar({ fetcher }: { fetcher?: FetcherWithComponents<any> }
         pulseTimeoutRef.current = null;
       }
     };
-  }, [showLoading, isLoading]);
+  }, [showLoading, isLoading, isPulseState]);
 
   if (!showLoading) return null;
 

--- a/packages/scms-core/src/components/LoadingBar.tsx
+++ b/packages/scms-core/src/components/LoadingBar.tsx
@@ -1,6 +1,6 @@
 import type { FetcherWithComponents } from 'react-router';
 import { useNavigation } from 'react-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, useRef } from 'react';
 import classNames from 'classnames';
 
 /**
@@ -48,16 +48,45 @@ function useLoading(fetcher?: FetcherWithComponents<any>) {
 
 export function LoadingBar({ fetcher }: { fetcher?: FetcherWithComponents<any> }) {
   const { isLoading, showLoading } = useLoading(fetcher);
+  const [isPulseState, setIsPulseState] = useState(false);
+  const pulseTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (showLoading && isLoading && !isPulseState) {
+      setIsPulseState(false);
+      pulseTimeoutRef.current = setTimeout(() => {
+        setIsPulseState(true);
+      }, 5000);
+    } else if (!showLoading && isPulseState) {
+      setIsPulseState(false);
+      if (pulseTimeoutRef.current) {
+        clearTimeout(pulseTimeoutRef.current);
+        pulseTimeoutRef.current = null;
+      }
+    }
+
+    return () => {
+      if (pulseTimeoutRef.current && !isLoading) {
+        clearTimeout(pulseTimeoutRef.current);
+        pulseTimeoutRef.current = null;
+      }
+    };
+  }, [showLoading, isLoading]);
+
   if (!showLoading) return null;
+
   return (
+    <>
+      <div className="absolute top-0 right-0 left-0 z-50">
     <div
-      className={classNames(
-        'min-w-[50px] absolute h-[3px] z-50 bg-blue-500 left-0 bottom-0 transition-transform origin-left',
-        {
-          'animate-load scale-x-40': isLoading,
-          'scale-x-100': !isLoading,
-        },
-      )}
+          className={classNames('min-w-[10px] bg-blue-500 origin-left', {
+            'animate-load': !isPulseState && showLoading,
+            'h-[3px]': !isPulseState && showLoading,
+            'h-[5px]': isPulseState && showLoading,
+            'w-full animate-pulse': isPulseState && showLoading,
+          })}
     />
+      </div>
+    </>
   );
 }

--- a/platform/scms/app/routes/app/route.tsx
+++ b/platform/scms/app/routes/app/route.tsx
@@ -43,7 +43,7 @@ export default function App() {
         <MobileControls />
         <PrimaryNav extensions={clientExtensions} />
         <div className="flex relative flex-col flex-1 w-full">
-          <div className="fixed z-50 top-0 h-[3px] w-full">
+          <div className="fixed top-0 z-50 w-full">
             <LoadingBar />
           </div>
           <div

--- a/platform/scms/app/styles/root.css
+++ b/platform/scms/app/styles/root.css
@@ -178,7 +178,7 @@ layer(base);
     }
 
     100% {
-      width: 50%;
+      width: 80%;
     }
   }
 


### PR DESCRIPTION
Changes because the loading animation was not great for long load times, this conveys loading a bit better and after 5s, which is a long time, changeset to a pulse to convey continued activity


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances the loading experience for long navigations.
> 
> - Updates `LoadingBar` to switch to a pulsing full‑width bar after 5s via a new pulse state with timeouts; resets correctly across quick successive loads
> - Adjusts container in `app/routes/app/route.tsx` to let `LoadingBar` control its own height (removes fixed `h-[3px]`)
> - Tweaks animation in `styles/root.css` so `animate-load` grows to 80% over 5s
> - Adds patch changesets for `@curvenote/scms-core` and `@curvenote/scms`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f77b5406d24ce56d713d9733ebf0db68d75fe7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->