### PR TITLE
✨Remove site link from SiteCard

### DIFF
--- a/.changeset/solid-news-kick.md
+++ b/.changeset/solid-news-kick.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-sites-ext': patch
+---
+
+Remove site link from SiteCard, add primary domain to site branding area in secondary nav

--- a/ee/sites/src/routes/sites/SiteCard.tsx
+++ b/ee/sites/src/routes/sites/SiteCard.tsx
@@ -1,11 +1,11 @@
 import { Link } from 'react-router';
 import type { UserSiteDTO } from '@curvenote/common';
 import { primitives, SiteLogo } from '@curvenote/scms-core';
-import { ExternalLinkIcon, Server } from 'lucide-react';
+import { Server } from 'lucide-react';
 
 export default function SiteCard({ site }: { site: UserSiteDTO }) {
   return (
-    <primitives.Card className="h-auto space-y-1 lg:p-6" lift>
+    <primitives.Card className="space-y-1 h-auto lg:p-6" lift>
       <Link className="block" prefetch="none" to={`/app/sites/${site.name}`}>
         <SiteLogo
           className="object-cover mb-4 h-14"
@@ -17,26 +17,15 @@ export default function SiteCard({ site }: { site: UserSiteDTO }) {
       <Link
         prefetch="none"
         to={`/app/sites/${site.name}`}
-        className="block no-underline hover:underline"
+        className="block mb-0 no-underline hover:underline"
       >
-        <h2>{site.title}</h2>
+        <h2 className="my-2">{site.title}</h2>
       </Link>
       {site.external && (
         <div className="flex items-center gap-1 mt-[10px]">
           <Server className="inline-block w-3 h-3 align-middle" />
           <span className="font-mono text-xs dark:text-white">Integration</span>
         </div>
-      )}
-      {site.url && (
-        <Link
-          prefetch="none"
-          to={site.url}
-          className="font-mono text-xs underline dark:text-white"
-          target="_blank"
-        >
-          {site.url}
-          <ExternalLinkIcon className="inline-block w-3 h-3 ml-1 align-middle" />
-        </Link>
       )}
     </primitives.Card>
   );

--- a/packages/scms-core/src/components/navigation/SecondaryNav.tsx
+++ b/packages/scms-core/src/components/navigation/SecondaryNav.tsx
@@ -47,11 +47,9 @@ export function SecondaryNav({
                   <div className="my-[2px] text-2xl font-normal text-black dark:text-white">
                     {title}
                   </div>
-                  {branding.url && (
-                    <div className="flex justify-center max-w-full text-xs truncate text-muted-foreground">
-                      {branding.url}
-                    </div>
-                  )}
+                  <div className="flex justify-center max-w-full text-xs truncate text-muted-foreground">
+                    {branding.url}
+                  </div>
                 </a>
               </SimpleTooltip>
             </div>

--- a/packages/scms-core/src/components/navigation/SecondaryNav.tsx
+++ b/packages/scms-core/src/components/navigation/SecondaryNav.tsx
@@ -4,6 +4,7 @@ import { SiteLogo } from '../SiteLogo.js';
 import { useMobile } from './Mobile.js';
 import type { MenuContents, ServerSideMenuContents } from './types.js';
 import type { ClientExtension } from '../../modules/index.js';
+import { SimpleTooltip } from '../ui/tooltip.js';
 
 export function SecondaryNav({
   contents,
@@ -35,17 +36,24 @@ export function SecondaryNav({
         <>
           {branding.url ? (
             <div className="pt-[60px]">
-              <a className="flex flex-col justify-center items-center" href={branding.url}>
-                <SiteLogo
-                  className="object-cover mb-4 h-10"
-                  alt={title ?? ''}
-                  logo={branding.logo}
-                  logo_dark={branding.logo_dark}
-                />
-                <div className="my-[2px] text-2xl font-normal text-black dark:text-white">
-                  {title}
-                </div>
-              </a>
+              <SimpleTooltip title={`Visit site at : ${branding.url}`} delayDuration={1000}>
+                <a className="flex flex-col justify-center items-center" href={branding.url}>
+                  <SiteLogo
+                    className="object-cover mb-4 h-10"
+                    alt={title ?? ''}
+                    logo={branding.logo}
+                    logo_dark={branding.logo_dark}
+                  />
+                  <div className="my-[2px] text-2xl font-normal text-black dark:text-white">
+                    {title}
+                  </div>
+                  {branding.url && (
+                    <div className="flex justify-center max-w-full text-xs truncate text-muted-foreground">
+                      {branding.url}
+                    </div>
+                  )}
+                </a>
+              </SimpleTooltip>
             </div>
           ) : (
             <div className="flex flex-col justify-center items-center pt-[60px]">


### PR DESCRIPTION
The site link was causing some major confusion on UX. People would click that and be taken to the actual end site rather than navigating into the admin area. We've removed that from the site card now, pending some improvement to the UX of the site card. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Removes external site URL link from `SiteCard`; cleans up `ExternalLinkIcon` import and adjusts minor spacing/classes.
> - In `SecondaryNav`, when `branding.url` exists, wraps branding in a link with `SimpleTooltip` and displays a truncated primary domain beneath the title.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dadb49ef1363a7cd0290344e6d895d638b4c01f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->