### PR TITLE
Hide draft works and DRAFT submissions

### DIFF
--- a/.changeset/bumpy-mangos-march.md
+++ b/.changeset/bumpy-mangos-march.md
@@ -3,3 +3,4 @@
 ---
 
 Do not show draft works or works/workVersions that have submissions with only DRAFT status
+Do not show submissions/submissionVersions with DRAFT status

--- a/.changeset/bumpy-mangos-march.md
+++ b/.changeset/bumpy-mangos-march.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms': patch
+---
+
+Do not show draft works or works/workVersions that have submissions with only DRAFT status

--- a/platform/scms/app/routes/app/works.$workId.details/WorkVersionsTable.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkVersionsTable.tsx
@@ -30,7 +30,9 @@ export function WorkVersionsTable({
             // there may be multiple submissions to a site, and there is a history of submission versions that it may be
             // important to surface but that is a TODO and needs more UI to convey
             // TODO: the badge should show a popup with user facing information about the submission and submission version history
-            const nonDraftSubmissionVersions = v.submissionVersions.filter((sv) => sv.status !== 'DRAFT');
+            const nonDraftSubmissionVersions = v.submissionVersions.filter(
+              (sv) => sv.status !== 'DRAFT',
+            );
             return (
               <tr key={v.id} className="border-b-[1px] border-gray-300 last:border-none">
                 <td

--- a/platform/scms/app/routes/app/works.$workId.details/WorkVersionsTable.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkVersionsTable.tsx
@@ -30,6 +30,7 @@ export function WorkVersionsTable({
             // there may be multiple submissions to a site, and there is a history of submission versions that it may be
             // important to surface but that is a TODO and needs more UI to convey
             // TODO: the badge should show a popup with user facing information about the submission and submission version history
+            const nonDraftSubmissionVersions = v.submissionVersions.filter((sv) => sv.status !== 'DRAFT');
             return (
               <tr key={v.id} className="border-b-[1px] border-gray-300 last:border-none">
                 <td
@@ -45,9 +46,9 @@ export function WorkVersionsTable({
                     'opacity-50': idx !== 0,
                   })}
                 >
-                  {v.submissionVersions.length > 0 ? (
+                  {nonDraftSubmissionVersions.length > 0 ? (
                     <div className="flex flex-wrap gap-2">
-                      {v.submissionVersions.map((sv) => (
+                      {nonDraftSubmissionVersions.map((sv) => (
                         <ui.SubmissionVersionBadge
                           key={`submission-badge-${v.id}-${sv.id}`}
                           submissionVersion={sv}

--- a/platform/scms/app/routes/app/works.$workId.details/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/route.tsx
@@ -36,6 +36,11 @@ export default function WorkDetailRoute() {
     'routes/app/works.$workId/route',
   ) as LoaderData;
 
+  // Prefer the latest non-draft work version for user-facing "Last updated" copy.
+  // (Versions are sorted newest-first, but drafts may appear at the top.)
+  const latestNonDraftWorkVersion = versions.find((v) => !v.draft);
+  const lastUpdatedDate = (latestNonDraftWorkVersion ?? versions[0])?.date_created;
+
   const truncatedTitle = work.title
     ? work.title.length > 32
       ? work.title.substring(0, 32) + '...'
@@ -58,9 +63,11 @@ export default function WorkDetailRoute() {
               ? work.authors.map((a) => a.name).join(', ')
               : 'Unknown authors'}
           </div>
-          <div className="text-xs text-muted-foreground">
-            Last updated {formatToNow(versions[0].date_created, { addSuffix: true })}
-          </div>
+          {lastUpdatedDate && (
+            <div className="text-xs text-muted-foreground">
+              Last updated {formatToNow(lastUpdatedDate, { addSuffix: true })}
+            </div>
+          )}
         </div>
         <SectionWithHeading heading="Submissions" icon={Radio}>
           <div className="grid grid-cols-1 gap-5 mt-5 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
@@ -107,7 +114,7 @@ export default function WorkDetailRoute() {
                           submissionVersion={sub.versions[0]}
                           workflows={workflows}
                           basePath={`/app/works/${work.id}`}
-                          workVersionId={sub.versions[0].id}
+                          workVersionId={sub.versions[0].work_version_id}
                           showLink
                         />
                       </div>

--- a/platform/scms/app/routes/app/works.$workId.site.$siteName.submission.$submissionVersionId/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.site.$siteName.submission.$submissionVersionId/db.server.ts
@@ -12,6 +12,10 @@ export async function getSubmissionVersionsForWorkAndSite(workId: string, siteNa
           name: siteName,
         },
       },
+      // Never show draft submission versions.
+      status: {
+        not: 'DRAFT',
+      },
     },
     include: {
       work_version: true,
@@ -39,6 +43,9 @@ export async function getSubmissionForWorkAndSite(workId: string, siteName: stri
         some: {
           work_version: {
             work_id: workId,
+          },
+          status: {
+            not: 'DRAFT',
           },
         },
       },

--- a/platform/scms/app/routes/app/works.$workId.site.$siteName.submission.$submissionVersionId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.site.$siteName.submission.$submissionVersionId/route.tsx
@@ -42,7 +42,14 @@ export const loader = async (args: Route.LoaderArgs) => {
     throw redirect(`/app/works/${workId}`);
   }
 
-  // Get the specific version being viewed
+  // Get all submission versions for the table
+  const submissionVersions = await getSubmissionVersionsForWorkAndSite(workId, siteName);
+  if (submissionVersions.length === 0) {
+    // Submission exists but only has draft versions (or none) that we intentionally hide.
+    throw redirect(`/app/works/${workId}`);
+  }
+
+  // Get the specific version being viewed (and ensure it isn't a hidden draft version)
   const viewingVersion = await getSubmissionVersion(submissionVersionId);
   if (!viewingVersion) {
     throw redirect(`/app/works/${workId}`);
@@ -56,8 +63,12 @@ export const loader = async (args: Route.LoaderArgs) => {
     throw redirect(`/app/works/${workId}`);
   }
 
-  // Get all submission versions for the table
-  const submissionVersions = await getSubmissionVersionsForWorkAndSite(workId, siteName);
+  // If the requested version is draft/hidden (or otherwise not in the visible list),
+  // redirect to the latest visible version.
+  const isVisibleRequestedVersion = submissionVersions.some((v) => v.id === viewingVersion.id);
+  if (!isVisibleRequestedVersion) {
+    throw redirect(`/app/works/${workId}/site/${siteName}/submission/${submissionVersions[0].id}`);
+  }
 
   // Get workflow configuration
   const workflow = getWorkflow(
@@ -82,7 +93,7 @@ export const loader = async (args: Route.LoaderArgs) => {
   });
 
   // Determine overall publication status and find published version
-  const publishedVersion = submissionVersions.find((v) => v.status === 'published');
+  const publishedVersion = submissionVersions.find((v) => v.status === 'PUBLISHED');
   const overallStatus = publishedVersion ? 'published' : activeVersion.status;
 
   // Get site logo from metadata if available

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -23,12 +23,35 @@ export const loader = async (args: LoaderFunctionArgs) => {
 
   const { workId } = args.params;
   if (!workId) return redirect('/app/works');
-  if (args.request.url.endsWith(workId)) {
-    throw redirect(`/app/works/${workId}/details`);
-  }
 
   const workVersions = await dbGetWorkVersionsWithSubmissionVersions(ctx.work.id);
   if (!workVersions) throw redirect('/app/works');
+
+  const isDraftOnlyWork = workVersions.length > 0 && workVersions.every((v) => v.draft);
+
+  const url = new URL(args.request.url);
+  const pathname = url.pathname;
+
+  // Draft-only works should route users into the upload flow, not the details pages.
+  if (isDraftOnlyWork) {
+    const isUploadPath = pathname.includes(`/app/works/${workId}/upload/`);
+    const isDetailsLikePath =
+      pathname === `/app/works/${workId}` ||
+      pathname === `/app/works/${workId}/` ||
+      pathname.startsWith(`/app/works/${workId}/details`) ||
+      pathname.startsWith(`/app/works/${workId}/users`) ||
+      pathname.startsWith(`/app/works/${workId}/checks`) ||
+      pathname.startsWith(`/app/works/${workId}/site/`);
+
+    if (!isUploadPath && isDetailsLikePath) {
+      throw redirect(`/app/works/${workId}/upload/${workVersions[0].id}`);
+    }
+  }
+
+  // Default index redirect.
+  if (pathname === `/app/works/${workId}` || pathname === `/app/works/${workId}/`) {
+    throw redirect(`/app/works/${workId}/details`);
+  }
 
   const submissions = getUniqueSubmissions(workVersions);
   const workflowNames = submissions.map((s) => s.collection.workflow);
@@ -67,7 +90,7 @@ export const meta: Route.MetaFunction = ({ matches, loaderData }) => {
 export default function WorkLayout({ loaderData }: Route.ComponentProps) {
   const { work, versions, submissions, userScopes } = loaderData;
 
-  const isDrafting = versions.length === 1 && versions[0].draft;
+  const isDrafting = versions.length > 0 && versions.every((v) => v.draft);
   const menu = buildMenu(`/app/works/${work.id}`, isDrafting, submissions, userScopes);
 
   return (

--- a/platform/scms/app/routes/app/works.$workId/utils.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/utils.server.ts
@@ -22,16 +22,18 @@ export function getUniqueSubmissions(versions: WorkVersionWithSubmissionVersions
       }
     });
   });
-  return Object.values(submissions)
-    // If a submission only has draft versions, omit the submission entirely.
-    .filter((s) => s.versions.length > 0)
-    .map((s) => ({
-      ...s,
-      versions: s.versions.sort((a, b) => {
+  return (
+    Object.values(submissions)
+      // If a submission only has draft versions, omit the submission entirely.
+      .filter((s) => s.versions.length > 0)
+      .map((s) => ({
+        ...s,
+        versions: s.versions.sort((a, b) => {
+          return new Date(b.date_created).getTime() - new Date(a.date_created).getTime();
+        }),
+      }))
+      .sort((a, b) => {
         return new Date(b.date_created).getTime() - new Date(a.date_created).getTime();
-      }),
-    }))
-    .sort((a, b) => {
-      return new Date(b.date_created).getTime() - new Date(a.date_created).getTime();
-    });
+      })
+  );
 }

--- a/platform/scms/app/routes/app/works.$workId/utils.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/utils.server.ts
@@ -10,6 +10,8 @@ export function getUniqueSubmissions(versions: WorkVersionWithSubmissionVersions
   const submissions: Record<string, SubmissionWithVersionsAndSite> = {};
   versions.forEach((v) => {
     v.submissionVersions.forEach((sv) => {
+      // Never surface draft submission versions in work details.
+      if (sv.status === 'DRAFT') return;
       if (submissions[sv.submission_id]) {
         submissions[sv.submission_id].versions.push(sv);
       } else {
@@ -21,6 +23,8 @@ export function getUniqueSubmissions(versions: WorkVersionWithSubmissionVersions
     });
   });
   return Object.values(submissions)
+    // If a submission only has draft versions, omit the submission entirely.
+    .filter((s) => s.versions.length > 0)
     .map((s) => ({
       ...s,
       versions: s.versions.sort((a, b) => {

--- a/platform/scms/app/routes/app/works._index/ClientListingHelpers.tsx
+++ b/platform/scms/app/routes/app/works._index/ClientListingHelpers.tsx
@@ -43,7 +43,8 @@ export function searchWorks(works: WorkWithRole[], searchTerm: string): WorkWith
   const searchLower = searchTerm.toLowerCase();
 
   return works.filter((work) => {
-    const latestVersion = work.versions[0];
+    // Always search against the latest non-draft version so draft versions don't affect listing/search.
+    const latestVersion = work.versions.find((v) => !v.draft);
     if (!latestVersion) return false;
 
     // Search in work version title

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -99,9 +99,8 @@ export function WorkListItem({
             {work.submissions
               .filter((submission) => submission.versions && submission.versions.length > 0)
               .map((submission) => {
-                const latestNonDraftSubmissionVersion = submission.versions.filter(
-                  (v) => v.status !== 'DRAFT',
-                )[0]; // Already sorted by date_created desc
+                // `dbGetWorksAndSubmissionVersions` already filters out DRAFT submission versions.
+                const latestNonDraftSubmissionVersion = submission.versions[0];
 
                 // Guard against null/undefined collection
                 if (!submission.collection?.workflow) return null;
@@ -131,7 +130,7 @@ export function WorkListItem({
                     workflows={{ [submission.collection.workflow]: workflow }}
                     basePath={`/app/works/${work.id}`}
                     workVersionId={
-                      latestNonDraftSubmissionVersion.work_version?.id || work.versions[0]?.id || ''
+                      latestNonDraftSubmissionVersion.work_version?.id || latestVersion?.id || ''
                     }
                     showSite
                     showLink={false}

--- a/platform/scms/app/routes/app/works._index/db.server.ts
+++ b/platform/scms/app/routes/app/works._index/db.server.ts
@@ -65,6 +65,19 @@ export async function dbGetWorksAndSubmissionVersions(userId: string) {
 
   // Transform works to include the user's role with precedence handling
   return works.map((work) => {
+    // Remove draft submission versions and drop submissions that only have drafts.
+    // This keeps listings consistent with the "don't show draft submissions/versions" rule.
+    const visibleSubmissions = work.submissions
+      .map((submission) => {
+        const nonDraftVersions = (submission.versions ?? []).filter((v) => v.status !== 'DRAFT');
+        if (nonDraftVersions.length === 0) return null;
+        return {
+          ...submission,
+          versions: nonDraftVersions,
+        };
+      })
+      .filter((s): s is NonNullable<typeof s> => !!s);
+
     // Get the highest precedence role: OWNER > CONTRIBUTOR > VIEWER
     const userRoles = work.work_users.map((wu) => wu.role);
     let userRole: WorkRole | 'ORPHANED' = 'ORPHANED';
@@ -78,10 +91,11 @@ export async function dbGetWorksAndSubmissionVersions(userId: string) {
     }
 
     // Extract unique sites for filter counting
-    const sites = [...new Set(work.submissions.map((sub) => sub.site.name))].filter(Boolean);
+    const sites = [...new Set(visibleSubmissions.map((sub) => sub.site.name))].filter(Boolean);
 
     return {
       ...work,
+      submissions: visibleSubmissions,
       userRole,
       sites,
     };


### PR DESCRIPTION
So currently on the my works and then on the works details page, we get presented with a number of draft submissions. The draft submissions should be completely hidden. They are meant as one-off submissions from the CLI, that was only intended to be a preview, so we are removing those. 


## Work Versions After Change
<img width="2428" height="1936" alt="image" src="https://github.com/user-attachments/assets/16d7972c-b063-4b7f-a46b-b155a247ed0a" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect routing and database query filtering for works/submissions; risk is mainly user-facing behavior changes (unexpected redirects or missing items) if draft/non-draft status assumptions are wrong.
> 
> **Overview**
> Hides draft-only/preview submission data across the works experience by filtering out `submissionVersions` with `status: 'DRAFT'` and omitting submissions that only contain draft versions in both the works index and work details views.
> 
> Adjusts navigation and routing to avoid surfacing draft-only works in detail pages (redirecting to the upload flow), updates “Last updated” to use the latest *non-draft* work version, and hardens submission detail routing/queries to never load draft submission versions (including redirecting deep links to hidden drafts to the latest visible version).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ac09be06a084ddc1092bc61d7bce2e4d1f73df1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->