### PR TITLE
Fix site users

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,6 +57,23 @@
       "smartStep": true,
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Platform SCMS Dev Server",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+      "smartStep": true,
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}/platform/scms",
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "sourceMaps": true,
+      "outputCapture": "std"
     }
   ]
 }

--- a/ee/sites/src/routes/$siteName.users/SiteRolesForm.tsx
+++ b/ee/sites/src/routes/$siteName.users/SiteRolesForm.tsx
@@ -1,10 +1,10 @@
 import { useFetcher } from 'react-router';
-import { ui } from '@curvenote/scms-core';
+import { ui, type GeneralError } from '@curvenote/scms-core';
 import { useRef, useState, useCallback, useEffect } from 'react';
 
 export function SiteRolesForm() {
   const form = useRef<HTMLFormElement>(null);
-  const fetcher = useFetcher<{ ok: boolean; error?: string | string[]; info?: string }>();
+  const fetcher = useFetcher<{ error?: GeneralError; message?: string; info?: string }>();
   const [selectedUser, setSelectedUser] = useState<string>('');
   const [selectedRole, setSelectedRole] = useState<string>('ADMIN');
 
@@ -12,9 +12,10 @@ export function SiteRolesForm() {
   useEffect(() => {
     if (fetcher.state === 'idle' && fetcher.data) {
       if (fetcher.data.error) {
-        const errorMessage = Array.isArray(fetcher.data.error)
-          ? fetcher.data.error.map((e: any) => e.message || e.code || String(e)).join(', ')
-          : String(fetcher.data.error);
+        const errorMessage =
+          typeof fetcher.data.error === 'object' && 'message' in fetcher.data.error
+            ? fetcher.data.error.message
+            : 'An error occurred';
         ui.toastError(errorMessage);
       } else if (fetcher.data.info) {
         ui.toastSuccess(fetcher.data.info);

--- a/ee/sites/src/routes/$siteName.users/SiteRolesForm.tsx
+++ b/ee/sites/src/routes/$siteName.users/SiteRolesForm.tsx
@@ -92,7 +92,7 @@ export function SiteRolesForm() {
 
   return (
     <form ref={form} className="flex flex-col gap-4" onSubmit={handleSubmit}>
-      <div className="flex items-center gap-2">
+      <div className="flex gap-2 items-center">
         <h3 className="font-medium text-md">Add New User</h3>
       </div>
 
@@ -123,7 +123,7 @@ export function SiteRolesForm() {
             Role
           </label>
           <select
-            className="w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
+            className="px-3 py-2 w-full bg-white rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
             id="invite.role"
             value={selectedRole}
             onChange={(e) => setSelectedRole(e.target.value)}

--- a/ee/sites/src/routes/$siteName.users/SiteRolesForm.tsx
+++ b/ee/sites/src/routes/$siteName.users/SiteRolesForm.tsx
@@ -6,7 +6,6 @@ export function SiteRolesForm({ canGrantAdminRole }: { canGrantAdminRole: boolea
   const form = useRef<HTMLFormElement>(null);
   const fetcher = useFetcher<{ error?: GeneralError; message?: string; info?: string }>();
   const [selectedUser, setSelectedUser] = useState<string>('');
-  const [selectedRole, setSelectedRole] = useState<string>('ADMIN');
 
   // Handle toast notifications
   useEffect(() => {
@@ -21,7 +20,6 @@ export function SiteRolesForm({ canGrantAdminRole }: { canGrantAdminRole: boolea
         ui.toastSuccess(fetcher.data.info);
         // Reset form on success
         setSelectedUser('');
-        setSelectedRole('ADMIN');
         form.current?.reset();
       }
     }
@@ -76,17 +74,20 @@ export function SiteRolesForm({ canGrantAdminRole }: { canGrantAdminRole: boolea
     }
   }, []);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!selectedUser) {
       ui.toastError('Please select a user');
       return;
     }
 
-    const formData = new FormData();
-    formData.append('intent', 'grant');
-    formData.append('userId', selectedUser);
-    formData.append('role', selectedRole);
+    // Get form data directly from the form element
+    // This automatically captures all form fields with 'name' attributes
+    // e.g. role
+    const formData = new FormData(e.currentTarget);
+    // Add the intent and userId since they're not in the form
+    formData.set('intent', 'grant');
+    formData.set('userId', selectedUser);
 
     fetcher.submit(formData, { method: 'POST' });
   };
@@ -94,7 +95,7 @@ export function SiteRolesForm({ canGrantAdminRole }: { canGrantAdminRole: boolea
   return (
     <form ref={form} className="flex flex-col gap-4" onSubmit={handleSubmit}>
       <div className="flex gap-2 items-center">
-        <h3 className="font-medium text-md">Add New User</h3>
+        <h3 className="font-medium text-md">Add a New User or Grant a Role</h3>
       </div>
 
       {/* Single row layout on md+ breakpoints */}
@@ -124,10 +125,9 @@ export function SiteRolesForm({ canGrantAdminRole }: { canGrantAdminRole: boolea
             Role
           </label>
           <select
-            className="px-3 py-2 w-full bg-white rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
+            className="px-3 py-2 w-full text-sm bg-white rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
             id="invite.role"
-            value={selectedRole}
-            onChange={(e) => setSelectedRole(e.target.value)}
+            name="role"
             required
             disabled={fetcher.state === 'submitting'}
           >
@@ -137,14 +137,14 @@ export function SiteRolesForm({ canGrantAdminRole }: { canGrantAdminRole: boolea
           </select>
         </div>
 
-        <div className="flex-none">
+        <div className="flex-none pb-[1px]">
           <ui.StatefulButton
             type="submit"
             overlayBusy
             busy={fetcher.state === 'submitting'}
             disabled={fetcher.state === 'submitting' || !selectedUser}
           >
-            Add User
+            Grant
           </ui.StatefulButton>
         </div>
       </div>

--- a/ee/sites/src/routes/$siteName.users/SiteRolesForm.tsx
+++ b/ee/sites/src/routes/$siteName.users/SiteRolesForm.tsx
@@ -2,7 +2,7 @@ import { useFetcher } from 'react-router';
 import { ui, type GeneralError } from '@curvenote/scms-core';
 import { useRef, useState, useCallback, useEffect } from 'react';
 
-export function SiteRolesForm() {
+export function SiteRolesForm({ canGrantAdminRole }: { canGrantAdminRole: boolean }) {
   const form = useRef<HTMLFormElement>(null);
   const fetcher = useFetcher<{ error?: GeneralError; message?: string; info?: string }>();
   const [selectedUser, setSelectedUser] = useState<string>('');
@@ -131,7 +131,7 @@ export function SiteRolesForm() {
             required
             disabled={fetcher.state === 'submitting'}
           >
-            <option value="ADMIN">Admin</option>
+            {canGrantAdminRole && <option value="ADMIN">Admin</option>}
             <option value="EDITOR">Editor</option>
             <option value="SUBMITTER">Submitter</option>
           </select>

--- a/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
@@ -172,12 +172,12 @@ async function getUserWithRoles<T>(
 export async function $actionGrantUserRole(ctx: SiteContextWithUser, payload: ParsedFormData) {
   return getUserWithRoles(ctx, payload, async (role, userWithRoles, existingRoleIfOnTargetUser) => {
     // Prevent non-admins from modifying their own roles
-    if (ctx.user.id === userWithRoles.id && !userHasSiteScope(ctx.user, siteScopes.users.admin, ctx.site.id)) {
+    if (ctx.user.id === userWithRoles.id) {
       return data(
         {
           error: {
             type: 'general',
-            message: 'Only admins can modify their own roles',
+            message: 'Users cannot modify their own roles',
           },
         },
         { status: 403 },
@@ -265,7 +265,10 @@ export async function $actionRevokeUserRole(ctx: SiteContextWithUser, payload: P
     }
 
     // Prevent non-admins from modifying their own roles
-    if (ctx.user.id === userWithRoles.id && !userHasSiteScope(ctx.user, siteScopes.users.admin, ctx.site.id)) {
+    if (
+      ctx.user.id === userWithRoles.id &&
+      !userHasSiteScope(ctx.user, siteScopes.users.admin, ctx.site.id)
+    ) {
       return data(
         {
           error: {

--- a/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
@@ -4,14 +4,14 @@ import { z } from 'zod';
 import type { SiteUser, User } from '@curvenote/scms-db';
 import { SiteRole } from '@curvenote/scms-db';
 import type { SiteContextWithUser, SiteContext } from '@curvenote/scms-server';
-import { SlackEventType } from '@curvenote/scms-server';
+import { SlackEventType, userHasSiteScope } from '@curvenote/scms-server';
 import {
   dbAddSiteUserRole,
   dbGetUserByEmail,
   dbGetUserById,
   dbRemoveSiteUserRole,
 } from './db.server.js';
-import { KnownResendEvents } from '@curvenote/scms-core';
+import { KnownResendEvents, site as siteScopes } from '@curvenote/scms-core';
 import { SiteTrackEvent } from '../../analytics/events.js';
 
 // User type that includes site_roles (as returned by dbGetUserById/dbGetUserByEmail)
@@ -171,6 +171,19 @@ async function getUserWithRoles<T>(
  */
 export async function $actionGrantUserRole(ctx: SiteContextWithUser, payload: ParsedFormData) {
   return getUserWithRoles(ctx, payload, async (role, userWithRoles, existingRoleIfOnTargetUser) => {
+    // Prevent non-admins from modifying their own roles
+    if (ctx.user.id === userWithRoles.id && !userHasSiteScope(ctx.user, siteScopes.users.admin, ctx.site.id)) {
+      return data(
+        {
+          error: {
+            type: 'general',
+            message: 'Only admins can modify their own roles',
+          },
+        },
+        { status: 403 },
+      );
+    }
+
     if (existingRoleIfOnTargetUser) {
       return { message: 'ok', info: 'user already has the requested role' };
     }
@@ -226,7 +239,8 @@ export async function $actionGrantUserRole(ctx: SiteContextWithUser, payload: Pa
  *
  * The function performs:
  * - Validation that the user has the role to revoke
- * - Self-protection check (prevents users from revoking their own admin role)
+ * - Self-protection check (prevents non-admins from modifying their own roles)
+ * - Self-protection check (prevents users from revoking their own admin role, even admins)
  *
  * Authorization should be performed in the route handler using:
  * - `withAppSiteContext()` to check required scopes
@@ -247,9 +261,29 @@ export async function $actionRevokeUserRole(ctx: SiteContextWithUser, payload: P
         { status: 422 },
       );
     }
-    if (role === SiteRole.ADMIN && ctx.user?.id === userWithRoles.id) {
+
+    // Prevent non-admins from modifying their own roles
+    if (ctx.user.id === userWithRoles.id && !userHasSiteScope(ctx.user, siteScopes.users.admin, ctx.site.id)) {
       return data(
-        { message: 'unprocessable content', error: 'cannot revoke your own admin permissions' },
+        {
+          error: {
+            type: 'general',
+            message: 'Only admins can modify their own roles',
+          },
+        },
+        { status: 403 },
+      );
+    }
+
+    // Prevent users from revoking their own admin role (even admins)
+    if (role === SiteRole.ADMIN && ctx.user.id === userWithRoles.id) {
+      return data(
+        {
+          error: {
+            type: 'general',
+            message: 'cannot revoke your own admin permissions',
+          },
+        },
         { status: 422 },
       );
     }

--- a/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
@@ -277,18 +277,7 @@ export async function $actionRevokeUserRole(ctx: SiteContextWithUser, payload: P
       );
     }
 
-    // Prevent users from revoking their own admin role (even admins)
-    if (role === SiteRole.ADMIN && ctx.user.id === userWithRoles.id) {
-      return data(
-        {
-          error: {
-            type: 'general',
-            message: 'cannot revoke your own admin permissions',
-          },
-        },
-        { status: 422 },
-      );
-    }
+
     await dbRemoveSiteUserRole(ctx.site.id, userWithRoles.id, role);
     await ctx.sendSlackNotification({
       eventType: SlackEventType.SITE_ROLE_REVOKED,

--- a/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
@@ -4,95 +4,175 @@ import { z } from 'zod';
 import type { SiteUser, User } from '@curvenote/scms-db';
 import { SiteRole } from '@curvenote/scms-db';
 import type { SiteContextWithUser, SiteContext } from '@curvenote/scms-server';
+import { SlackEventType } from '@curvenote/scms-server';
 import {
   dbAddSiteUserRole,
   dbGetUserByEmail,
   dbGetUserById,
   dbRemoveSiteUserRole,
 } from './db.server.js';
-import { SlackEventType } from '@curvenote/scms-server';
 import { KnownResendEvents } from '@curvenote/scms-core';
 import { SiteTrackEvent } from '../../analytics/events.js';
 
-const UpdateSiteRoleObject = {
-  // Accept either email or userId for backward compatibility and new search functionality
-  email: zfd.text(z.string().optional()),
-  userId: zfd.text(z.string().optional()),
-  role: zfd.text(z.union([z.literal('ADMIN'), z.literal('EDITOR'), z.literal('SUBMITTER')])),
+// User type that includes site_roles (as returned by dbGetUserById/dbGetUserByEmail)
+type UserWithSiteRoles = User & {
+  site_roles: Array<{ site_id: string; role: SiteRole }>;
 };
 
-async function getUserWithRoles<T>(
-  ctx: SiteContext,
-  formData: FormData,
-  dbUpdate: (role: SiteRole, userWithRoles: User, requestedRole?: SiteUser) => Promise<T>,
-) {
-  const UpdateSiteRoleSchema = zfd.formData(UpdateSiteRoleObject);
-  let payload;
-  try {
-    payload = UpdateSiteRoleSchema.parse(Object.fromEntries(formData));
-  } catch (error: any) {
-    console.error(`Invalid form data ${error}`);
+// Schema for the action form data including intent
+export const ActionFormDataSchema = zfd
+  .formData({
+    intent: zfd.text(z.union([z.literal('grant'), z.literal('revoke')])),
+    // Accept either email or userId for backward compatibility and new search functionality
+    email: zfd.text(z.email({ message: 'invalid email address' }).optional().or(z.literal(''))),
+    userId: zfd.text(z.string().min(1).optional().or(z.literal(''))),
+    role: zfd.text(z.union([z.literal('ADMIN'), z.literal('EDITOR'), z.literal('SUBMITTER')])),
+  })
+  .refine(
+    (item) => {
+      const hasUserId = item.userId && item.userId.trim().length > 0;
+      const hasEmail = item.email && item.email.trim().length > 0;
+      return hasUserId || hasEmail;
+    },
+    {
+      message: 'Either email or userId must be provided',
+      path: ['email'], // This will show the error on the email field
+    },
+  )
+  .transform((item) => ({
+    intent: item.intent,
+    // Normalize empty strings to undefined
+    email: item.email?.trim() || undefined,
+    userId: item.userId?.trim() || undefined,
+    role: item.role,
+  }));
+
+// Type for validated role update payload (without intent - intent is validated in route.tsx)
+export type ParsedFormData = {
+  email?: string;
+  userId?: string;
+  role: 'ADMIN' | 'EDITOR' | 'SUBMITTER';
+};
+
+function isErrorResponse<T>(value: T | ReturnType<typeof data>): value is ReturnType<typeof data> {
+  return typeof value === 'object' && value !== null && 'status' in value;
+}
+
+async function fetchUserById(userId: string): Promise<UserWithSiteRoles | ReturnType<typeof data>> {
+  const user = await dbGetUserById(userId);
+  if (!user) {
     return data(
-      { message: 'unprocessable content', error: error?.issues?.[0]?.message },
-      { status: 422 },
+      { message: 'not found', error: 'no user found for provided userId' },
+      { status: 404 },
     );
   }
-  const { email, userId, role } = payload;
+  return user as UserWithSiteRoles;
+}
 
-  // Validate that either email or userId is provided (and not empty strings)
-  const hasUserId = userId && typeof userId === 'string' && userId.trim().length > 0;
-  const hasEmail = email && typeof email === 'string' && email.trim().length > 0;
-
-  if (!hasUserId && !hasEmail) {
+async function fetchUserByEmail(
+  email: string,
+): Promise<UserWithSiteRoles | ReturnType<typeof data>> {
+  const user = await dbGetUserByEmail(email);
+  if (!user) {
     return data(
-      { message: 'unprocessable content', error: 'Either email or userId must be provided' },
-      { status: 422 },
+      { message: 'not found', error: 'no user found for provided email' },
+      { status: 404 },
     );
   }
+  return user as UserWithSiteRoles;
+}
 
-  // Get user by email or userId
-  let userWithRoles;
-  if (hasUserId && userId) {
-    userWithRoles = await dbGetUserById(userId);
-    if (!userWithRoles) {
-      return data(
-        { message: 'not found', error: 'no user found for provided userId' },
-        { status: 404 },
-      );
-    }
-  } else if (hasEmail && email) {
-    // Validate email format if provided
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
-      return data(
-        { message: 'unprocessable content', error: 'invalid email address' },
-        { status: 422 },
-      );
-    }
-    userWithRoles = await dbGetUserByEmail(email);
-    if (!userWithRoles) {
-      return data(
-        { message: 'not found', error: 'no user found for provided email' },
-        { status: 404 },
-      );
-    }
-  }
-
-  if (!userWithRoles) {
+function ensureUserFound(
+  user: UserWithSiteRoles | ReturnType<typeof data> | undefined,
+): UserWithSiteRoles | ReturnType<typeof data> {
+  if (!user || isErrorResponse(user)) {
     return data({ message: 'not found', error: 'user not found' }, { status: 404 });
   }
+  return user;
+}
 
-  const requestedRole = userWithRoles.site_roles.find((site_role) => {
-    return site_role.site_id === ctx.site.id && site_role.role === role;
-  });
-  const resp = await dbUpdate(role, userWithRoles, requestedRole);
+/**
+ * Shared helper function for user role management operations (grant/revoke).
+ *
+ * This function handles the common user lookup logic for role management:
+ * 1. Fetches the target user by ID or email (from validated payload)
+ * 2. Finds any existing role assignment for the target role on this site
+ * 3. Invokes the provided `dbUpdate` callback with the validated data
+ *
+ * The function returns early with appropriate error responses if the user cannot be found:
+ * - 404 (Not Found) if the user cannot be found
+ *
+ * **⚠️ IMPORTANT:**
+ * - Form data validation must be done by the caller before invoking this function
+ * - Authorization checks (scopes and role hierarchy) must be done by the caller
+ *   before invoking this function
+ *
+ * @template T - The return type of the `dbUpdate` callback
+ * @param ctx - Site context containing site information
+ * @param payload - Validated form data containing `email` (optional), `userId` (optional), and `role`
+ * @param dbUpdate - Callback function that performs the actual database operation
+ * @returns The result of the `dbUpdate` callback, or an error response if user is not found
+ */
+async function getUserWithRoles<T>(
+  ctx: SiteContext,
+  payload: ParsedFormData,
+  dbUpdate: (
+    role: SiteRole,
+    userWithRoles: UserWithSiteRoles,
+    requestedRole?: SiteUser,
+  ) => Promise<T>,
+) {
+  const { email, userId, role } = payload;
+
+  // At this point, Zod has validated that at least one of email or userId is provided
+  // and email format is valid if email is provided
+  let userWithRoles: UserWithSiteRoles | ReturnType<typeof data> | undefined;
+
+  if (userId) {
+    userWithRoles = await fetchUserById(userId);
+  } else if (email) {
+    userWithRoles = await fetchUserByEmail(email);
+  }
+
+  const user = ensureUserFound(userWithRoles);
+  if (isErrorResponse(user)) {
+    return user;
+  }
+
+  const existingRoleIfOnTargetUser = user.site_roles.find(
+    (site_role: { site_id: string; role: SiteRole }) => {
+      return site_role.site_id === ctx.site.id && site_role.role === role;
+    },
+  ) as SiteUser | undefined;
+
+  const resp = await dbUpdate(role, user, existingRoleIfOnTargetUser);
   return resp;
 }
 
-export async function actionGrantUserRole(ctx: SiteContextWithUser, formData: FormData) {
-  return getUserWithRoles(ctx, formData, async (role, userWithRoles, requestedRole) => {
-    if (requestedRole) {
-      return { message: 'ok', info: 'user already has requested role' };
+/**
+ * Grant a site role to a user.
+ *
+ * **⚠️ IMPORTANT: Authorization is assumed to be done by the caller.**
+ *
+ * This function expects that the caller has already verified:
+ * - The actor has the required scopes (e.g., `site.users.update`)
+ * - The actor has permission to grant the target role (role hierarchy check)
+ *
+ * The function performs:
+ * - Validation that the target user doesn't already have the role
+ *
+ * Authorization should be performed in the route handler using:
+ * - `withAppSiteContext()` to check required scopes
+ * - `canModifySiteRole()` or `canGrantSiteRole()` to check role hierarchy permissions
+ *
+ * @param ctx - Site context with authenticated user
+ * @param payload - Validated form data containing `userId` or `email` and `role`
+ * @returns Success response or error response
+ */
+export async function $actionGrantUserRole(ctx: SiteContextWithUser, payload: ParsedFormData) {
+  return getUserWithRoles(ctx, payload, async (role, userWithRoles, existingRoleIfOnTargetUser) => {
+    if (existingRoleIfOnTargetUser) {
+      return { message: 'ok', info: 'user already has the requested role' };
     }
     await dbAddSiteUserRole(ctx.site.id, userWithRoles.id, role);
 
@@ -136,10 +216,36 @@ export async function actionGrantUserRole(ctx: SiteContextWithUser, formData: Fo
   });
 }
 
-export async function actionRevokeUserRole(ctx: SiteContextWithUser, formData: FormData) {
-  return getUserWithRoles(ctx, formData, async (role, userWithRoles, requestedRole) => {
-    if (!requestedRole) {
-      return { message: 'ok', info: 'user does not have specified role' };
+/**
+ * Revoke a site role from a user.
+ *
+ * **⚠️ IMPORTANT: Authorization is assumed to be done by the caller.**
+ * This function expects that the caller has already verified:
+ * - The actor has the required scopes (e.g., `site.users.delete`)
+ * - The actor has permission to modify the target role (role hierarchy check)
+ *
+ * The function performs:
+ * - Validation that the user has the role to revoke
+ * - Self-protection check (prevents users from revoking their own admin role)
+ *
+ * Authorization should be performed in the route handler using:
+ * - `withAppSiteContext()` to check required scopes
+ * - `canModifySiteRole()` to check role hierarchy permissions
+ *
+ * @param ctx - Site context with authenticated user
+ * @param payload - Validated form data containing `userId` or `email` and `role`
+ * @returns Success response or error response
+ */
+export async function $actionRevokeUserRole(ctx: SiteContextWithUser, payload: ParsedFormData) {
+  return getUserWithRoles(ctx, payload, async (role, userWithRoles, existingRoleIfOnTargetUser) => {
+    if (!existingRoleIfOnTargetUser) {
+      return data(
+        {
+          message: 'unprocessable content',
+          info: 'user does not have specified role, cannot revoke it',
+        },
+        { status: 422 },
+      );
     }
     if (role === SiteRole.ADMIN && ctx.user?.id === userWithRoles.id) {
       return data(

--- a/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
@@ -171,7 +171,7 @@ async function getUserWithRoles<T>(
  */
 export async function $actionGrantUserRole(ctx: SiteContextWithUser, payload: ParsedFormData) {
   return getUserWithRoles(ctx, payload, async (role, userWithRoles, existingRoleIfOnTargetUser) => {
-    // Prevent non-admins from modifying their own roles
+    // Prevent users from modifying their own roles
     if (ctx.user.id === userWithRoles.id) {
       return data(
         {
@@ -264,11 +264,8 @@ export async function $actionRevokeUserRole(ctx: SiteContextWithUser, payload: P
       );
     }
 
-    // Prevent non-admins from modifying their own roles
-    if (
-      ctx.user.id === userWithRoles.id &&
-      !userHasSiteScope(ctx.user, siteScopes.users.admin, ctx.site.id)
-    ) {
+    // Prevent users from modifying their own roles
+    if (ctx.user.id === userWithRoles.id) {
       return data(
         {
           error: {

--- a/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
@@ -39,8 +39,11 @@ async function getUserWithRoles<T>(
   }
   const { email, userId, role } = payload;
 
-  // Validate that either email or userId is provided
-  if (!email && !userId) {
+  // Validate that either email or userId is provided (and not empty strings)
+  const hasUserId = userId && typeof userId === 'string' && userId.trim().length > 0;
+  const hasEmail = email && typeof email === 'string' && email.trim().length > 0;
+
+  if (!hasUserId && !hasEmail) {
     return data(
       { message: 'unprocessable content', error: 'Either email or userId must be provided' },
       { status: 422 },
@@ -49,7 +52,7 @@ async function getUserWithRoles<T>(
 
   // Get user by email or userId
   let userWithRoles;
-  if (userId) {
+  if (hasUserId && userId) {
     userWithRoles = await dbGetUserById(userId);
     if (!userWithRoles) {
       return data(
@@ -57,7 +60,7 @@ async function getUserWithRoles<T>(
         { status: 404 },
       );
     }
-  } else if (email) {
+  } else if (hasEmail && email) {
     // Validate email format if provided
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(email)) {
@@ -133,7 +136,7 @@ export async function actionGrantUserRole(ctx: SiteContextWithUser, formData: Fo
   });
 }
 
-export async function actionRevokeUserRole(ctx: SiteContext, formData: FormData) {
+export async function actionRevokeUserRole(ctx: SiteContextWithUser, formData: FormData) {
   return getUserWithRoles(ctx, formData, async (role, userWithRoles, requestedRole) => {
     if (!requestedRole) {
       return { message: 'ok', info: 'user does not have specified role' };

--- a/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
@@ -255,8 +255,10 @@ export async function $actionRevokeUserRole(ctx: SiteContextWithUser, payload: P
     if (!existingRoleIfOnTargetUser) {
       return data(
         {
-          message: 'unprocessable content',
-          info: 'user does not have specified role, cannot revoke it',
+          error: {
+            type: 'general',
+            message: 'user does not have specified role, cannot revoke it',
+          },
         },
         { status: 422 },
       );

--- a/ee/sites/src/routes/$siteName.users/route.tsx
+++ b/ee/sites/src/routes/$siteName.users/route.tsx
@@ -45,6 +45,7 @@ export async function loader(args: LoaderFunctionArgs): Promise<LoaderData | { e
 
 export async function action(args: ActionFunctionArgs) {
   const ctx = await withAppSiteContext(args, [siteScopes.users.update, siteScopes.users.delete]);
+  console.log('ctx', ctx.user);
 
   const formData = await args.request.formData();
   const intent = formData.get('intent');

--- a/ee/sites/src/routes/$siteName.users/route.tsx
+++ b/ee/sites/src/routes/$siteName.users/route.tsx
@@ -78,13 +78,9 @@ export async function loader(args: LoaderFunctionArgs): Promise<LoaderData | { e
 export async function action(args: ActionFunctionArgs) {
   // redirect: false here without a catch and custom error handling, with return a hard 403, resulting in an error page
   // this desired UX as the UI controls should be disabled if the user does not have permission
-  const ctx = await withAppSiteContext(
-    args,
-    [siteScopes.users.update, siteScopes.users.delete, siteScopes.users.admin],
-    {
-      redirect: false,
-    },
-  );
+  const ctx = await withAppSiteContext(args, [siteScopes.users.update, siteScopes.users.delete], {
+    redirect: false,
+  });
 
   const formData = await args.request.formData();
 
@@ -146,7 +142,7 @@ export default function Users({ loaderData }: { loaderData: LoaderData }) {
       {/* Add User Section */}
 
       {canUpdateRoles && (
-        <SectionWithHeading heading="Add User" icon={UserPlus}>
+        <SectionWithHeading heading="Grant Roles" icon={UserPlus}>
           <div className="p-6 bg-white rounded-lg border border-gray-200 dark:bg-gray-800 dark:border-gray-700">
             <SiteRolesForm canGrantAdminRole={canModifyAdminRoles} />
           </div>
@@ -170,10 +166,7 @@ export default function Users({ loaderData }: { loaderData: LoaderData }) {
                 key={user.id}
                 name={user.display_name || 'Unknown User'}
                 email={user.email}
-                roles={user.site_roles.map((roleObj) => ({
-                  role: roleObj.role,
-                  canRemove: roleObj.canRemove,
-                }))}
+                roles={user.site_roles}
                 userId={user.id}
               />
             ))

--- a/ee/sites/src/routes/$siteName.users/route.tsx
+++ b/ee/sites/src/routes/$siteName.users/route.tsx
@@ -63,7 +63,12 @@ export async function loader(args: LoaderFunctionArgs): Promise<LoaderData | { e
     ...user,
     site_roles: user.site_roles.map((role) => ({
       role,
-      canRemove: role === SiteRole.ADMIN ? canModifyAdminRoles : canUpdateRoles,
+      canRemove:
+        user.id === ctx.user.id
+          ? false
+          : role === SiteRole.ADMIN
+            ? canModifyAdminRoles
+            : canUpdateRoles,
     })),
   }));
 

--- a/ee/sites/src/routes/$siteName.users/route.tsx
+++ b/ee/sites/src/routes/$siteName.users/route.tsx
@@ -20,6 +20,7 @@ import {
   $actionGrantUserRole,
   $actionRevokeUserRole,
   ActionFormDataSchema,
+  type ParsedFormData,
 } from './actionHelpers.server.js';
 
 interface LoaderData {
@@ -88,7 +89,8 @@ export async function action(args: ActionFunctionArgs) {
 
   // Extract intent and payload (without intent)
   const { intent, ...payload } = validatedData;
-  const { role: targetRole } = payload;
+  const rolePayload: ParsedFormData = payload;
+  const { role: targetRole } = rolePayload;
 
   if (targetRole === SiteRole.ADMIN) {
     if (!userHasSiteScope(ctx.user, siteScopes.users.admin)) {
@@ -106,9 +108,9 @@ export async function action(args: ActionFunctionArgs) {
 
   // Route to appropriate action based on intent
   if (intent === 'grant') {
-    return $actionGrantUserRole(ctx, payload);
+    return $actionGrantUserRole(ctx, rolePayload);
   } else if (intent === 'revoke') {
-    return $actionRevokeUserRole(ctx, payload);
+    return $actionRevokeUserRole(ctx, rolePayload);
   }
 
   // This should never happen due to Zod validation, but TypeScript needs it

--- a/ee/sites/src/routes/$siteName.users/route.tsx
+++ b/ee/sites/src/routes/$siteName.users/route.tsx
@@ -52,7 +52,8 @@ export async function loader(args: LoaderFunctionArgs): Promise<LoaderData | { e
     [siteScopes.users.update, siteScopes.users.delete],
     ctx.site.id,
   );
-  const canModifyAdminRoles = canUpdateRoles && userHasSiteScope(ctx.user, siteScopes.users.admin);
+  const canModifyAdminRoles =
+    canUpdateRoles && userHasSiteScope(ctx.user, siteScopes.users.admin, ctx.site.id);
 
   // Regular page load
   const dbo = await dbGetSiteUsers(ctx.site.name);
@@ -112,7 +113,7 @@ export async function action(args: ActionFunctionArgs) {
   const { role: targetRole } = rolePayload;
 
   if (targetRole === SiteRole.ADMIN) {
-    if (!userHasSiteScope(ctx.user, siteScopes.users.admin)) {
+    if (!userHasSiteScope(ctx.user, siteScopes.users.admin, ctx.site.id)) {
       return data(
         {
           error: {

--- a/ee/sites/src/routes/$siteName.users/route.tsx
+++ b/ee/sites/src/routes/$siteName.users/route.tsx
@@ -24,10 +24,14 @@ import {
 } from './actionHelpers.server.js';
 
 interface LoaderData {
-  users: ReturnType<typeof dtoSiteUsers>;
+  users: Array<
+    Omit<ReturnType<typeof dtoSiteUsers>[number], 'site_roles'> & {
+      site_roles: { role: SiteRole; canRemove: boolean }[];
+    }
+  >;
   site: ReturnType<typeof sites.formatSiteDTO>;
-  canAddRemoveUsers: boolean;
-  canRemoveAdmins: boolean;
+  canUpdateRoles: boolean;
+  canModifyAdminRoles: boolean;
 }
 
 export const meta: MetaFunction<typeof loader> = ({ matches, loaderData }) => {
@@ -43,18 +47,32 @@ export async function loader(args: LoaderFunctionArgs): Promise<LoaderData | { e
     redirect: true,
   });
 
-  const canAddRemoveUsers = userHasSiteScopes(
+  const canUpdateRoles = userHasSiteScopes(
     ctx.user,
     [siteScopes.users.update, siteScopes.users.delete],
     ctx.site.id,
   );
-  const canRemoveAdmins = canAddRemoveUsers && userHasSiteScope(ctx.user, siteScopes.users.admin);
+  const canModifyAdminRoles = canUpdateRoles && userHasSiteScope(ctx.user, siteScopes.users.admin);
 
   // Regular page load
   const dbo = await dbGetSiteUsers(ctx.site.name);
   if (!dbo) return { error: 'Failed to get site users' };
   const users = dtoSiteUsers(dbo);
-  return { users, site: ctx.siteDTO, canAddRemoveUsers, canRemoveAdmins };
+
+  const usersWithScopedRoles = users.map((user) => ({
+    ...user,
+    site_roles: user.site_roles.map((role) => ({
+      role,
+      canRemove: role === SiteRole.ADMIN ? canModifyAdminRoles : canUpdateRoles,
+    })),
+  }));
+
+  return {
+    users: usersWithScopedRoles,
+    site: ctx.siteDTO,
+    canUpdateRoles,
+    canModifyAdminRoles,
+  };
 }
 
 export async function action(args: ActionFunctionArgs) {
@@ -121,16 +139,16 @@ export async function action(args: ActionFunctionArgs) {
 }
 
 export default function Users({ loaderData }: { loaderData: LoaderData }) {
-  const { users, site, canAddRemoveUsers } = loaderData;
+  const { users, site, canUpdateRoles, canModifyAdminRoles } = loaderData;
 
   return (
     <PageFrame title="Users" subtitle={`Manage the users and access roles for ${site?.title}`}>
       {/* Add User Section */}
 
-      {canAddRemoveUsers && (
+      {canUpdateRoles && (
         <SectionWithHeading heading="Add User" icon={UserPlus}>
           <div className="p-6 bg-white rounded-lg border border-gray-200 dark:bg-gray-800 dark:border-gray-700">
-            <SiteRolesForm />
+            <SiteRolesForm canGrantAdminRole={canModifyAdminRoles} />
           </div>
         </SectionWithHeading>
       )}
@@ -152,9 +170,9 @@ export default function Users({ loaderData }: { loaderData: LoaderData }) {
                 key={user.id}
                 name={user.display_name || 'Unknown User'}
                 email={user.email}
-                roles={user.site_roles.map((role) => ({
-                  role,
-                  canRemove: canAddRemoveUsers,
+                roles={user.site_roles.map((roleObj) => ({
+                  role: roleObj.role,
+                  canRemove: roleObj.canRemove,
                 }))}
                 userId={user.id}
               />

--- a/ee/sites/src/routes/$siteName.users/route.tsx
+++ b/ee/sites/src/routes/$siteName.users/route.tsx
@@ -1,8 +1,9 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
 import { data } from 'react-router';
+import { SiteRole } from '@curvenote/scms-db';
 import type { GeneralError } from '@curvenote/scms-core';
 import type { sites } from '@curvenote/scms-server';
-import { withAppSiteContext, userHasScope, assertUserDefined } from '@curvenote/scms-server';
+import { withAppSiteContext, userHasSiteScopes, userHasSiteScope } from '@curvenote/scms-server';
 import { UserIcon } from '@heroicons/react/24/outline';
 import { User, UserPlus } from 'lucide-react';
 import {
@@ -12,15 +13,20 @@ import {
   getBrandingFromMetaMatches,
   joinPageTitle,
   SectionWithHeading,
-  scopes,
 } from '@curvenote/scms-core';
 import { dbGetSiteUsers, dtoSiteUsers } from './db.server.js';
 import { SiteRolesForm } from './SiteRolesForm.js';
-import { actionGrantUserRole, actionRevokeUserRole } from './actionHelpers.server.js';
+import {
+  $actionGrantUserRole,
+  $actionRevokeUserRole,
+  ActionFormDataSchema,
+} from './actionHelpers.server.js';
 
 interface LoaderData {
   users: ReturnType<typeof dtoSiteUsers>;
   site: ReturnType<typeof sites.formatSiteDTO>;
+  canAddRemoveUsers: boolean;
+  canRemoveAdmins: boolean;
 }
 
 export const meta: MetaFunction<typeof loader> = ({ matches, loaderData }) => {
@@ -36,48 +42,76 @@ export async function loader(args: LoaderFunctionArgs): Promise<LoaderData | { e
     redirect: true,
   });
 
+  const canAddRemoveUsers = userHasSiteScopes(
+    ctx.user,
+    [siteScopes.users.update, siteScopes.users.delete],
+    ctx.site.id,
+  );
+  const canRemoveAdmins = canAddRemoveUsers && userHasSiteScope(ctx.user, siteScopes.users.admin);
+
   // Regular page load
   const dbo = await dbGetSiteUsers(ctx.site.name);
   if (!dbo) return { error: 'Failed to get site users' };
   const users = dtoSiteUsers(dbo);
-  return { users, site: ctx.siteDTO };
+  return { users, site: ctx.siteDTO, canAddRemoveUsers, canRemoveAdmins };
 }
 
 export async function action(args: ActionFunctionArgs) {
-  const ctx = await withAppSiteContext(args, [siteScopes.users.update, siteScopes.users.delete]);
-  console.log('ctx', ctx.user);
+  // redirect: false here without a catch and custom error handling, with return a hard 403, resulting in an error page
+  // this desired UX as the UI controls should be disabled if the user does not have permission
+  const ctx = await withAppSiteContext(
+    args,
+    [siteScopes.users.update, siteScopes.users.delete, siteScopes.users.admin],
+    {
+      redirect: false,
+    },
+  );
 
   const formData = await args.request.formData();
-  const intent = formData.get('intent');
 
-  if (typeof intent !== 'string' || intent.length === 0) {
-    return data(
-      { error: { type: 'general', message: 'Intent not set' } as GeneralError },
-      { status: 400 },
-    );
-  }
-
-  // For grant/revoke actions, require additional permissions
-  assertUserDefined(ctx.user);
-
-  if (!userHasScope(ctx.user, scopes.site.users.update, ctx.site.name)) {
+  // Validate form data including intent
+  let validatedData;
+  try {
+    validatedData = ActionFormDataSchema.parse(Object.fromEntries(formData));
+  } catch (error: any) {
+    console.error(`Invalid form data ${error}`);
     return data(
       {
         error: {
           type: 'general',
-          message: 'Unauthorized: current user cannot update user roles',
+          message: error?.issues?.[0]?.message || 'Invalid form data',
         } as GeneralError,
       },
-      { status: 401 },
+      { status: 422 },
     );
   }
 
-  if (intent === 'grant') {
-    return actionGrantUserRole(ctx, formData);
-  } else if (intent === 'revoke') {
-    return actionRevokeUserRole(ctx, formData);
+  // Extract intent and payload (without intent)
+  const { intent, ...payload } = validatedData;
+  const { role: targetRole } = payload;
+
+  if (targetRole === SiteRole.ADMIN) {
+    if (!userHasSiteScope(ctx.user, siteScopes.users.admin)) {
+      return data(
+        {
+          error: {
+            type: 'general',
+            message: `You are not authorized to ${intent} admin permissions`,
+          } as GeneralError,
+        },
+        { status: 403 },
+      );
+    }
   }
 
+  // Route to appropriate action based on intent
+  if (intent === 'grant') {
+    return $actionGrantUserRole(ctx, payload);
+  } else if (intent === 'revoke') {
+    return $actionRevokeUserRole(ctx, payload);
+  }
+
+  // This should never happen due to Zod validation, but TypeScript needs it
   return data(
     { error: { type: 'general', message: 'Invalid intent' } as GeneralError },
     { status: 400 },
@@ -85,17 +119,19 @@ export async function action(args: ActionFunctionArgs) {
 }
 
 export default function Users({ loaderData }: { loaderData: LoaderData }) {
-  const { users, site } = loaderData;
+  const { users, site, canAddRemoveUsers } = loaderData;
 
   return (
     <PageFrame title="Users" subtitle={`Manage the users and access roles for ${site?.title}`}>
       {/* Add User Section */}
 
-      <SectionWithHeading heading="Add User" icon={UserPlus}>
-        <div className="p-6 bg-white rounded-lg border border-gray-200 dark:bg-gray-800 dark:border-gray-700">
-          <SiteRolesForm />
-        </div>
-      </SectionWithHeading>
+      {canAddRemoveUsers && (
+        <SectionWithHeading heading="Add User" icon={UserPlus}>
+          <div className="p-6 bg-white rounded-lg border border-gray-200 dark:bg-gray-800 dark:border-gray-700">
+            <SiteRolesForm />
+          </div>
+        </SectionWithHeading>
+      )}
 
       {/* Current Users Section */}
       <SectionWithHeading heading="Current Users" icon={User}>
@@ -114,7 +150,10 @@ export default function Users({ loaderData }: { loaderData: LoaderData }) {
                 key={user.id}
                 name={user.display_name || 'Unknown User'}
                 email={user.email}
-                roles={user.site_roles}
+                roles={user.site_roles.map((role) => ({
+                  role,
+                  canRemove: canAddRemoveUsers,
+                }))}
                 userId={user.id}
               />
             ))

--- a/ee/sites/src/routes/$siteName/menu.server.ts
+++ b/ee/sites/src/routes/$siteName/menu.server.ts
@@ -1,9 +1,9 @@
 import type { MenuContents } from '@curvenote/scms-core';
-import type { SiteContext } from '@curvenote/scms-server';
+import type { SiteContextWithUser } from '@curvenote/scms-server';
 import { registerExtensionNavigation, scopes } from '@curvenote/scms-core';
 import { userHasSiteScope } from '@curvenote/scms-server';
 
-export async function buildMenu(ctx: SiteContext): Promise<MenuContents> {
+export async function buildMenu(ctx: SiteContextWithUser): Promise<MenuContents> {
   const mountPoint = `app/sites/${ctx.site.name}`;
   const baseUrl = `/${mountPoint}`;
 
@@ -71,13 +71,13 @@ export async function buildMenu(ctx: SiteContext): Promise<MenuContents> {
           name: 'admin.advanced',
           label: 'Advanced',
           url: `${baseUrl}/advanced`,
-          scope: scopes.site.update,
+          scope: scopes.system.admin,
         },
         {
           name: 'admin.analytics',
           label: 'Analytics',
           url: `${baseUrl}/analytics`,
-          scope: scopes.site.read,
+          scope: scopes.site.analytics.list,
         },
       ],
     },

--- a/packages/scms-core/src/components/InviteUserDialog.tsx
+++ b/packages/scms-core/src/components/InviteUserDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useFetcher } from 'react-router';
-import { SimpleDialog } from './ui/simple-dialog.js';
+import { SimpleDialog } from './dialogs/SimpleDialog.js';
 import { Button } from './ui/button.js';
 import { LimitedTextarea } from './ui/limited-textarea.js';
 import { Label } from './ui/label.js';

--- a/packages/scms-core/src/components/InviteUserDialog.tsx
+++ b/packages/scms-core/src/components/InviteUserDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useFetcher } from 'react-router';
-import { SimpleDialog } from './dialogs/SimpleDialog.js';
+import { SimpleDialog } from './ui/dialogs/index.js';
 import { Button } from './ui/button.js';
 import { LimitedTextarea } from './ui/limited-textarea.js';
 import { Label } from './ui/label.js';

--- a/packages/scms-core/src/components/RequestHelpDialog.tsx
+++ b/packages/scms-core/src/components/RequestHelpDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useFetcher } from 'react-router';
-import { SimpleDialog } from './dialogs/SimpleDialog.js';
+import { SimpleDialog } from './ui/dialogs/index.js';
 import { Button } from './ui/button.js';
 import { LimitedTextarea } from './ui/limited-textarea.js';
 import { Label } from './ui/label.js';
@@ -287,7 +287,7 @@ export function RequestHelpDialog({
         footerButtons={[{ label: 'Close', onClick: handleSuccessClose }]}
       >
         <div className="flex flex-col items-center py-6">
-          <CircleCheck className="w-16 h-16 mb-4 text-green-600" />
+          <CircleCheck className="mb-4 w-16 h-16 text-green-600" />
           <h2 className="text-lg font-semibold leading-none text-center">Request Sent</h2>
           <p className="mt-2 text-base text-center text-muted-foreground">{successMessage}</p>
         </div>

--- a/packages/scms-core/src/components/RequestHelpDialog.tsx
+++ b/packages/scms-core/src/components/RequestHelpDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useFetcher } from 'react-router';
-import { SimpleDialog } from './ui/simple-dialog.js';
+import { SimpleDialog } from './dialogs/SimpleDialog.js';
 import { Button } from './ui/button.js';
 import { LimitedTextarea } from './ui/limited-textarea.js';
 import { Label } from './ui/label.js';

--- a/packages/scms-core/src/components/UserCard.tsx
+++ b/packages/scms-core/src/components/UserCard.tsx
@@ -2,8 +2,9 @@ import { useFetcher } from 'react-router';
 import { UserIcon } from '@heroicons/react/24/outline';
 import { X } from 'lucide-react';
 import { Badge } from './ui/index.js';
+import { SimpleDialog } from './dialogs/index.js';
 import { cn } from '../utils/cn.js';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useMyUser } from '../providers/MyUserProvider.js';
 import { toastSuccess, toastError } from './ui/toast.js';
 import type { GeneralError } from '../backend/types.js';
@@ -23,6 +24,9 @@ function TableRow({ children, className }: { children: React.ReactNode; classNam
 export function UserCard({ roles, email, name, userId }: UserProps) {
   const fetcher = useFetcher<{ error?: GeneralError; message?: string; info?: string }>();
   const currentUser = useMyUser();
+  const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+  const [roleToRemove, setRoleToRemove] = useState<string | null>(null);
+  const [formToSubmit, setFormToSubmit] = useState<HTMLFormElement | null>(null);
 
   // Check if the current user is viewing their own card
   const isCurrentUser = currentUser && userId && currentUser.id === userId;
@@ -44,6 +48,22 @@ export function UserCard({ roles, email, name, userId }: UserProps) {
 
   const getRoleDisplayName = (role: string) => {
     return role.charAt(0).toUpperCase() + role.slice(1).toLowerCase();
+  };
+
+  const handleConfirmRemove = () => {
+    if (formToSubmit) {
+      const formData = new FormData(formToSubmit);
+      fetcher.submit(formData, { method: 'POST' });
+    }
+    setConfirmDialogOpen(false);
+    setRoleToRemove(null);
+    setFormToSubmit(null);
+  };
+
+  const handleCancelRemove = () => {
+    setConfirmDialogOpen(false);
+    setRoleToRemove(null);
+    setFormToSubmit(null);
   };
 
   return (
@@ -77,14 +97,9 @@ export function UserCard({ roles, email, name, userId }: UserProps) {
                       toastError('Cannot remove user: user ID is missing');
                       return;
                     }
-                    if (
-                      window.confirm(
-                        `Are you sure you want to remove the ${getRoleDisplayName(role)} role from ${name || 'this user'}?`,
-                      )
-                    ) {
-                      const formData = new FormData(e.currentTarget);
-                      fetcher.submit(formData, { method: 'POST' });
-                    }
+                    setRoleToRemove(role);
+                    setFormToSubmit(e.currentTarget);
+                    setConfirmDialogOpen(true);
                   }}
                 >
                   <input type="hidden" name="intent" value="revoke" />
@@ -119,6 +134,28 @@ export function UserCard({ roles, email, name, userId }: UserProps) {
           ))}
         </div>
       </TableRow>
+      <SimpleDialog
+        open={confirmDialogOpen}
+        onOpenChange={setConfirmDialogOpen}
+        title="Remove Role"
+        description={
+          roleToRemove
+            ? `Are you sure you want to remove the ${getRoleDisplayName(roleToRemove)} role from ${name || 'this user'}?`
+            : ''
+        }
+        footerButtons={[
+          {
+            label: 'Cancel',
+            onClick: handleCancelRemove,
+            variant: 'outline',
+          },
+          {
+            label: 'Remove Role',
+            onClick: handleConfirmRemove,
+            variant: 'destructive',
+          },
+        ]}
+      />
     </>
   );
 }

--- a/packages/scms-core/src/components/UserCard.tsx
+++ b/packages/scms-core/src/components/UserCard.tsx
@@ -106,6 +106,10 @@ export function UserCard({ roles, email, name, userId }: UserProps) {
                   method="post"
                   onSubmit={(e) => {
                     e.preventDefault();
+                    if (!userId) {
+                      toastError('Cannot remove user: user ID is missing');
+                      return;
+                    }
                     if (
                       window.confirm(
                         `Are you sure you want to remove the ${getRoleDisplayName(role)} role from ${name || 'this user'}?`,
@@ -117,7 +121,7 @@ export function UserCard({ roles, email, name, userId }: UserProps) {
                   }}
                 >
                   <input type="hidden" name="intent" value="revoke" />
-                  <input type="hidden" name="email" value={email || ''} />
+                  <input type="hidden" name="userId" value={userId || ''} />
                   <input type="hidden" name="role" value={role} />
                   <Badge
                     variant="outline"

--- a/packages/scms-core/src/components/UserCard.tsx
+++ b/packages/scms-core/src/components/UserCard.tsx
@@ -6,10 +6,10 @@ import { cn } from '../utils/cn.js';
 import { useEffect } from 'react';
 import { useMyUser } from '../providers/MyUserProvider.js';
 import { toastSuccess, toastError } from './ui/toast.js';
-import type { SiteRole } from '@curvenote/scms-db';
+import type { GeneralError } from '../backend/types.js';
 
 type UserProps = {
-  roles: { role: SiteRole; canRemove: boolean }[];
+  roles: { role: string; canRemove: boolean }[];
   email?: string | null;
   name?: string | null;
   userId?: string | null;
@@ -21,7 +21,7 @@ function TableRow({ children, className }: { children: React.ReactNode; classNam
 }
 
 export function UserCard({ roles, email, name, userId }: UserProps) {
-  const fetcher = useFetcher<{ ok: boolean; error?: string; info?: string }>();
+  const fetcher = useFetcher<{ error?: GeneralError; message?: string; info?: string }>();
   const currentUser = useMyUser();
 
   // Check if the current user is viewing their own card
@@ -31,7 +31,11 @@ export function UserCard({ roles, email, name, userId }: UserProps) {
   useEffect(() => {
     if (fetcher.state === 'idle' && fetcher.data) {
       if (fetcher.data.error) {
-        toastError(fetcher.data.error);
+        const errorMessage =
+          typeof fetcher.data.error === 'object' && 'message' in fetcher.data.error
+            ? fetcher.data.error.message
+            : 'An error occurred';
+        toastError(errorMessage);
       } else if (fetcher.data.info) {
         toastSuccess(fetcher.data.info);
       }

--- a/packages/scms-core/src/components/UserCard.tsx
+++ b/packages/scms-core/src/components/UserCard.tsx
@@ -1,17 +1,19 @@
 import { useFetcher } from 'react-router';
 import { UserIcon } from '@heroicons/react/24/outline';
-import { X, Crown, Edit, Eye, User, FileText } from 'lucide-react';
+import { X } from 'lucide-react';
 import { Badge } from './ui/index.js';
 import { cn } from '../utils/cn.js';
 import { useEffect } from 'react';
 import { useMyUser } from '../providers/MyUserProvider.js';
 import { toastSuccess, toastError } from './ui/toast.js';
+import type { SiteRole } from '@curvenote/scms-db';
 
 type UserProps = {
-  roles: string[];
+  roles: { role: SiteRole; canRemove: boolean }[];
   email?: string | null;
   name?: string | null;
   userId?: string | null;
+  canUpdateUsers?: boolean;
 };
 
 function TableRow({ children, className }: { children: React.ReactNode; className?: string }) {
@@ -36,55 +38,16 @@ export function UserCard({ roles, email, name, userId }: UserProps) {
     }
   }, [fetcher.state, fetcher.data]);
 
-  const getRoleIcon = (role: string) => {
-    switch (role) {
-      case 'ADMIN':
-      case 'OWNER':
-        return <Crown className="w-4 h-4 text-foreground" />;
-      case 'CONTRIBUTOR':
-      case 'EDITOR':
-        return <Edit className="w-4 h-4 text-foreground" />;
-      case 'VIEWER':
-      case 'REVIEWER':
-        return <Eye className="w-4 h-4 text-foreground" />;
-      case 'AUTHOR':
-        return <User className="w-4 h-4 text-foreground" />;
-      case 'SUBMITTER':
-        return <FileText className="w-4 h-4 text-foreground" />;
-      default:
-        return <User className="w-4 h-4 text-foreground" />;
-    }
-  };
-
   const getRoleDisplayName = (role: string) => {
-    switch (role) {
-      case 'ADMIN':
-        return 'Admin';
-      case 'EDITOR':
-        return 'Editor';
-      case 'REVIEWER':
-        return 'Reviewer';
-      case 'AUTHOR':
-        return 'Author';
-      case 'SUBMITTER':
-        return 'Submitter';
-      case 'OWNER':
-        return 'Owner';
-      case 'CONTRIBUTOR':
-        return 'Contributor';
-      case 'VIEWER':
-        return 'Viewer';
-      default:
-        return role.charAt(0).toUpperCase() + role.slice(1).toLowerCase();
-    }
+    return role.charAt(0).toUpperCase() + role.slice(1).toLowerCase();
   };
 
   return (
     <>
-      <TableRow className="flex items-center justify-between p-4 bg-white">
+      <TableRow className="flex justify-between items-center p-4 bg-white">
         <div className="flex items-center space-x-3">
           <div className="flex-shrink-0">
-            <div className="flex items-center justify-center w-10 h-10 rounded-full bg-foreground/10">
+            <div className="flex justify-center items-center w-10 h-10 rounded-full bg-foreground/10">
               <UserIcon className="w-6 h-6 text-muted-foreground" />
             </div>
           </div>
@@ -99,9 +62,9 @@ export function UserCard({ roles, email, name, userId }: UserProps) {
         </div>
 
         <div className="flex items-center space-x-2">
-          {roles.map((role) => (
+          {roles.map(({ role, canRemove }) => (
             <div key={role} className="relative">
-              {!isCurrentUser ? (
+              {!isCurrentUser && canRemove ? (
                 <fetcher.Form
                   method="post"
                   onSubmit={(e) => {
@@ -135,16 +98,14 @@ export function UserCard({ roles, email, name, userId }: UserProps) {
                       }
                     }}
                   >
-                    {getRoleIcon(role)}
                     <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
                       {getRoleDisplayName(role)}
                     </span>
-                    <X className="w-3 h-3 ml-1 text-gray-400 transition-colors group-hover:text-red-500" />
+                    <X className="ml-1 w-3 h-3 text-gray-400 transition-colors group-hover:text-red-500" />
                   </Badge>
                 </fetcher.Form>
               ) : (
                 <Badge variant="outline">
-                  {getRoleIcon(role)}
                   <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
                     {getRoleDisplayName(role)}
                   </span>

--- a/packages/scms-core/src/components/UserCard.tsx
+++ b/packages/scms-core/src/components/UserCard.tsx
@@ -2,7 +2,7 @@ import { useFetcher } from 'react-router';
 import { UserIcon } from '@heroicons/react/24/outline';
 import { X } from 'lucide-react';
 import { Badge } from './ui/index.js';
-import { SimpleDialog } from './dialogs/index.js';
+import { SimpleDialog } from './ui/dialogs/index.js';
 import { cn } from '../utils/cn.js';
 import { useEffect, useState } from 'react';
 import { useMyUser } from '../providers/MyUserProvider.js';

--- a/packages/scms-core/src/components/dialogs/SimpleDialog.tsx
+++ b/packages/scms-core/src/components/dialogs/SimpleDialog.tsx
@@ -8,8 +8,8 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from './dialog.js';
-import { Button, type ButtonProps } from './button.js';
+} from '../ui/dialog.js';
+import { Button, type ButtonProps } from '../ui/button.js';
 import { cn } from '../../utils/cn.js';
 import type { DialogContentProps } from '@radix-ui/react-dialog';
 

--- a/packages/scms-core/src/components/dialogs/index.ts
+++ b/packages/scms-core/src/components/dialogs/index.ts
@@ -1,1 +1,2 @@
 export * from './ResumeDraftWorkDialog.js';
+export * from './SimpleDialog.js';

--- a/packages/scms-core/src/components/index.ts
+++ b/packages/scms-core/src/components/index.ts
@@ -17,8 +17,6 @@ export * from './SystemAdminBadge.js';
 export * from './ThemeSwitcher.js';
 export * from './UserCard.js';
 export * from './VersionsListing.js';
-
-export * from './dialogs/index.js';
 export * from './layout/index.js';
 export * from './navigation/index.js';
 export * from './upload/index.js';

--- a/packages/scms-core/src/components/ui/dialogs/ResumeDraftWorkDialog.tsx
+++ b/packages/scms-core/src/components/ui/dialogs/ResumeDraftWorkDialog.tsx
@@ -8,24 +8,13 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '../ui/dialog.js';
-import { Button } from '../ui/button.js';
-import { LoadingSpinner } from '../LoadingSpinner.js';
+} from '../dialog.js';
+import { Button } from '../button.js';
+import { LoadingSpinner } from '../../LoadingSpinner.js';
 import { formatDistanceToNow } from 'date-fns';
 import { Trash2 } from 'lucide-react';
-import { plural } from '../../utils/plural.js';
-
-/**
- * Base draft work type - can be extended for specific use cases
- */
-export interface DraftWork {
-  workId: string;
-  workVersionId: string;
-  workTitle: string;
-  dateModified: string;
-  dateCreated: string;
-  metadata?: any;
-}
+import { plural } from '../../../utils/plural.js';
+import type { DraftWork } from './types.js';
 
 /**
  * Props for the ResumeDraftWorkDialog component
@@ -177,9 +166,9 @@ function DraftWorkItem<T extends DraftWork>({
 
   return (
     <>
-      <div className="flex items-center justify-between p-4 border rounded-lg hover:bg-gray-50">
+      <div className="flex justify-between items-center p-4 rounded-lg border hover:bg-gray-50">
         <div className="flex-1 min-w-0">
-          <div className="flex items-center justify-between mb-2">
+          <div className="flex justify-between items-center mb-2">
             <div className="flex flex-col">
               <div className="text-sm font-medium text-muted-foreground">
                 Last modified {timeAgo}
@@ -196,7 +185,7 @@ function DraftWorkItem<T extends DraftWork>({
               <Trash2 className="w-4 h-4" />
             </Button>
           </div>
-          <div className="flex items-center justify-between mb-1">
+          <div className="flex justify-between items-center mb-1">
             <h3 className="text-base font-medium text-gray-900 truncate">{draft.workTitle}</h3>
           </div>
           {renderDetails && (
@@ -204,7 +193,7 @@ function DraftWorkItem<T extends DraftWork>({
           )}
           <Button
             onClick={handleResume}
-            className="w-full mt-2"
+            className="mt-2 w-full"
             disabled={fetcher.state !== 'idle'}
           >
             {resumeButtonLabel}
@@ -364,11 +353,11 @@ export function ResumeDraftWorkDialog<T extends DraftWork>({
     <div>
       You already have <span className="font-bold">{drafts.length}</span> draft{' '}
       {plural(`${objectLabel}(s)`, drafts.length)}. {resumeButtonLabel} one of them,{' '}
-      <Button className="inline-block h-auto py-0" variant="link" onClick={handleCreateNew}>
+      <Button className="inline-block py-0 h-auto" variant="link" onClick={handleCreateNew}>
         create a new {objectLabel}
       </Button>{' '}
       or{' '}
-      <Button className="inline-block h-auto py-0" variant="link" onClick={handleDeleteAll}>
+      <Button className="inline-block py-0 h-auto" variant="link" onClick={handleDeleteAll}>
         delete them all
       </Button>
       .

--- a/packages/scms-core/src/components/ui/dialogs/SimpleDialog.tsx
+++ b/packages/scms-core/src/components/ui/dialogs/SimpleDialog.tsx
@@ -8,9 +8,9 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '../ui/dialog.js';
-import { Button, type ButtonProps } from '../ui/button.js';
-import { cn } from '../../utils/cn.js';
+} from '../dialog.js';
+import { Button, type ButtonProps } from '../button.js';
+import { cn } from '../../../utils/cn.js';
 import type { DialogContentProps } from '@radix-ui/react-dialog';
 
 export interface DialogButton {

--- a/packages/scms-core/src/components/ui/dialogs/index.ts
+++ b/packages/scms-core/src/components/ui/dialogs/index.ts
@@ -1,2 +1,3 @@
 export * from './ResumeDraftWorkDialog.js';
 export * from './SimpleDialog.js';
+export * from './types.js';

--- a/packages/scms-core/src/components/ui/dialogs/types.ts
+++ b/packages/scms-core/src/components/ui/dialogs/types.ts
@@ -1,0 +1,11 @@
+/**
+ * Base draft work type - can be extended for specific use cases
+ */
+export interface DraftWork {
+  workId: string;
+  workVersionId: string;
+  workTitle: string;
+  dateModified: string;
+  dateCreated: string;
+  metadata?: any;
+}

--- a/packages/scms-core/src/components/ui/index.ts
+++ b/packages/scms-core/src/components/ui/index.ts
@@ -29,7 +29,6 @@ export * from './popover.js';
 export * from './radio-group.js';
 export * from './RoleBadge.js';
 export * from './select.js';
-export * from './simple-dialog.js';
 export * from './SimpleAlert.js';
 export * from './Toaster.js';
 export * from './StatefulButton.js';

--- a/packages/scms-core/src/components/ui/index.ts
+++ b/packages/scms-core/src/components/ui/index.ts
@@ -14,6 +14,7 @@ export * from './combobox-client.js';
 export * from './command.js';
 export * from './ConfigurableBreadcrumb.js';
 export * from './dialog.js';
+export * from './dialogs/index.js';
 export * from './dot.js';
 export * from './dropzone.js';
 export * from './error.js';

--- a/packages/scms-core/src/index.ts
+++ b/packages/scms-core/src/index.ts
@@ -7,3 +7,6 @@ export * from './providers/index.js';
 export * from './services/index.js';
 export * from './utils/index.js';
 export * from './workflow/index.js';
+
+// Re-export commonly used types from ui components
+export type { DraftWork } from './components/ui/dialogs/types.js';

--- a/packages/scms-core/src/scopes.ts
+++ b/packages/scms-core/src/scopes.ts
@@ -12,6 +12,10 @@ export const site = {
     delete: 'site:domains:delete',
     update: 'site:domains:update',
   },
+  analytics: {
+    read: 'site:analytics:read',
+    list: 'site:analytics:list',
+  },
   submissions: {
     list: 'site:submissions:list',
     read: 'site:submissions:read',
@@ -50,6 +54,7 @@ export const site = {
     create: 'site:users:create',
     update: 'site:users:update',
     delete: 'site:users:delete',
+    admin: 'site:users:admin',
   },
 };
 

--- a/packages/scms-server/src/backend/roles.server.ts
+++ b/packages/scms-server/src/backend/roles.server.ts
@@ -1,5 +1,6 @@
 import { SystemRole, SiteRole, WorkRole } from '@curvenote/scms-db';
 import { system, site, work, app } from '@curvenote/scms-core';
+import type { MyUserDBO } from './db.types.js';
 
 const SYSTEM_ROLES: Record<SystemRole, Set<string>> = {
   [SystemRole.SERVICE]: new Set([system.admin]), // in future service accounts will have limited scope, that's the whole point
@@ -15,6 +16,8 @@ const SITE_ROLES: Record<SiteRole, Set<string>> = {
     site.read,
     site.update,
     site.details,
+    site.analytics.read,
+    site.analytics.list,
     site.domains.list,
     site.domains.create,
     site.domains.delete,
@@ -56,6 +59,8 @@ const SITE_ROLES: Record<SiteRole, Set<string>> = {
     site.submissions.versions.create,
     site.users.list,
     site.users.read,
+    site.users.update,
+    site.users.delete,
   ]),
   [SiteRole.SUBMITTER]: new Set([
     site.list,

--- a/packages/scms-server/src/backend/roles.server.ts
+++ b/packages/scms-server/src/backend/roles.server.ts
@@ -1,6 +1,5 @@
 import { SystemRole, SiteRole, WorkRole } from '@curvenote/scms-db';
 import { system, site, work, app } from '@curvenote/scms-core';
-import type { MyUserDBO } from './db.types.js';
 
 const SYSTEM_ROLES: Record<SystemRole, Set<string>> = {
   [SystemRole.SERVICE]: new Set([system.admin]), // in future service accounts will have limited scope, that's the whole point
@@ -43,6 +42,7 @@ const SITE_ROLES: Record<SiteRole, Set<string>> = {
     site.users.read,
     site.users.update,
     site.users.delete,
+    site.users.admin,
   ]),
   [SiteRole.EDITOR]: new Set([
     site.list,

--- a/packages/scms-server/src/backend/scopes.helpers.server.ts
+++ b/packages/scms-server/src/backend/scopes.helpers.server.ts
@@ -18,17 +18,13 @@ import {
 export function userHasSiteScope(
   user: UserWithRolesDBO | undefined,
   scope: string,
-  siteId?: string,
+  siteId: string,
 ): boolean {
   if (!user) return false;
   if (hasScopeViaSystemRole(user.system_role, system.admin)) return true;
-  if (siteId) {
-    const siteRoles = user.site_roles.filter((sr) => sr.site_id === siteId).map(({ role }) => role);
-    const rolesWithScope = siteRoles.filter((siteRole) => hasSiteScope(siteRole, scope));
-
-    return rolesWithScope.length > 0;
-  }
-  return false;
+  const siteRoles = user.site_roles.filter((sr) => sr.site_id === siteId).map(({ role }) => role);
+  const rolesWithScope = siteRoles.filter((siteRole) => hasSiteScope(siteRole, scope));
+  return rolesWithScope.length > 0;
 }
 
 /**
@@ -40,7 +36,7 @@ export function userHasSiteScope(
 export function userHasSiteScopes(
   user: UserWithRolesDBO | undefined,
   scopes: string[],
-  siteId?: string,
+  siteId: string,
 ): boolean {
   return scopes.every((scope) => userHasSiteScope(user, scope, siteId));
 }

--- a/packages/scms-server/src/backend/scopes.helpers.server.ts
+++ b/packages/scms-server/src/backend/scopes.helpers.server.ts
@@ -32,6 +32,20 @@ export function userHasSiteScope(
 }
 
 /**
+ * Returns true only if the user has ALL of the requested site scopes.
+ *
+ * For site-scoped checks, if `siteId` is provided it will be used
+ * for all scope checks.
+ */
+export function userHasSiteScopes(
+  user: UserWithRolesDBO | undefined,
+  scopes: string[],
+  siteId?: string,
+): boolean {
+  return scopes.every((scope) => userHasSiteScope(user, scope, siteId));
+}
+
+/**
  * ⚠️  IMPORTANT: Consider using userHasSiteScope or userHasWorkScope when specifically checking for site or work scopes
  *
  * Returns true if the user exists and has the specified scope, or if they are a system admin.

--- a/platform/scms/app/routes/app/works.$workId.users/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.users/route.tsx
@@ -80,7 +80,7 @@ export default function Users({ loaderData }: Route.ComponentProps) {
               <UserCard
                 key={u.id}
                 name={u.display_name}
-                roles={u.work_roles}
+                roles={u.work_roles.map((role) => ({ role, canRemove: false }))}
                 email={u.email}
                 userId={u.id}
               />

--- a/platform/scms/app/routes/app/works._index/route.tsx
+++ b/platform/scms/app/routes/app/works._index/route.tsx
@@ -9,7 +9,7 @@ import {
   MainWrapper,
   PageFrame,
   FrameHeader,
-  ResumeDraftWorkDialog,
+  ui,
   getBrandingFromMetaMatches,
   joinPageTitle,
   getWorkflows,
@@ -326,7 +326,7 @@ export default function MyWorks({ loaderData }: Route.ComponentProps) {
         </PageFrame>
       </MainWrapper>
 
-      <ResumeDraftWorkDialog<DraftWork>
+      <ui.ResumeDraftWorkDialog<DraftWork>
         isOpen={showResumeDialog}
         onClose={() => setShowResumeDialog(false)}
         onCreateNew={handleCreateNew}

--- a/platform/scms/vite.config.mts
+++ b/platform/scms/vite.config.mts
@@ -26,8 +26,8 @@ export default defineConfig(async ({ mode }) => {
   /**
    * Monorepo-optimized Vite configuration
    *
-   * This config enables hot module reload (HMR) for changes in local packages:
-   * - Watches package source directories for changes
+   * This config enables hot module reload (HMR) for changes in local packages and ee:
+   * - Watches package and ee source directories for changes
    * - Excludes local packages from pre-bundling for faster updates
    * - Processes local packages through Vite's SSR transform
    * - Restarts dev server when package configuration changes
@@ -35,13 +35,15 @@ export default defineConfig(async ({ mode }) => {
   const userConfig: UserConfig = {
     server: {
       port: env.VITE_PORT ? parseInt(env.VITE_PORT) : undefined,
-      // Watch package source files for changes to enable hot reload
+      // Watch package and ee source files for changes to enable hot reload
       watch: {
-        // Explicitly watch all files in packages directory (use ** for recursive matching)
+        // Explicitly watch all files in packages and ee directories (use ** for recursive matching)
         // The negation pattern (!) means "don't ignore this"
         ignored: [
           // Don't ignore any files in packages - watch everything recursively
           '!**/packages/**',
+          // Don't ignore any files in ee - watch everything recursively
+          '!**/ee/**',
         ],
         // Use polling for better reliability with TypeScript file changes
         // This ensures enum/type changes are picked up immediately
@@ -49,13 +51,15 @@ export default defineConfig(async ({ mode }) => {
         // Increase interval for polling if enabled
         interval: 100,
       },
-      // Allow Vite to serve files from the workspace root and packages
+      // Allow Vite to serve files from the workspace root, packages, and ee
       fs: {
         allow: [
-          // Workspace root
+          // Workspace root (current directory when running from platform/scms)
           process.cwd(),
-          // Allow access to all packages
-          path.join(process.cwd(), 'packages'),
+          // Allow access to all packages (go up to workspace root, then into packages)
+          path.resolve(process.cwd(), '../../packages'),
+          // Allow access to ee folder (go up to workspace root, then into ee)
+          path.resolve(process.cwd(), '../../ee'),
         ],
       },
     },
@@ -124,16 +128,22 @@ export default defineConfig(async ({ mode }) => {
           'packages/*/package.json',
           // Restart when tsconfig files change in packages (affects types)
           'packages/*/tsconfig.json',
+          // Restart when package.json or tsconfig files change in ee
+          'ee/*/package.json',
+          'ee/*/tsconfig.json',
         ],
       }),
       // Plugin to invalidate modules when TypeScript files change (e.g., enum updates)
-      // This ensures enum/type changes in packages are picked up immediately without rebuild
+      // This ensures enum/type changes in packages and ee are picked up immediately without rebuild
       {
         name: 'invalidate-on-typescript-changes',
         configureServer(server) {
-          // Watch TypeScript files in packages and trigger HMR when they change
+          // Watch TypeScript files in packages and ee, trigger HMR when they change
           server.watcher.on('change', (file) => {
-            if (file.includes('packages/') && (file.endsWith('.ts') || file.endsWith('.tsx'))) {
+            if (
+              (file.includes('packages/') || file.includes('ee/')) &&
+              (file.endsWith('.ts') || file.endsWith('.tsx'))
+            ) {
               // Find the module and invalidate it along with all dependents
               const module = server.moduleGraph.getModuleById(file);
               if (module) {


### PR DESCRIPTION
Fixes to the Site > Users screen

## Testing summary

The following shows post-fix behaviour of the backend, here the UI protection is not in place so we can see the endpoint rejecting changes based on the lower permissions level of the editor role. Also note the reduced secondary navigation content.


https://github.com/user-attachments/assets/a2bdd372-1beb-4b5e-b346-551a8b8ebb12

### With UI level logic added

<img width="3007" height="1920" alt="site users editor" src="https://github.com/user-attachments/assets/60c701ab-4b71-4e1d-be74-eba0dbff880b" />

☝🏼 The Editor role can no longer add or revoke admin roles



<img width="1498" height="918" alt="site user submitter" src="https://github.com/user-attachments/assets/50fb4ec1-b324-438a-b491-8244b77acab1" />
☝🏼 Submitters cannot see any users


<img width="1443" height="804" alt="site users admin" src="https://github.com/user-attachments/assets/89935844-08bb-475f-9ce1-7aec51928e02" />
☝🏼 **if** we were to add the `site.users.list` scope to the submitter or any other low level role, then they could see users but as readonly


<img width="1443" height="804" alt="site users admin" src="https://github.com/user-attachments/assets/53fd6e4f-1e71-4152-909b-f624048ce220" />
☝🏼 Admins can still do everything



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens Site Users authorization and aligns UI with capabilities.
> 
> - Server: Introduces `$actionGrantUserRole`/`$actionRevokeUserRole` with Zod-validated `ActionFormDataSchema`, prevents self-modification, returns structured errors, and requires site-scoped checks (`userHasSiteScope/userHasSiteScopes`) with admin-only guard for `ADMIN` role
> - Loader/UI: Computes `canUpdateRoles`/`canModifyAdminRoles`; `SiteRolesForm` only shows `ADMIN` option when allowed and submits normalized form data; `UserCard` supports per-role `canRemove` and adds confirmation dialog for revocation
> - Menu/scopes/roles: Adds site analytics scopes and `site.users.admin`; updates role-to-scope mappings (admin/editor), and scope helpers (new `userHasSiteScopes`, `userHasSiteScope` now requires `siteId`)
> - Components: Moves SimpleDialog/ResumeDraftWorkDialog under `ui/dialogs`, adds shared `DraftWork` type export; updates imports in InviteUserDialog/RequestHelpDialog and ResumeDraftWorkDialog internals
> - App updates: Works routes consume `ui.ResumeDraftWorkDialog` and pass `{ role, canRemove }` to `UserCard`
> - Tooling: Vite dev server watches `packages` and `ee`; new VS Code launch config for Platform SCMS dev server
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1239e77d5b6c5a6faeac730f009ec6d19ad7abd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->