### PR TITLE
🧪 Work Details Page Variant - experiment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4735,6 +4735,7 @@
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
       "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
@@ -4753,6 +4754,7 @@
       "version": "4.12.2",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -4762,6 +4764,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -4785,6 +4788,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -4801,6 +4805,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4811,6 +4816,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -4820,12 +4826,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -4838,6 +4846,7 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6244,6 +6253,7 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
       "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.3",
@@ -6258,6 +6268,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6268,6 +6279,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6280,6 +6292,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -6294,6 +6307,7 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@iarna/toml": {
@@ -12228,6 +12242,7 @@
       "version": "8.50.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.0.tgz",
       "integrity": "sha512-O7QnmOXYKVtPrfYzMolrCTfkezCJS9+ljLdKW/+DCvRsc3UAz+sbH6Xcsv7p30+0OwUbeWfUDAQE0vpabZ3QLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
@@ -12256,6 +12271,7 @@
       "version": "8.52.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.52.0.tgz",
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
@@ -12280,6 +12296,7 @@
       "version": "8.52.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.52.0.tgz",
       "integrity": "sha512-xD0MfdSdEmeFa3OmVqonHi+Cciab96ls1UhIF/qX/O/gPu5KXD0bY9lu33jj04fjzrXHcuvjBcBC+D3SNSadaw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.52.0",
@@ -12301,6 +12318,7 @@
       "version": "8.52.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.52.0.tgz",
       "integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.52.0",
@@ -12318,6 +12336,7 @@
       "version": "8.52.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.52.0.tgz",
       "integrity": "sha512-jl+8fzr/SdzdxWJznq5nvoI7qn2tNYV/ZBAEcaFMVXf+K6jmXvAFrgo/+5rxgnL152f//pDEAYAhhBAZGrVfwg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12334,6 +12353,7 @@
       "version": "8.52.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.52.0.tgz",
       "integrity": "sha512-LWQV1V4q9V4cT4H5JCIx3481iIFxH1UkVk+ZkGGAV1ZGcjGI9IoFOfg3O6ywz8QqCDEp7Inlg6kovMofsNRaGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12347,6 +12367,7 @@
       "version": "8.52.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.52.0.tgz",
       "integrity": "sha512-XP3LClsCc0FsTK5/frGjolyADTh3QmsLp6nKd476xNI9CsSsLnmn4f0jrzNoAulmxlmNIpeXuHYeEQv61Q6qeQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/project-service": "8.52.0",
@@ -12374,6 +12395,7 @@
       "version": "8.52.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.52.0.tgz",
       "integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.52.0",
@@ -12391,6 +12413,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12403,6 +12426,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
       "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.12"
@@ -12415,6 +12439,7 @@
       "version": "8.50.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.0.tgz",
       "integrity": "sha512-Cg/nQcL1BcoTijEWyx4mkVC56r8dj44bFDvBdygifuS20f3OZCHmFbjF34DPSi07kwlFvqfv/xOLnJ5DquxSGQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.50.0",
@@ -12436,6 +12461,7 @@
       "version": "8.50.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.0.tgz",
       "integrity": "sha512-xCwfuCZjhIqy7+HKxBLrDVT5q/iq7XBVBXLn57RTIIpelLtEIZHXAF/Upa3+gaCpeV1NNS5Z9A+ID6jn50VD4A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.50.0",
@@ -12453,6 +12479,7 @@
       "version": "8.50.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.0.tgz",
       "integrity": "sha512-vxd3G/ybKTSlm31MOA96gqvrRGv9RJ7LGtZCn2Vrc5htA0zCDvcMqUkifcjrWNNKXHUU3WCkYOzzVSFBd0wa2w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12469,6 +12496,7 @@
       "version": "8.50.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.0.tgz",
       "integrity": "sha512-7OciHT2lKCewR0mFoBrvZJ4AXTMe/sYOe87289WAViOocEmDjjv8MvIOT2XESuKj9jp8u3SZYUSh89QA4S1kQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.50.0",
@@ -12493,6 +12521,7 @@
       "version": "8.50.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.0.tgz",
       "integrity": "sha512-iX1mgmGrXdANhhITbpp2QQM2fGehBse9LbTf0sidWK6yg/NE+uhV5dfU1g6EYPlcReYmkE9QLPq/2irKAmtS9w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12506,6 +12535,7 @@
       "version": "8.50.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.0.tgz",
       "integrity": "sha512-W7SVAGBR/IX7zm1t70Yujpbk+zdPq/u4soeFSknWFdXIFuWsBGBOUu/Tn/I6KHSKvSh91OiMuaSnYp3mtPt5IQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/project-service": "8.50.0",
@@ -12533,6 +12563,7 @@
       "version": "8.50.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.0.tgz",
       "integrity": "sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
@@ -12556,6 +12587,7 @@
       "version": "8.50.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.0.tgz",
       "integrity": "sha512-Xzmnb58+Db78gT/CCj/PVCvK+zxbnsw6F+O1oheYszJbBSdEjVhQi3C/Xttzxgi/GLmpvOggRs1RFpiJ8+c34Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.50.0",
@@ -12573,6 +12605,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12585,6 +12618,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@unified-latex/unified-latex": {
@@ -13522,6 +13556,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -15186,6 +15221,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -18515,6 +18551,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -19547,6 +19584,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -20126,6 +20164,7 @@
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -20142,6 +20181,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -20154,6 +20194,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -20170,6 +20211,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -20180,6 +20222,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -20196,6 +20239,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -20212,6 +20256,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -20224,6 +20269,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -20233,12 +20279,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -20254,6 +20302,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -20266,6 +20315,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -20281,6 +20331,7 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
@@ -20311,6 +20362,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -20323,6 +20375,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -21024,6 +21077,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -21559,6 +21613,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
       "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -21573,6 +21628,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/for-each": {
@@ -21795,6 +21851,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -22465,6 +22522,7 @@
       "version": "13.24.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -22480,6 +22538,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -22997,6 +23056,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/gtoken": {
@@ -24294,6 +24354,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -24353,6 +24414,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -24369,6 +24431,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -24415,6 +24478,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -25111,6 +25175,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -25976,6 +26041,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
@@ -26355,6 +26421,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -29539,6 +29606,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare-lite": {
@@ -31111,6 +31179,7 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -31583,6 +31652,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -31782,6 +31852,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -32434,6 +32505,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -34682,6 +34754,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -34697,6 +34770,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -34708,6 +34782,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -34728,6 +34803,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -36643,6 +36719,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -37141,6 +37218,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/thenify": {
@@ -37472,6 +37550,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
       "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.12"
@@ -38023,6 +38102,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -38162,6 +38242,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/platform/scms/app/routes.ts
+++ b/platform/scms/app/routes.ts
@@ -136,6 +136,8 @@ export default [
     // Register extension routes at the app level
     ...getRoutesForMountPoint('app'),
 
+    ...prefix('works/v3', [index('routes/app/works._index/route.tsx', { id: 'works.v3.index' })]),
+
     // Works Routes
     ...prefix('works/v2', [
       index('routes/app/works._index/route.tsx', { id: 'worksV2.index' }),
@@ -149,6 +151,7 @@ export default [
       ...getRoutesForMountPoint('app/works'),
       index('routes/app/works._index/route.tsx'),
       route('drafts', 'routes/app/works.drafts/route.tsx'),
+      route('v3/:workId', 'routes/app/works.v3.$workId/route.tsx'),
       route(':workId', 'routes/app/works.$workId/route.tsx', [
         ...getRoutesForMountPoint('app/works/:workId'),
         // index('routes/app/works.$workId._index/route.tsx'),

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -1,34 +1,20 @@
 import type { Route } from './+types/route';
 import { redirect, type LoaderFunctionArgs } from 'react-router';
 import { Outlet } from 'react-router';
-import { withSecureWorkContext } from '@curvenote/scms-server';
 import {
   MainWrapper,
   SecondaryNav,
   getBrandingFromMetaMatches,
   joinPageTitle,
-  TrackEvent,
-  getWorkflows,
-  registerExtensionWorkflows,
-  scopes,
 } from '@curvenote/scms-core';
 import { buildMenu } from './menu';
-import { dbGetWorkVersionsWithSubmissionVersions } from './db.server';
 import { WorkDetailsCard } from './WorkDetailsCard';
-import { getUniqueSubmissions } from './utils.server';
 import { extensions } from '../../../extensions/client';
+import { workLayoutLoader } from './workLayoutLoader.server';
 
 export const loader = async (args: LoaderFunctionArgs) => {
-  const ctx = await withSecureWorkContext(args, [scopes.work.read]);
-
+  const data = await workLayoutLoader(args);
   const { workId } = args.params;
-  if (!workId) return redirect('/app/works');
-
-  const workVersions = await dbGetWorkVersionsWithSubmissionVersions(ctx.work.id);
-  if (!workVersions) throw redirect('/app/works');
-
-  const isDraftOnlyWork = workVersions.length > 0 && workVersions.every((v) => v.draft);
-
   const url = new URL(args.request.url);
   const pathname = url.pathname;
   const includeDraftSubmissions = url.searchParams.get('drafts') === 'true';
@@ -50,6 +36,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
   }
 
   // Default index redirect (preserve query string e.g. ?drafts=true).
+  // Default index redirect for main work layout only.
   if (pathname === `/app/works/${workId}` || pathname === `/app/works/${workId}/`) {
     throw redirect(`/app/works/${workId}/details${url.search}`);
   }

--- a/platform/scms/app/routes/app/works.$workId/workLayoutLoader.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/workLayoutLoader.server.ts
@@ -1,11 +1,6 @@
 import { redirect, type LoaderFunctionArgs } from 'react-router';
 import { withSecureWorkContext } from '@curvenote/scms-server';
-import {
-  TrackEvent,
-  getWorkflows,
-  registerExtensionWorkflows,
-  scopes,
-} from '@curvenote/scms-core';
+import { TrackEvent, getWorkflows, registerExtensionWorkflows, scopes } from '@curvenote/scms-core';
 import { dbGetWorkVersionsWithSubmissionVersions } from './db.server';
 import { getUniqueSubmissions } from './utils.server';
 import { extensions } from '../../../extensions/client';

--- a/platform/scms/app/routes/app/works.$workId/workLayoutLoader.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/workLayoutLoader.server.ts
@@ -1,0 +1,69 @@
+import { redirect, type LoaderFunctionArgs } from 'react-router';
+import { withSecureWorkContext } from '@curvenote/scms-server';
+import {
+  TrackEvent,
+  getWorkflows,
+  registerExtensionWorkflows,
+  scopes,
+} from '@curvenote/scms-core';
+import { dbGetWorkVersionsWithSubmissionVersions } from './db.server';
+import { getUniqueSubmissions } from './utils.server';
+import { extensions } from '../../../extensions/client';
+
+/** Shared loader data for work layout and v3 work details. Used by works.$workId and works.v3.$workId. */
+export async function workLayoutLoader(args: LoaderFunctionArgs) {
+  const ctx = await withSecureWorkContext(args, [scopes.work.read]);
+
+  const { workId } = args.params;
+  if (!workId) return redirect('/app/works');
+
+  const workVersions = await dbGetWorkVersionsWithSubmissionVersions(ctx.work.id);
+  if (!workVersions) throw redirect('/app/works');
+
+  const isDraftOnlyWork = workVersions.length > 0 && workVersions.every((v) => v.draft);
+
+  const url = new URL(args.request.url);
+  const pathname = url.pathname;
+
+  // Draft-only works should route users into the upload flow, not the details pages.
+  const isUploadPath = pathname.includes(`/app/works/${workId}/upload/`);
+  const isDetailsLikePath =
+    pathname === `/app/works/${workId}` ||
+    pathname === `/app/works/${workId}/` ||
+    pathname.startsWith(`/app/works/${workId}/details`) ||
+    pathname.startsWith(`/app/works/${workId}/users`) ||
+    pathname.startsWith(`/app/works/${workId}/checks`) ||
+    pathname.startsWith(`/app/works/${workId}/site/`) ||
+    pathname === `/app/works/v3/${workId}`;
+
+  if (isDraftOnlyWork && !isUploadPath && isDetailsLikePath) {
+    throw redirect(`/app/works/${workId}/upload/${workVersions[0].id}`);
+  }
+
+  const submissions = getUniqueSubmissions(workVersions);
+  const workflowNames = submissions.map((s) => s.collection.workflow);
+
+  const workflows = Object.fromEntries(
+    Object.entries(getWorkflows(ctx.$config, registerExtensionWorkflows(extensions))).filter(
+      ([name]) => workflowNames.includes(name),
+    ),
+  );
+
+  await ctx.trackEvent(TrackEvent.WORK_VIEWED, {
+    workId: ctx.work.id,
+    workTitle: ctx.workDTO.title,
+    versionCount: workVersions.length,
+    submissionCount: submissions.length,
+    isDraft: workVersions.length === 1 && workVersions[0].draft,
+  });
+
+  await ctx.analytics.flush();
+
+  return {
+    userScopes: ctx.scopes,
+    workflows,
+    work: ctx.workDTO,
+    versions: workVersions ?? [],
+    submissions: submissions ?? [],
+  };
+}

--- a/platform/scms/app/routes/app/works.v3.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.v3.$workId/route.tsx
@@ -59,7 +59,9 @@ export default function WorkDetailsV3Route({ loaderData }: Route.ComponentProps)
       : '—';
 
   const truncatedTitle =
-    work.title && work.title.length > 32 ? work.title.substring(0, 32) + '...' : work.title ?? 'Untitled Work';
+    work.title && work.title.length > 32
+      ? work.title.substring(0, 32) + '...'
+      : (work.title ?? 'Untitled Work');
   const breadcrumbs = [
     { label: 'Works', href: '/app/works' },
     { label: truncatedTitle, isCurrentPage: true },
@@ -86,14 +88,14 @@ export default function WorkDetailsV3Route({ loaderData }: Route.ComponentProps)
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
             {/* Metadata */}
             <primitives.Card className="p-4 space-y-4">
-              <div className="flex items-center justify-between">
+              <div className="flex justify-between items-center">
                 <h2 className="text-lg font-semibold">Metadata</h2>
                 <button
                   type="button"
                   className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
                   aria-label="Edit metadata"
                 >
-                  <Settings className="h-4 w-4" />
+                  <Settings className="w-4 h-4" />
                   Edit
                 </button>
               </div>
@@ -119,11 +121,11 @@ export default function WorkDetailsV3Route({ loaderData }: Route.ComponentProps)
 
             {/* Submissions */}
             <primitives.Card className="p-4 space-y-4">
-              <div className="flex items-center justify-between">
+              <div className="flex justify-between items-center">
                 <h2 className="text-lg font-semibold">Submissions</h2>
                 {/* TODO: link to new submission flow (e.g. site picker) when available */}
                 <span className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground opacity-90">
-                  <PlusCircle className="h-4 w-4" />
+                  <PlusCircle className="w-4 h-4" />
                   New submission
                 </span>
               </div>
@@ -138,9 +140,9 @@ export default function WorkDetailsV3Route({ loaderData }: Route.ComponentProps)
                     return (
                       <li
                         key={sub.id}
-                        className="flex flex-wrap items-center justify-between gap-2 rounded-md border p-3"
+                        className="flex flex-wrap gap-2 justify-between items-center p-3 rounded-md border"
                       >
-                        <div className="flex flex-wrap items-center gap-2">
+                        <div className="flex flex-wrap gap-2 items-center">
                           <span className="font-medium">{sub.site.title}</span>
                           <ui.SubmissionVersionBadge
                             submissionVersion={latestSv}
@@ -167,14 +169,14 @@ export default function WorkDetailsV3Route({ loaderData }: Route.ComponentProps)
 
           {/* Revisions */}
           <primitives.Card className="p-4 space-y-4">
-            <div className="flex items-center justify-between">
+            <div className="flex justify-between items-center">
               <h2 className="text-lg font-semibold">Revisions</h2>
               {latestVersionId && (
                 <Link
                   to={`/app/works/${workId}/upload/${latestVersionId}`}
                   className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
                 >
-                  <Upload className="h-4 w-4" />
+                  <Upload className="w-4 h-4" />
                   Upload new revision
                 </Link>
               )}
@@ -186,7 +188,7 @@ export default function WorkDetailsV3Route({ loaderData }: Route.ComponentProps)
                 return (
                   <li
                     key={v.id}
-                    className="flex flex-wrap items-center gap-2 rounded-md border p-3 text-sm"
+                    className="flex flex-wrap gap-2 items-center p-3 text-sm rounded-md border"
                   >
                     <span className="font-medium tabular-nums">
                       {formatDate(v.date_created, 'MMM dd, yyyy')}
@@ -197,8 +199,8 @@ export default function WorkDetailsV3Route({ loaderData }: Route.ComponentProps)
                       </ui.Badge>
                     )}
                     {nonDraftSvs.length > 0 ? (
-                      <span className="flex flex-wrap items-center gap-2">
-                        <Leaf className="h-4 w-4 text-muted-foreground" aria-hidden />
+                      <span className="flex flex-wrap gap-2 items-center">
+                        <Leaf className="w-4 h-4 text-muted-foreground" aria-hidden />
                         {nonDraftSvs.map((sv) => (
                           <ui.SubmissionVersionBadge
                             key={sv.id}

--- a/platform/scms/app/routes/app/works.v3.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.v3.$workId/route.tsx
@@ -1,0 +1,225 @@
+import type { Route } from './+types/route';
+import { Link } from 'react-router';
+import {
+  MainWrapper,
+  PageFrame,
+  primitives,
+  formatDate,
+  getBrandingFromMetaMatches,
+  joinPageTitle,
+  ui,
+} from '@curvenote/scms-core';
+import { workLayoutLoader } from '../works.$workId/workLayoutLoader.server';
+import type {
+  SubmissionWithVersionsAndSite,
+  WorkVersionWithSubmissionVersions,
+} from '../works.$workId/types';
+import type { Workflow } from '@curvenote/scms-core';
+import { Settings, PlusCircle, RefreshCw, Upload, Leaf } from 'lucide-react';
+
+type LoaderData = {
+  workflows: Record<string, Workflow>;
+  work: { id: string; title?: string; authors?: { name: string }[] };
+  versions: WorkVersionWithSubmissionVersions[];
+  submissions: SubmissionWithVersionsAndSite[];
+};
+
+function formatMetadataValue(value: unknown): string {
+  if (value == null || value === '') return '—';
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) {
+    return value.map((v) => (typeof v === 'string' ? v : String(v))).join(', ');
+  }
+  if (typeof value === 'object' && value !== null && 'content' in value) {
+    const content = (value as { content?: { id?: string } }).content;
+    return content?.id ?? String(value);
+  }
+  return String(value);
+}
+
+export const loader = workLayoutLoader;
+
+export const meta: Route.MetaFunction = ({ matches, loaderData }) => {
+  const branding = getBrandingFromMetaMatches(matches);
+  return [{ title: joinPageTitle(loaderData?.work?.title, 'Work Details', branding.title) }];
+};
+
+export default function WorkDetailsV3Route({ loaderData }: Route.ComponentProps) {
+  const { workflows, work, versions, submissions } = loaderData as LoaderData;
+  const workId = work.id;
+
+  const latestNonDraftVersion = versions.find((v) => !v.draft) ?? versions[0];
+  const metaObj = (latestNonDraftVersion?.metadata ?? null) as Record<string, unknown> | null;
+  const license = metaObj?.license != null ? formatMetadataValue(metaObj.license) : '—';
+  const keywords = metaObj?.keywords != null ? formatMetadataValue(metaObj.keywords) : '—';
+  const funding = metaObj?.funding != null ? formatMetadataValue(metaObj.funding) : '—';
+  const lastUpdated =
+    latestNonDraftVersion?.date_created != null
+      ? formatDate(latestNonDraftVersion.date_created, 'MMM dd, yyyy')
+      : '—';
+
+  const truncatedTitle =
+    work.title && work.title.length > 32 ? work.title.substring(0, 32) + '...' : work.title ?? 'Untitled Work';
+  const breadcrumbs = [
+    { label: 'Works', href: '/app/works' },
+    { label: truncatedTitle, isCurrentPage: true },
+  ];
+
+  const submissionDetailBasePath = `/app/works/${workId}`;
+  const latestVersionId = versions[0]?.id;
+
+  return (
+    <MainWrapper hasSecondaryNav={false}>
+      <PageFrame breadcrumbs={breadcrumbs}>
+        <div className="mt-4 space-y-6">
+          {/* Work details header */}
+          <div className="space-y-1">
+            <h1 className="text-3xl font-bold tracking-tight">{work.title ?? 'Untitled Work'}</h1>
+            <p className="text-base text-muted-foreground">
+              {work.authors && work.authors.length > 0
+                ? work.authors.map((a) => a.name).join(', ')
+                : 'Unknown authors'}
+            </p>
+          </div>
+
+          {/* Two-column: Metadata (left) + Submissions (right) */}
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            {/* Metadata */}
+            <primitives.Card className="p-4 space-y-4">
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold">Metadata</h2>
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                  aria-label="Edit metadata"
+                >
+                  <Settings className="h-4 w-4" />
+                  Edit
+                </button>
+              </div>
+              <dl className="space-y-2 text-sm">
+                <div>
+                  <dt className="font-medium text-muted-foreground">License</dt>
+                  <dd>{license}</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-muted-foreground">Keywords</dt>
+                  <dd>{keywords}</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-muted-foreground">Funding</dt>
+                  <dd>{funding}</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-muted-foreground">Last updated</dt>
+                  <dd>{lastUpdated}</dd>
+                </div>
+              </dl>
+            </primitives.Card>
+
+            {/* Submissions */}
+            <primitives.Card className="p-4 space-y-4">
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold">Submissions</h2>
+                {/* TODO: link to new submission flow (e.g. site picker) when available */}
+                <span className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground opacity-90">
+                  <PlusCircle className="h-4 w-4" />
+                  New submission
+                </span>
+              </div>
+              <ul className="space-y-3">
+                {submissions.length === 0 ? (
+                  <li className="text-sm text-muted-foreground">No submissions yet.</li>
+                ) : (
+                  submissions.map((sub) => {
+                    const latestSv = sub.versions[0];
+                    if (!latestSv) return null;
+                    const submissionUrl = `${submissionDetailBasePath}/site/${sub.site.name}/submission/${latestSv.id}`;
+                    return (
+                      <li
+                        key={sub.id}
+                        className="flex flex-wrap items-center justify-between gap-2 rounded-md border p-3"
+                      >
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-medium">{sub.site.title}</span>
+                          <ui.SubmissionVersionBadge
+                            submissionVersion={latestSv}
+                            workflows={workflows}
+                            basePath={submissionDetailBasePath}
+                            workVersionId={latestSv.work_version_id}
+                            showLink
+                          />
+                        </div>
+                        <Link
+                          to={submissionUrl}
+                          className="inline-flex items-center gap-1.5 rounded-md border bg-muted/50 px-2.5 py-1.5 text-sm hover:bg-muted"
+                        >
+                          <RefreshCw className="h-3.5 w-3.5" />
+                          Update
+                        </Link>
+                      </li>
+                    );
+                  })
+                )}
+              </ul>
+            </primitives.Card>
+          </div>
+
+          {/* Revisions */}
+          <primitives.Card className="p-4 space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold">Revisions</h2>
+              {latestVersionId && (
+                <Link
+                  to={`/app/works/${workId}/upload/${latestVersionId}`}
+                  className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                >
+                  <Upload className="h-4 w-4" />
+                  Upload new revision
+                </Link>
+              )}
+            </div>
+            <ul className="space-y-2">
+              {versions.map((v) => {
+                const nonDraftSvs = v.submissionVersions.filter((sv) => sv.status !== 'DRAFT');
+                const isCurrent = latestNonDraftVersion?.id === v.id && !v.draft;
+                return (
+                  <li
+                    key={v.id}
+                    className="flex flex-wrap items-center gap-2 rounded-md border p-3 text-sm"
+                  >
+                    <span className="font-medium tabular-nums">
+                      {formatDate(v.date_created, 'MMM dd, yyyy')}
+                    </span>
+                    {isCurrent && (
+                      <ui.Badge variant="secondary" className="text-xs">
+                        Current
+                      </ui.Badge>
+                    )}
+                    {nonDraftSvs.length > 0 ? (
+                      <span className="flex flex-wrap items-center gap-2">
+                        <Leaf className="h-4 w-4 text-muted-foreground" aria-hidden />
+                        {nonDraftSvs.map((sv) => (
+                          <ui.SubmissionVersionBadge
+                            key={sv.id}
+                            submissionVersion={sv}
+                            workflows={workflows}
+                            basePath={submissionDetailBasePath}
+                            workVersionId={v.id}
+                            showSite
+                          />
+                        ))}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">No submissions</span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </primitives.Card>
+        </div>
+      </PageFrame>
+    </MainWrapper>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches routing and loader logic for work pages, so regressions could affect navigation/redirects and data/analytics loading for work details.
> 
> **Overview**
> Adds a new experimental Work Details page at `app/works/v3/:workId` with a redesigned, single-page layout showing metadata, submissions, and revision history.
> 
> Refactors the work-details data loading into a shared `workLayoutLoader` (used by both the existing `works.$workId` layout and the new v3 route), including draft-only redirect behavior and analytics event tracking. Also updates `routes.ts` to register the new v3 routes and adjusts `package-lock.json` metadata (mostly marking lint/tooling dependencies as `dev`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1bbed1242bc814dbbf14a3ff0bca55562cb902e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->