### PR TITLE
Work access controls

### DIFF
--- a/packages/scms-core/src/components/UserCard.tsx
+++ b/packages/scms-core/src/components/UserCard.tsx
@@ -12,18 +12,22 @@ type UserProps = {
   email?: string | null;
   name?: string | null;
   userId?: string | null;
+  canManageUsers?: boolean;
 };
 
 function TableRow({ children, className }: { children: React.ReactNode; className?: string }) {
   return <div className={cn('border-b bg-background last:border-b-0', className)}>{children}</div>;
 }
 
-export function UserCard({ roles, email, name, userId }: UserProps) {
+export function UserCard({ roles, email, name, userId, canManageUsers = true }: UserProps) {
   const fetcher = useFetcher<{ ok: boolean; error?: string; info?: string }>();
   const currentUser = useMyUser();
 
   // Check if the current user is viewing their own card
   const isCurrentUser = currentUser && userId && currentUser.id === userId;
+  
+  // Only show revoke button if user has permission and it's not their own card
+  const canRevokeRole = canManageUsers && !isCurrentUser;
 
   // Handle toast notifications for role removal
   useEffect(() => {
@@ -101,7 +105,7 @@ export function UserCard({ roles, email, name, userId }: UserProps) {
         <div className="flex items-center space-x-2">
           {roles.map((role) => (
             <div key={role} className="relative">
-              {!isCurrentUser ? (
+              {canRevokeRole ? (
                 <fetcher.Form
                   method="post"
                   onSubmit={(e) => {

--- a/platform/scms/app/routes/app/works.$workId.users/actionHelpers.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.users/actionHelpers.server.ts
@@ -8,7 +8,6 @@ import {
   dbGetUserByEmail,
   dbGetUserById,
   dbRemoveWorkUserRole,
-  dbGetUserWorkRole,
 } from './db.server';
 import type { GeneralError } from '@curvenote/scms-core';
 import { TrackEvent, KnownResendEvents } from '@curvenote/scms-core';
@@ -17,11 +16,14 @@ import { works } from '@curvenote/scms-server';
 
 /**
  * Helper function to check if the current user has OWNER role on the work
+ * Uses the work_roles already loaded in the context to avoid additional DB queries
  */
-async function isCurrentUserOwner(ctx: WorkContext): Promise<boolean> {
+function isCurrentUserOwner(ctx: WorkContext): boolean {
   if (!ctx.user) return false;
-  const userRole = await dbGetUserWorkRole(ctx.user.id, ctx.work.id);
-  return userRole?.role === WorkRole.OWNER;
+  // ctx.user.work_roles contains all work roles for the user
+  // Filter to find the role for the current work
+  const userWorkRole = ctx.user.work_roles?.find((wr) => wr.work_id === ctx.work.id);
+  return userWorkRole?.role === WorkRole.OWNER;
 }
 
 const UpdateWorkRoleObject = {
@@ -92,7 +94,7 @@ async function getUserWithRolesById(
 
 export async function actionGrantUserRole(ctx: WorkContext, formData: FormData) {
   // Check if current user is an OWNER
-  const isOwner = await isCurrentUserOwner(ctx);
+  const isOwner = isCurrentUserOwner(ctx);
   if (!isOwner) {
     return data(
       {
@@ -161,7 +163,7 @@ export async function actionGrantUserRole(ctx: WorkContext, formData: FormData) 
 
 export async function actionRevokeUserRole(ctx: WorkContext, formData: FormData) {
   // Check if current user is an OWNER
-  const isOwner = await isCurrentUserOwner(ctx);
+  const isOwner = isCurrentUserOwner(ctx);
   if (!isOwner) {
     return data(
       {

--- a/platform/scms/app/routes/app/works.$workId.users/actionHelpers.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.users/actionHelpers.server.ts
@@ -8,11 +8,21 @@ import {
   dbGetUserByEmail,
   dbGetUserById,
   dbRemoveWorkUserRole,
+  dbGetUserWorkRole,
 } from './db.server';
 import type { GeneralError } from '@curvenote/scms-core';
 import { TrackEvent, KnownResendEvents } from '@curvenote/scms-core';
 import type { WorkContext } from '@curvenote/scms-server';
 import { works } from '@curvenote/scms-server';
+
+/**
+ * Helper function to check if the current user has OWNER role on the work
+ */
+async function isCurrentUserOwner(ctx: WorkContext): Promise<boolean> {
+  if (!ctx.user) return false;
+  const userRole = await dbGetUserWorkRole(ctx.user.id, ctx.work.id);
+  return userRole?.role === WorkRole.OWNER;
+}
 
 const UpdateWorkRoleObject = {
   email: zfd.text(z.string().email({ message: 'invalid email address' }).trim().toLowerCase()),
@@ -81,6 +91,20 @@ async function getUserWithRolesById(
 }
 
 export async function actionGrantUserRole(ctx: WorkContext, formData: FormData) {
+  // Check if current user is an OWNER
+  const isOwner = await isCurrentUserOwner(ctx);
+  if (!isOwner) {
+    return data(
+      {
+        error: {
+          type: 'general',
+          message: 'Only owners can add users to this work',
+        } as GeneralError,
+      },
+      { status: 403 },
+    );
+  }
+
   const userId = formData.get('userId');
 
   // Determine which method to use based on available data
@@ -136,6 +160,20 @@ export async function actionGrantUserRole(ctx: WorkContext, formData: FormData) 
 }
 
 export async function actionRevokeUserRole(ctx: WorkContext, formData: FormData) {
+  // Check if current user is an OWNER
+  const isOwner = await isCurrentUserOwner(ctx);
+  if (!isOwner) {
+    return data(
+      {
+        error: {
+          type: 'general',
+          message: 'Only owners can remove users from this work',
+        } as GeneralError,
+      },
+      { status: 403 },
+    );
+  }
+
   const userId = formData.get('userId');
 
   // Determine which method to use based on available data

--- a/platform/scms/app/routes/app/works.$workId.users/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.users/db.server.ts
@@ -49,6 +49,16 @@ export async function dbGetUserById(userId: string) {
   });
 }
 
+export async function dbGetUserWorkRole(userId: string, workId: string) {
+  const prisma = await getPrismaClient();
+  return prisma.workUser.findFirst({
+    where: {
+      user_id: userId,
+      work_id: workId,
+    },
+  });
+}
+
 export async function dbGetWorkUsers(workId: string) {
   const prisma = await getPrismaClient();
   return prisma.user.findMany({

--- a/platform/scms/app/routes/app/works.$workId.users/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.users/db.server.ts
@@ -49,16 +49,6 @@ export async function dbGetUserById(userId: string) {
   });
 }
 
-export async function dbGetUserWorkRole(userId: string, workId: string) {
-  const prisma = await getPrismaClient();
-  return prisma.workUser.findFirst({
-    where: {
-      user_id: userId,
-      work_id: workId,
-    },
-  });
-}
-
 export async function dbGetWorkUsers(workId: string) {
   const prisma = await getPrismaClient();
   return prisma.user.findMany({

--- a/platform/scms/app/routes/app/works.$workId.users/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.users/route.tsx
@@ -18,9 +18,15 @@ import { actionGrantUserRole, actionRevokeUserRole } from './actionHelpers.serve
 export async function loader(args: Route.LoaderArgs) {
   const ctx = await withSecureWorkContext(args, [scopes.work.users.read]);
   const dbo = await dbGetWorkUsers(ctx.work.id);
-  if (!dbo) return { work: ctx.workDTO, error: 'Failed to get work users', users: [] };
+  if (!dbo) return { work: ctx.workDTO, error: 'Failed to get work users', users: [], canManageUsers: false };
   const users = dtoWorkUsers(dbo);
-  return { work: ctx.workDTO, users };
+  
+  // Check if the current user is an OWNER of this work
+  // Only OWNERs can add or remove users
+  const userWorkRole = ctx.user.work_roles?.find((wr) => wr.work_id === ctx.work.id);
+  const canManageUsers = userWorkRole?.role === 'OWNER';
+  
+  return { work: ctx.workDTO, users, canManageUsers };
 }
 
 export const meta: Route.MetaFunction = ({ matches }) => {
@@ -54,7 +60,7 @@ export async function action(args: Route.ActionArgs) {
 }
 
 export default function Users({ loaderData }: Route.ComponentProps) {
-  const { work, users } = loaderData;
+  const { work, users, canManageUsers } = loaderData;
 
   const truncatedTitle = work.title
     ? work.title.length > 32
@@ -71,9 +77,11 @@ export default function Users({ loaderData }: Route.ComponentProps) {
   return (
     <PageFrame title="Users" subtitle="Who can access this work?" breadcrumbs={breadcrumbs}>
       <div className="flex flex-col space-y-5">
-        <div>
-          <WorkRolesForm />
-        </div>
+        {canManageUsers && (
+          <div>
+            <WorkRolesForm />
+          </div>
+        )}
         <SectionWithHeading heading="Current Users" icon={User}>
           <div className="overflow-hidden rounded-sm border bg-background">
             {users.map((u) => (
@@ -83,6 +91,7 @@ export default function Users({ loaderData }: Route.ComponentProps) {
                 roles={u.work_roles}
                 email={u.email}
                 userId={u.id}
+                canManageUsers={canManageUsers}
               />
             ))}
           </div>


### PR DESCRIPTION
Add explicit owner role checks to work user management actions to prevent non-owners from modifying work access.

This change ensures that only users with the `OWNER` role can add or remove users from a work, addressing a bug where contributors could remove owners. While scope-based permissions already restrict this, explicit role checks provide an additional layer of security.

---
Linear Issue: [CN-1678](https://linear.app/curvenote/issue/CN-1678/a-contributor-maybe-viewer-can-remove-admin-control-on-a-work)

<a href="https://cursor.com/background-agent?bcId=bc-c16a7998-e6ea-4ad5-9e42-3b1ee1505724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c16a7998-e6ea-4ad5-9e42-3b1ee1505724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

