### PR TITLE
🖼️ Page Frame Context

### DIFF
--- a/packages/scms-core/src/components/layout/PageFrame.tsx
+++ b/packages/scms-core/src/components/layout/PageFrame.tsx
@@ -1,9 +1,30 @@
-import { forwardRef } from 'react';
+import { createContext, useContext, forwardRef } from 'react';
 import { useLocation } from 'react-router';
 import { cn } from '../../utils/index.js';
 import { FrameHeader } from '../FrameHeader.js';
 import { ConfigurableBreadcrumb, type BreadcrumbItemConfig } from '../ui/ConfigurableBreadcrumb.js';
 import { useDeploymentConfig } from '../../providers/DeploymentProvider.js';
+
+interface PageFrameContextValue {
+  title?: React.ReactNode;
+  subtitle?: React.ReactNode;
+  description?: React.ReactNode;
+  header?: React.ReactNode;
+  className?: string;
+  hasSecondaryNav?: boolean;
+  breadcrumbs?: BreadcrumbItemConfig[];
+}
+
+const PageFrameContext = createContext<PageFrameContextValue | null>(null);
+
+/**
+ * Hook to access PageFrame context values
+ * @throws Error if used outside of a PageFrame component
+ */
+export function usePageFrame(): PageFrameContextValue {
+  const context = useContext(PageFrameContext);
+  return context ?? {};
+}
 
 interface PageFrameProps {
   title?: React.ReactNode;
@@ -48,36 +69,48 @@ export const PageFrame = forwardRef<HTMLDivElement, PageFrameProps>(function Pag
   const finalHasSecondaryNav = propHasSecondaryNav ?? true;
   const finalBreadcrumbs = propBreadcrumbs;
 
+  const contextValue: PageFrameContextValue = {
+    title: finalTitle,
+    subtitle: finalSubtitle,
+    description: finalDescription,
+    header: finalHeader,
+    className: finalClassName,
+    hasSecondaryNav: finalHasSecondaryNav,
+    breadcrumbs: finalBreadcrumbs,
+  };
+
   return (
-    <div
-      ref={ref}
-      data-name="page-frame"
-      className={cn(
-        'relative py-16 pr-4 w-full xl:mt-0 xl:py-[56px] xl:pr-8 2xl:pr-16',
-        {
-          'xl:pl-10 2xl:pl-16 max-w-[1400px]': finalHasSecondaryNav,
-          'max-w-[1680px]': !finalHasSecondaryNav,
-        },
-        finalClassName,
-      )}
-    >
-      {finalBreadcrumbs && finalBreadcrumbs.length > 0 && (
-        <div className="mb-4">
-          <ConfigurableBreadcrumb items={finalBreadcrumbs} />
-        </div>
-      )}
-      {(finalHeader || finalTitle || finalSubtitle || finalDescription) && (
-        <div className="mb-12">
-          {finalHeader || (
-            <FrameHeader
-              title={finalTitle}
-              subtitle={finalSubtitle}
-              description={finalDescription}
-            />
-          )}
-        </div>
-      )}
-      <div className="space-y-12">{children}</div>
-    </div>
+    <PageFrameContext.Provider value={contextValue}>
+      <div
+        ref={ref}
+        data-name="page-frame"
+        className={cn(
+          'relative py-16 pr-4 w-full xl:mt-0 xl:py-[56px] xl:pr-8 2xl:pr-16',
+          {
+            'xl:pl-10 2xl:pl-16 max-w-[1400px]': finalHasSecondaryNav,
+            'max-w-[1680px]': !finalHasSecondaryNav,
+          },
+          finalClassName,
+        )}
+      >
+        {finalBreadcrumbs && finalBreadcrumbs.length > 0 && (
+          <div className="mb-4">
+            <ConfigurableBreadcrumb items={finalBreadcrumbs} />
+          </div>
+        )}
+        {(finalHeader || finalTitle || finalSubtitle || finalDescription) && (
+          <div className="mb-12">
+            {finalHeader || (
+              <FrameHeader
+                title={finalTitle}
+                subtitle={finalSubtitle}
+                description={finalDescription}
+              />
+            )}
+          </div>
+        )}
+        <div className="space-y-12">{children}</div>
+      </div>
+    </PageFrameContext.Provider>
   );
 });

--- a/platform/scms/app/routes/app/works._index/WorkList.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkList.tsx
@@ -84,7 +84,7 @@ export function WorkList({
       renderGroup={renderGroup}
       renderItem={renderItem}
       getItemKey={(work) => work.id}
-      emptyMessage="No Works to show"
+      emptyMessage="No items to show"
       persist={true}
     />
   );


### PR DESCRIPTION
This frame now has an integral context provider and an associated hook. This allows children to get at the final metadata decided on the page frame. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Adds context to `PageFrame` for downstream access to resolved metadata**
> 
> - Introduces `PageFrameContext` and `usePageFrame()` to expose final `title`, `subtitle`, `description`, `header`, `className`, `hasSecondaryNav`, and `breadcrumbs` to child components
> - Wraps existing `PageFrame` markup with a context provider; rendering behavior otherwise unchanged
> - Minor copy update in `WorkList.tsx`: `emptyMessage` changed to `"No items to show"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c45f1ae38a2483f3eddff4009ff687b0f5df4ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->