### PR TITLE
🗝️ add GitHub OAuth 2 module

### DIFF
--- a/.app-config.schema.yml
+++ b/.app-config.schema.yml
@@ -127,6 +127,35 @@ properties:
           adminLogin:
             type: boolean
             default: false
+      github:
+        type: object
+        required:
+          - clientId
+          - clientSecret
+          - redirectUrl
+        properties:
+          displayName:
+            type: string
+            description: Display name for the auth provider shown in UI
+          clientId:
+            type: string
+          clientSecret:
+            type: string
+            secret: true
+          redirectUrl:
+            type: string
+          allowLogin:
+            type: boolean
+            default: true
+          provisionNewUser:
+            type: boolean
+            default: false
+          allowLinking:
+            type: boolean
+            default: false
+          adminLogin:
+            type: boolean
+            default: false
   api:
     type: object
     required:

--- a/.changeset/happy-lines-strive.md
+++ b/.changeset/happy-lines-strive.md
@@ -1,0 +1,7 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms-core': patch
+'@curvenote/scms': patch
+---
+
+Adding a github oauth2 auth module

--- a/package-lock.json
+++ b/package-lock.json
@@ -4160,10 +4160,6 @@
       "integrity": "sha512-1j7184Wmg5lhgSXt6AXtG82E0PFJ7ULFPplfshQDzb4nIOLKruYFD0CYWheRPMM/eVqNbNZUzc/LLrhyubsK0Q==",
       "license": "MIT"
     },
-    "node_modules/@curvenote/scms": {
-      "resolved": "platform/scms",
-      "link": true
-    },
     "node_modules/@curvenote/scms-core": {
       "resolved": "packages/scms-core",
       "link": true
@@ -4286,6 +4282,7 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
       "integrity": "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4297,6 +4294,7 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
       "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4307,6 +4305,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
       "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7077,6 +7076,7 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10004,6 +10004,7 @@
       "version": "7.9.5",
       "resolved": "https://registry.npmjs.org/@react-router/express/-/express-7.9.5.tgz",
       "integrity": "sha512-Mg94Tw9JSaRuwkvIC6PaODRzsLs6mo70ppz5qdIK/G3iotSxsH08TDNdzot7CaXXevk/pIiD/+Tbn0H/asHsYA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@react-router/node": "7.9.5"
@@ -10718,6 +10719,7 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
       "integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -10733,6 +10735,7 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
       "integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -10759,6 +10762,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10775,6 +10779,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10791,6 +10796,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10807,6 +10813,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10823,6 +10830,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10839,6 +10847,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10855,6 +10864,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10871,6 +10881,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10887,6 +10898,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10911,6 +10923,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10932,6 +10945,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10948,6 +10962,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10981,20 +10996,6 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
-      }
-    },
-    "node_modules/@tailwindcss/vite": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.18.tgz",
-      "integrity": "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tailwindcss/node": "4.1.18",
-        "@tailwindcss/oxide": "4.1.18",
-        "tailwindcss": "4.1.18"
-      },
-      "peerDependencies": {
-        "vite": "^5.2.0 || ^6 || ^7"
       }
     },
     "node_modules/@tanstack/react-virtual": {
@@ -11123,56 +11124,11 @@
         "node": ">=18"
       }
     },
-    "node_modules/@ts-morph/common": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.11.1.tgz",
-      "integrity": "sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-glob": "^3.2.7",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^1.0.4",
-        "path-browserify": "^1.0.1"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13203,33 +13159,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/@vercel/static-config": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.1.2.tgz",
-      "integrity": "sha512-2d+TXr6K30w86a+WbMbGm2W91O0UzO5VeemZYBBUJbCjk/5FLLGIi8aV6RS2+WmaRvtcqNTn2pUA7nCOK3bGcQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ajv": "8.6.3",
-        "json-schema-to-ts": "1.6.4",
-        "ts-morph": "12.0.0"
-      }
-    },
-    "node_modules/@vercel/static-config/node_modules/ajv": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@vitest/expect": {
@@ -15960,12 +15889,6 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/code-block-writer": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
-      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
-      "license": "MIT"
-    },
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -18339,6 +18262,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -18841,6 +18765,7 @@
       "version": "5.18.4",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
       "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -21858,15 +21783,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/fuse.js": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
-      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -22538,6 +22454,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/gonzales-pe": {
@@ -25681,6 +25598,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -25912,16 +25830,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/json-schema-to-ts": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-1.6.4.tgz",
-      "integrity": "sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.6",
-        "ts-toolbelt": "^6.15.5"
       }
     },
     "node_modules/json-schema-to-typescript": {
@@ -26477,6 +26385,7 @@
       "version": "1.30.2",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
       "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -27213,6 +27122,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -36965,6 +36875,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -37522,26 +37433,11 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/ts-morph": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-12.0.0.tgz",
-      "integrity": "sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@ts-morph/common": "~0.11.0",
-        "code-block-writer": "^10.1.1"
-      }
-    },
-    "node_modules/ts-toolbelt": {
-      "version": "6.15.5",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
-      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
-      "license": "Apache-2.0"
-    },
     "node_modules/tsconfck": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
       "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "tsconfck": "bin/tsconfck.js"
@@ -39657,21 +39553,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite-plugin-restart": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-restart/-/vite-plugin-restart-2.0.0.tgz",
-      "integrity": "sha512-OYsD89msjtd72HHpXnidZmQ+14ztJR74IxQq9aPa48LUx3IeukS+NmnVtk+/VaNoYQJLnTFWG3Sbq/AEwaAyeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "micromatch": "^4.0.8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "vite": "^2.9.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/vite-tsconfig-paths": {
@@ -42931,533 +42812,6 @@
       "optionalDependencies": {
         "@esbuild/linux-x64": "^0.25.1",
         "@rollup/rollup-linux-x64-gnu": "^4.35.0"
-      }
-    },
-    "platform/scms/node_modules/@curvenote/cdn": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@curvenote/cdn/-/cdn-0.2.24.tgz",
-      "integrity": "sha512-TCOsKVUqFuqq/k/HhbNPlYSv9PEVKo9q4Kgsey1BM47m+s63Y98osdk/KHM8O2H2HwWlgr+LslsjiYmvH6ks6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@curvenote/common": "^0.2.24",
-        "cache-manager": "^5.2.3",
-        "doi-utils": "^2.0.5",
-        "myst-common": "^1.8.3",
-        "myst-config": "^1.8.3",
-        "myst-frontmatter": "^1.8.3",
-        "myst-migrate": "^1.6.4",
-        "myst-spec-ext": "^1.8.3",
-        "nbtx": "^0.2.3",
-        "node-cache": "^5.1.2",
-        "node-fetch": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "platform/scms/node_modules/@curvenote/check-definitions": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@curvenote/check-definitions/-/check-definitions-0.0.29.tgz",
-      "integrity": "sha512-WjMNVWC5QyWxD/mevacvkHv3bsrjt0POMG+rfp9MBzlxgAh5cIyrSt7qPEGeycfoXhukDjmbiXiFncRaau0DxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "myst-common": "^1.8.3",
-        "myst-templates": "^1.0.26"
-      }
-    },
-    "platform/scms/node_modules/@curvenote/common": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@curvenote/common/-/common-0.2.24.tgz",
-      "integrity": "sha512-lTc0WJr1dcyr4rrC/+se9cO/3oxsjGYIQncqpy4AJ+SYivgVMEDllg7i538QBvCCVQab4u/0sFo3EalURp78jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@curvenote/blocks": "^1.5.30",
-        "myst-common": "^1.8.3",
-        "myst-config": "^1.8.3"
-      }
-    },
-    "platform/scms/node_modules/@react-router/dev": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.9.5.tgz",
-      "integrity": "sha512-MkWI4zN7VbQ0tteuJtX5hmDINNS26IW236a8lM8+o1344xdnT/ZsBvcUh8AkzDdCRYEz1blgzgirpj0Wc1gmXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.27.7",
-        "@babel/generator": "^7.27.5",
-        "@babel/parser": "^7.27.7",
-        "@babel/plugin-syntax-jsx": "^7.27.1",
-        "@babel/preset-typescript": "^7.27.1",
-        "@babel/traverse": "^7.27.7",
-        "@babel/types": "^7.27.7",
-        "@npmcli/package-json": "^4.0.1",
-        "@react-router/node": "7.9.5",
-        "@remix-run/node-fetch-server": "^0.9.0",
-        "arg": "^5.0.1",
-        "babel-dead-code-elimination": "^1.0.6",
-        "chokidar": "^4.0.0",
-        "dedent": "^1.5.3",
-        "es-module-lexer": "^1.3.1",
-        "exit-hook": "2.2.1",
-        "isbot": "^5.1.11",
-        "jsesc": "3.0.2",
-        "lodash": "^4.17.21",
-        "p-map": "^7.0.3",
-        "pathe": "^1.1.2",
-        "picocolors": "^1.1.1",
-        "prettier": "^3.6.2",
-        "react-refresh": "^0.14.0",
-        "semver": "^7.3.7",
-        "tinyglobby": "^0.2.14",
-        "valibot": "^1.1.0",
-        "vite-node": "^3.2.2"
-      },
-      "bin": {
-        "react-router": "bin.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@react-router/serve": "^7.9.5",
-        "@vitejs/plugin-rsc": "*",
-        "react-router": "^7.9.5",
-        "typescript": "^5.1.0",
-        "vite": "^5.1.0 || ^6.0.0 || ^7.0.0",
-        "wrangler": "^3.28.2 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@react-router/serve": {
-          "optional": true
-        },
-        "@vitejs/plugin-rsc": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        },
-        "wrangler": {
-          "optional": true
-        }
-      }
-    },
-    "platform/scms/node_modules/@react-router/dev/node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "license": "MIT"
-    },
-    "platform/scms/node_modules/@scienceicons/react": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@scienceicons/react/-/react-0.0.13.tgz",
-      "integrity": "sha512-ZEQbQt856PUf+R58qrV49s6NN2Z9LCmH9aj52UWT0QumbxL05GyRGf6TBWO22Nrg+nGkcO4ZOaE4CfqrGwlYGw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">= 16"
-      }
-    },
-    "platform/scms/node_modules/@types/node": {
-      "version": "22.19.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
-      "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "platform/scms/node_modules/@vercel/react-router": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@vercel/react-router/-/react-router-1.2.4.tgz",
-      "integrity": "sha512-ep4yczB3O24yMQ+08IBB/zamNTAW0BzgEv1urnhLnsvN6wrjACk/2M28obmyE0EEgW5YLNaYVbGKcYI3QSMcQw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@vercel/static-config": "3.1.2",
-        "ts-morph": "12.0.0"
-      },
-      "peerDependencies": {
-        "@react-router/dev": "7",
-        "@react-router/node": "7",
-        "isbot": "5",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "platform/scms/node_modules/@vitest/expect": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.17.tgz",
-      "integrity": "sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.17",
-        "@vitest/utils": "4.0.17",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "platform/scms/node_modules/@vitest/mocker": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.17.tgz",
-      "integrity": "sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.0.17",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "platform/scms/node_modules/@vitest/pretty-format": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.17.tgz",
-      "integrity": "sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "platform/scms/node_modules/@vitest/runner": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.17.tgz",
-      "integrity": "sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.0.17",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "platform/scms/node_modules/@vitest/snapshot": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.17.tgz",
-      "integrity": "sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.0.17",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "platform/scms/node_modules/@vitest/spy": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.17.tgz",
-      "integrity": "sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "platform/scms/node_modules/@vitest/utils": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.17.tgz",
-      "integrity": "sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.0.17",
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "platform/scms/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "platform/scms/node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "platform/scms/node_modules/jsesc": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "platform/scms/node_modules/jsonwebtoken": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
-      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^4.0.1",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      }
-    },
-    "platform/scms/node_modules/myst-to-react": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/myst-to-react/-/myst-to-react-0.17.1.tgz",
-      "integrity": "sha512-5B3GP0NZJrCo0ikwunuDSoTr2UNQ89MfKMaGOCFFOVCbjBro+L7wQgTzHTGJolquPANx8Wgq/AeFBP/PHWfqcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@heroicons/react": "^2.0.18",
-        "@myst-theme/providers": "^0.17.1",
-        "@radix-ui/react-hover-card": "^1.0.6",
-        "@scienceicons/react": "^0.0.13",
-        "buffer": "^6.0.3",
-        "classnames": "^2.3.2",
-        "myst-common": "^1.8.1",
-        "myst-config": "^1.8.1",
-        "myst-spec": "^0.0.5",
-        "nanoid": "^4.0.2",
-        "react-syntax-highlighter": "15.5.0",
-        "swr": "^2.1.5",
-        "unist-util-select": "^4.0.3",
-        "unist-util-visit": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8 || ^17.0 || ^18.0",
-        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "platform/scms/node_modules/nanoid": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18"
-      }
-    },
-    "platform/scms/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "platform/scms/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "platform/scms/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "platform/scms/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "platform/scms/node_modules/vite-tsconfig-paths": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
-      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      },
-      "peerDependenciesMeta": {
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "platform/scms/node_modules/vitest": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.17.tgz",
-      "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "4.0.17",
-        "@vitest/mocker": "4.0.17",
-        "@vitest/pretty-format": "4.0.17",
-        "@vitest/runner": "4.0.17",
-        "@vitest/snapshot": "4.0.17",
-        "@vitest/spy": "4.0.17",
-        "@vitest/utils": "4.0.17",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.17",
-        "@vitest/browser-preview": "4.0.17",
-        "@vitest/browser-webdriverio": "4.0.17",
-        "@vitest/ui": "4.0.17",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "platform/scms/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "platform/scms/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     }
   }

--- a/packages/scms-core/package.json
+++ b/packages/scms-core/package.json
@@ -79,6 +79,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "@react-email/components": "0.5.7",
     "@react-router/dev": "7.9.5",
+    "@scienceicons/react": "^0.0.13",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
     "class-variance-authority": "^0.7.1",

--- a/packages/scms-core/src/modules/auth/auth.tsx
+++ b/packages/scms-core/src/modules/auth/auth.tsx
@@ -14,6 +14,11 @@ import {
   ProfileCardContent as ORCIDProfileCardContent,
   LoginUI as ORCIDLoginUI,
 } from './orcid/ui.js';
+import {
+  Badge as GitHubBadge,
+  ProfileCardContent as GitHubProfileCardContent,
+  LoginUI as GitHubLoginUI,
+} from './github/ui.js';
 import type { FirebaseProfile } from './firebase/types.js';
 import type { OktaProfile } from '@curvenote/remix-auth-okta';
 
@@ -23,6 +28,8 @@ export function ProviderBadge({ provider, ...props }: { provider: string }) {
       return <Badge {...props} />;
     case 'firebase-email':
       return <FirebaseEmailBadge {...props} />;
+    case 'github':
+      return <GitHubBadge {...props} />;
     case 'okta':
       return <OktaBadge {...props} />;
     case 'orcid':
@@ -66,5 +73,10 @@ export const AuthComponentMap: Record<string, AuthProviderComponents> = {
     Badge: ORCIDBadge,
     ProfileCardContent: ORCIDProfileCardContent,
     LoginUI: ORCIDLoginUI,
+  },
+  github: {
+    Badge: GitHubBadge,
+    ProfileCardContent: GitHubProfileCardContent,
+    LoginUI: GitHubLoginUI,
   },
 };

--- a/packages/scms-core/src/modules/auth/github/index.ts
+++ b/packages/scms-core/src/modules/auth/github/index.ts
@@ -1,0 +1,2 @@
+export * from './types.js';
+export * from './ui.js';

--- a/packages/scms-core/src/modules/auth/github/types.ts
+++ b/packages/scms-core/src/modules/auth/github/types.ts
@@ -1,0 +1,17 @@
+export interface GitHubClientSideSafeOptions {
+  provider: 'github';
+  displayName?: string;
+  allowLogin?: boolean;
+  allowLinking?: boolean;
+  provisionNewUser?: boolean;
+  adminLogin?: boolean;
+}
+
+/** Profile shape from GitHub API /user (subset used in linked accounts). */
+export interface GitHubProfile {
+  id: number;
+  login: string;
+  name: string | null;
+  email: string | null;
+  avatar_url: string | null;
+}

--- a/packages/scms-core/src/modules/auth/github/ui.tsx
+++ b/packages/scms-core/src/modules/auth/github/ui.tsx
@@ -1,0 +1,91 @@
+import { useFetcher } from 'react-router';
+import { useEffect } from 'react';
+import { ProfileContentLayout } from '../common.js';
+import type { GitHubProfile } from './types.js';
+import { Github, Shield } from 'lucide-react';
+import { StatefulButton } from '../../../components/ui/index.js';
+
+export function Badge({
+  className,
+  size,
+  showName,
+}: {
+  className?: string;
+  size?: number;
+  showName?: boolean;
+}) {
+  return (
+    <div className={`flex items-center space-x-2 ${className ?? ''}`}>
+      <Github size={size ?? 20} strokeWidth={1.5} />
+      {showName && <span>GitHub</span>}
+    </div>
+  );
+}
+
+export function ProfileCardContent({
+  profile,
+  children,
+}: React.PropsWithChildren<{ profile: GitHubProfile }>) {
+  return (
+    <ProfileContentLayout
+      content={
+        <div className="flex items-center space-x-6 grow">
+          <Github className="flex-shrink-0" size={48} strokeWidth={1.5} />
+          <div className="flex flex-col">
+            <p title="Display Name">{profile.name ?? profile.login}</p>
+            <p title="email" className="flex items-center">
+              {profile.email ?? '—'}
+              {profile.email && (
+                <span className="inline-block ml-[2px]" title="email from GitHub">
+                  <Shield className="w-3 h-3 fill-blue-200 stroke-blue-600 dark:fill-stone-600 dark:stroke-stone-200" />
+                </span>
+              )}
+            </p>
+            <p title="GitHub login" className="inline-block pt-1 font-mono text-xs text-stone-400">
+              @{profile.login}
+            </p>
+          </div>
+        </div>
+      }
+    >
+      {children}
+    </ProfileContentLayout>
+  );
+}
+
+export function LoginUI({
+  disabled,
+  setSubmitting,
+  className,
+}: {
+  disabled?: boolean;
+  setSubmitting: (flag: boolean) => void;
+  className?: string;
+}) {
+  const fetcher = useFetcher();
+
+  useEffect(() => {
+    if (fetcher.state !== 'idle') {
+      setSubmitting(true);
+    } else {
+      setSubmitting(false);
+    }
+  }, [fetcher.state, setSubmitting]);
+
+  return (
+    <fetcher.Form method="post" action="/auth/github" aria-disabled={disabled} className="w-full">
+      <StatefulButton
+        variant="outline"
+        type="submit"
+        aria-label="Sign in with GitHub"
+        disabled={disabled}
+        busy={fetcher.state !== 'idle'}
+        overlayBusy
+        className={className}
+      >
+        <Github className="w-5 h-5 mr-2" strokeWidth={1.5} />
+        Sign in with GitHub
+      </StatefulButton>
+    </fetcher.Form>
+  );
+}

--- a/packages/scms-core/src/modules/auth/github/ui.tsx
+++ b/packages/scms-core/src/modules/auth/github/ui.tsx
@@ -2,7 +2,8 @@ import { useFetcher } from 'react-router';
 import { useEffect } from 'react';
 import { ProfileContentLayout } from '../common.js';
 import type { GitHubProfile } from './types.js';
-import { Github, Shield } from 'lucide-react';
+import { Shield } from 'lucide-react';
+import { GithubIcon } from '@scienceicons/react/24/solid';
 import { StatefulButton } from '../../../components/ui/index.js';
 
 export function Badge({
@@ -16,7 +17,7 @@ export function Badge({
 }) {
   return (
     <div className={`flex items-center space-x-2 ${className ?? ''}`}>
-      <Github size={size ?? 20} strokeWidth={1.5} />
+      <GithubIcon style={{ width: size ?? 20, height: size ?? 20 }} />
       {showName && <span>GitHub</span>}
     </div>
   );
@@ -30,7 +31,7 @@ export function ProfileCardContent({
     <ProfileContentLayout
       content={
         <div className="flex items-center space-x-6 grow">
-          <Github className="flex-shrink-0" size={48} strokeWidth={1.5} />
+          <GithubIcon className="flex-shrink-0 w-12 h-12" />
           <div className="flex flex-col">
             <p title="Display Name">{profile.name ?? profile.login}</p>
             <p title="email" className="flex items-center">
@@ -83,8 +84,10 @@ export function LoginUI({
         overlayBusy
         className={className}
       >
-        <Github className="w-5 h-5 mr-2" strokeWidth={1.5} />
-        Sign in with GitHub
+        <span className="inline-flex items-center whitespace-nowrap">
+          <GithubIcon className="mr-1.5 w-5 h-5 shrink-0" />
+          GitHub
+        </span>
       </StatefulButton>
     </fetcher.Form>
   );

--- a/packages/scms-core/src/modules/auth/index.ts
+++ b/packages/scms-core/src/modules/auth/index.ts
@@ -3,6 +3,7 @@ export * from './auth.js';
 export * from './common.js';
 export * from './types.js';
 export * as firebase from './firebase/index.js';
+export * as github from './github/index.js';
 export * as google from './google/index.js';
 export * as okta from './okta/index.js';
 export * as orcid from './orcid/index.js';

--- a/packages/scms-core/src/modules/auth/types.ts
+++ b/packages/scms-core/src/modules/auth/types.ts
@@ -1,12 +1,14 @@
 import type { FirebaseClientSideSafeOptions } from './firebase/types.js';
+import type { GitHubClientSideSafeOptions } from './github/types.js';
 import type { GoogleClientSideSafeOptions } from './google/types.js';
 import type { OKTAClientSideSafeOptions } from './okta/types.js';
 import type { ORCIDClientSideSafeOptions } from './orcid/types.js';
 
-export type AuthProvider = 'firebase' | 'google' | 'okta' | 'orcid';
+export type AuthProvider = 'firebase' | 'github' | 'google' | 'okta' | 'orcid';
 
 export type ClientSideSafeAuthOptions =
   | FirebaseClientSideSafeOptions
+  | GitHubClientSideSafeOptions
   | GoogleClientSideSafeOptions
   | OKTAClientSideSafeOptions
   | ORCIDClientSideSafeOptions;

--- a/packages/scms-server/src/backend/signup/index.server.ts
+++ b/packages/scms-server/src/backend/signup/index.server.ts
@@ -446,9 +446,11 @@ function validateSigninSignupConfig(
   }
 
   // validate link-providers step
-  // list linkable providers from auth config
+  // list linkable providers from auth config (use Record to support all configured providers including github)
   const linkableProviderNames = authConfig
-    ? Object.keys(authConfig).filter((p) => authConfig?.[p as AuthProvider]?.allowLinking)
+    ? Object.keys(authConfig).filter((p) =>
+        (authConfig as Record<string, { allowLinking?: boolean }>)?.[p]?.allowLinking,
+      )
     : [];
 
   if (config?.signup?.steps) {

--- a/packages/scms-server/src/modules/auth/auth.server.ts
+++ b/packages/scms-server/src/modules/auth/auth.server.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from 'remix-auth';
 import { getConfig } from '../../app-config.server.js';
+import { registerGitHubStrategy } from './github/register.server.js';
 import { registerGoogleStrategy } from './google/register.server.js';
 import { registerFirebaseStrategy } from './firebase/register.server.js';
 import { registerOktaStrategy } from './okta/register.server.js';
@@ -21,6 +22,9 @@ export async function authenticatorFactory() {
   const authProviders = config.auth;
   for (const provider in authProviders) {
     // TODO some dynamic module loading thing
+    if (provider === 'github') {
+      registerGitHubStrategy(config, authenticator);
+    }
     if (provider === 'google') {
       registerGoogleStrategy(config, authenticator);
     }

--- a/packages/scms-server/src/modules/auth/github/README.md
+++ b/packages/scms-server/src/modules/auth/github/README.md
@@ -1,0 +1,88 @@
+# GitHub OAuth authentication
+
+This module adds GitHub as an OAuth 2.0 sign-in provider, supporting **sign-in**, **sign-up**, and **account linking** when enabled in app config.
+
+## Enabling GitHub authentication
+
+1. **Add GitHub to the app-config schema**  
+   The root `.app-config.schema.yml` already includes a `github` provider under `auth`. No schema change is required unless you need to add fields.
+
+2. **Create a GitHub OAuth App** (see below) and add the credentials to your app config.
+
+3. **Configure behaviour** in your deployment config (e.g. `.app-config.development.yml` and `.app-config.secrets.development.yml`):
+
+   - `allowLogin: true` – show “Sign in with GitHub” on the login page.
+   - `allowLinking: true` – allow users to link a GitHub account in settings.
+   - `provisionNewUser: true` – allow new users to sign up with GitHub (creates a user when they don’t exist).
+
+## Getting GitHub OAuth credentials
+
+To get a **Client ID** and **Client Secret** for your application:
+
+1. **Sign in to GitHub** and go to **Settings** → **Developer settings** → **OAuth Apps**:  
+   [https://github.com/settings/developers](https://github.com/settings/developers)
+
+2. **Create an OAuth App** (or use an existing one):
+   - **Application name**: e.g. “My SCMS (Development)” or your deployment name.
+   - **Homepage URL**: your app’s public URL (e.g. `https://myscms.example.com` or `http://localhost:3031` for local dev).
+   - **Authorization callback URL**: must match exactly what your app uses:
+     - Production: `https://<your-host>/auth/github/callback`
+     - Local: `http://localhost:3031/auth/github/callback` (or the port your app uses).
+
+3. After creating the app, GitHub shows:
+   - **Client ID** – use this in config as `auth.github.clientId`.
+   - **Client secret** – generate one if needed, then set it as `auth.github.clientSecret` (preferably in a secrets file).
+
+4. **Put the values in app config**:
+   - In the main config (e.g. `.app-config.development.yml`) set `auth.github.clientId` and `auth.github.redirectUrl` (and other options like `allowLogin`, `allowLinking`, `provisionNewUser`).
+   - Put `auth.github.clientSecret` in your secrets config (e.g. `.app-config.secrets.development.yml`) so it is not committed.
+
+## Example app-config
+
+**Main config** (e.g. `.app-config.development.yml`):
+
+```yaml
+auth:
+  github:
+    displayName: GitHub
+    clientId: your-github-oauth-client-id
+    redirectUrl: http://localhost:3031/auth/github/callback
+    allowLogin: true
+    allowLinking: true
+    provisionNewUser: true
+    adminLogin: false
+```
+
+**Secrets config** (e.g. `.app-config.secrets.development.yml`):
+
+```yaml
+auth:
+  github:
+    clientSecret: your-github-oauth-client-secret
+```
+
+## Callback URL and redirect URI
+
+The **Authorization callback URL** in the GitHub OAuth App and the **redirectUrl** in your app config must match:
+
+- Same scheme (`http` vs `https`).
+- Same host and port.
+- Path must be: `/<base-path-if-any>/auth/github/callback`.
+
+For example, if your app is at `http://localhost:3031`, use:
+
+- In GitHub OAuth App: `http://localhost:3031/auth/github/callback`
+- In config: `redirectUrl: http://localhost:3031/auth/github/callback`
+
+## Email requirement for new users
+
+GitHub does not always expose the user’s email. For **new sign-ups** (provisioning), the app requires an email:
+
+- If GitHub does not return an email, the user is redirected to an error page asking them to add or make visible a public email in their GitHub profile, then try again.
+- Existing users (sign-in or account linking) can have no email from GitHub; their profile is updated as-is.
+
+New users who sign up via GitHub and have no email will also be asked for email (and other details) in the signup data-collection step, consistent with other providers (e.g. ORCID).
+
+## Scopes
+
+The strategy requests the scopes `user` and `user:email` so the app can read profile and email. No repository or other scopes are required for sign-in/sign-up/linking.

--- a/packages/scms-server/src/modules/auth/github/index.ts
+++ b/packages/scms-server/src/modules/auth/github/index.ts
@@ -1,0 +1,1 @@
+export * from './register.server.js';

--- a/packages/scms-server/src/modules/auth/github/register.server.ts
+++ b/packages/scms-server/src/modules/auth/github/register.server.ts
@@ -28,6 +28,34 @@ export interface GitHubProfile {
   avatar_url: string | null;
 }
 
+/** GitHub /user/emails entry (subset we use). */
+interface GitHubEmail {
+  email: string;
+  primary: boolean;
+  verified: boolean;
+  visibility: string | null;
+}
+
+async function getGitHubUserEmails(accessToken: string): Promise<string | null> {
+  const resp = await fetch('https://api.github.com/user/emails', {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${accessToken}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+
+  if (!resp.ok) {
+    return null;
+  }
+
+  const emails = (await resp.json()) as GitHubEmail[];
+  const primaryVerified = emails.find((e) => e.primary && e.verified);
+  if (primaryVerified) return primaryVerified.email;
+  const firstVerified = emails.find((e) => e.verified);
+  return firstVerified?.email ?? null;
+}
+
 async function getGitHubUser(accessToken: string): Promise<GitHubProfile> {
   const resp = await fetch('https://api.github.com/user', {
     headers: {
@@ -42,11 +70,15 @@ async function getGitHubUser(accessToken: string): Promise<GitHubProfile> {
   }
 
   const data = (await resp.json()) as GitHubProfile;
+  let email = data.email?.trim() ?? null;
+  if (!email) {
+    email = await getGitHubUserEmails(accessToken);
+  }
   return {
     id: data.id,
     login: data.login,
     name: data.name ?? data.login,
-    email: data.email ?? null,
+    email,
     avatar_url: data.avatar_url ?? null,
   };
 }
@@ -63,7 +95,7 @@ export function registerGitHubStrategy(
         authorizationEndpoint: 'https://github.com/login/oauth/authorize',
         tokenEndpoint: 'https://github.com/login/oauth/access_token',
         redirectURI: config.auth?.github?.redirectUrl ?? 'INVALID',
-        scopes: ['user', 'user:email'],
+        scopes: ['read:user', 'user:email'],
       },
       async ({ tokens, request }) => {
         const analytics = new AnalyticsContext();
@@ -160,7 +192,7 @@ export function registerGitHubStrategy(
                 failureRedirectUrl({
                   provider: 'github',
                   message:
-                    'GitHub did not provide an email. Please add a public email in your GitHub profile or make your email visible, then try again.',
+                    'GitHub did not provide a verified email. Please add and verify an email in your GitHub account settings, then try again.',
                 }),
                 {
                   headers: { 'Set-Cookie': await sessionStorage.destroySession(session) },

--- a/packages/scms-server/src/modules/auth/github/register.server.ts
+++ b/packages/scms-server/src/modules/auth/github/register.server.ts
@@ -1,0 +1,243 @@
+import type { Authenticator } from 'remix-auth';
+import { OAuth2Strategy } from 'remix-auth-oauth2';
+import {
+  assertLinkedAccount,
+  dbCreateUserWithPrimaryLinkedAccount,
+  dbGetUserByLinkedAccount,
+  dbUpdateUserLinkedAccountProfile,
+  failureRedirectUrl,
+  handleAccountLinking,
+} from '../common.server.js';
+import { getSetProviderCookie } from '../../../cookies.server.js';
+import { redirect } from 'react-router';
+import type { AuthenticatedUserWithProviderCookie } from '../../../session.server.js';
+import { sessionStorageFactory } from '../../../session.server.js';
+import { $sendSlackNotification, SlackEventType } from '../../../backend/services/slack.server.js';
+import {
+  AnalyticsContext,
+  addSegmentAnalytics,
+} from '../../../backend/services/analytics/segment.server.js';
+import { TrackEvent } from '@curvenote/scms-core';
+
+/** GitHub API user response (subset we use). */
+export interface GitHubProfile {
+  id: number;
+  login: string;
+  name: string | null;
+  email: string | null;
+  avatar_url: string | null;
+}
+
+async function getGitHubUser(accessToken: string): Promise<GitHubProfile> {
+  const resp = await fetch('https://api.github.com/user', {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${accessToken}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch GitHub user: ${resp.status}`);
+  }
+
+  const data = (await resp.json()) as GitHubProfile;
+  return {
+    id: data.id,
+    login: data.login,
+    name: data.name ?? data.login,
+    email: data.email ?? null,
+    avatar_url: data.avatar_url ?? null,
+  };
+}
+
+export function registerGitHubStrategy(
+  config: AppConfig,
+  auth: Authenticator<AuthenticatedUserWithProviderCookie>,
+) {
+  auth.use(
+    new OAuth2Strategy(
+      {
+        clientId: config.auth?.github?.clientId ?? 'INVALID',
+        clientSecret: config.auth?.github?.clientSecret ?? 'INVALID',
+        authorizationEndpoint: 'https://github.com/login/oauth/authorize',
+        tokenEndpoint: 'https://github.com/login/oauth/access_token',
+        redirectURI: config.auth?.github?.redirectUrl ?? 'INVALID',
+        scopes: ['user', 'user:email'],
+      },
+      async ({ tokens, request }) => {
+        const analytics = new AnalyticsContext();
+        addSegmentAnalytics(analytics, config.api?.segment);
+
+        const sessionStorage = await sessionStorageFactory();
+        const session = await sessionStorage.getSession(request.headers.get('Cookie'));
+
+        // GitHub does not return id_token; fetch user from API
+        const profile = await getGitHubUser(tokens.accessToken());
+        const idAtProvider = String(profile.id);
+
+        const provisionNewUsers = config.auth?.github?.provisionNewUser ?? false;
+        const allowLinking = config.auth?.github?.allowLinking ?? false;
+        let dbUserViaGithub = await dbGetUserByLinkedAccount('github', idAtProvider);
+
+        if (dbUserViaGithub) {
+          const user = session.get('user');
+          if (user && dbUserViaGithub.id !== user.userId) {
+            throw redirect(
+              `/app/settings/linked-accounts?error=true&provider=github&message=${encodeURIComponent('This GitHub account has already been linked to another account.')}`,
+            );
+          }
+          try {
+            const account = assertLinkedAccount('github', dbUserViaGithub);
+            await dbUpdateUserLinkedAccountProfile(account.id, profile);
+          } catch (error: any) {
+            console.error('GitHub provider - Failed to update linked account profile', error);
+            await analytics.trackEvent(
+              TrackEvent.USER_LINKING_FAILED,
+              dbUserViaGithub.id,
+              {
+                provider: 'github',
+                operation: 'update_profile',
+                error: error.message || 'Unknown error',
+              },
+              request,
+            );
+          }
+
+          await analytics.identifyEvent(dbUserViaGithub);
+          await analytics.trackEvent(
+            TrackEvent.USER_LOGGED_IN,
+            dbUserViaGithub.id,
+            {
+              provider: 'github',
+              method: 'oauth',
+              linkedAccountEmail: profile.email ?? undefined,
+              idAtProvider,
+            },
+            request,
+          );
+        } else {
+          const user = session.get('user');
+          if (user && allowLinking) {
+            try {
+              dbUserViaGithub = await handleAccountLinking('github', user, {
+                idAtProvider,
+                email: profile.email ?? undefined,
+                profile,
+              });
+
+              await analytics.identifyEvent(dbUserViaGithub);
+              await analytics.trackEvent(
+                TrackEvent.USER_LINKED,
+                dbUserViaGithub.id,
+                {
+                  provider: 'github',
+                  method: 'oauth',
+                  linkedAccountEmail: profile.email ?? undefined,
+                  idAtProvider,
+                },
+                request,
+              );
+            } catch (error: any) {
+              console.error('GitHub provider - Failed to link account', error);
+              await analytics.trackEvent(
+                TrackEvent.USER_LINKING_FAILED,
+                user.userId,
+                {
+                  provider: 'github',
+                  operation: 'link_account',
+                  error: error.message || 'Unknown error',
+                },
+                request,
+              );
+              throw error;
+            }
+          } else if (provisionNewUsers) {
+            // Option A: require email for new users (same as ORCID)
+            const email = profile.email?.trim();
+            if (!email) {
+              throw redirect(
+                failureRedirectUrl({
+                  provider: 'github',
+                  message:
+                    'GitHub did not provide an email. Please add a public email in your GitHub profile or make your email visible, then try again.',
+                }),
+                {
+                  headers: { 'Set-Cookie': await sessionStorage.destroySession(session) },
+                },
+              );
+            }
+
+            const profileForDb = { ...profile, id: idAtProvider };
+            dbUserViaGithub = await dbCreateUserWithPrimaryLinkedAccount<typeof profileForDb>({
+              email,
+              username: (profile.name ?? profile.login).toLocaleLowerCase().replace(/\s/g, '_'),
+              displayName: profile.name ?? profile.login,
+              primaryProvider: 'github',
+              profile: profileForDb,
+            });
+            console.log(
+              `GITHUB provider - provisioned new user (${profile.name ?? profile.login}, ${idAtProvider}, ${dbUserViaGithub.id})`,
+            );
+            await $sendSlackNotification(
+              {
+                eventType: SlackEventType.USER_CREATED,
+                message: `New user${dbUserViaGithub.username ? ` *${dbUserViaGithub.username}*` : ''} provisioned via github`,
+                user: dbUserViaGithub,
+                metadata: {
+                  provider: 'github',
+                  username: dbUserViaGithub.username,
+                  displayName: dbUserViaGithub.display_name,
+                },
+              },
+              config.api?.slack,
+            );
+
+            await analytics.identifyEvent(dbUserViaGithub);
+            await analytics.trackEvent(
+              TrackEvent.USER_SIGNED_UP,
+              dbUserViaGithub.id,
+              {
+                provider: 'github',
+                method: 'oauth',
+                linkedAccountEmail: email,
+                idAtProvider,
+              },
+              request,
+            );
+          } else if (allowLinking) {
+            if (!user) {
+              throw redirect(`/link-accounts?provider=github`);
+            }
+          }
+        }
+
+        if (!dbUserViaGithub) {
+          throw redirect(
+            failureRedirectUrl({
+              provider: 'github',
+              message: `You are logged into GitHub as ${profile.login} but that user is not found in the ${config.name}. To log in as a different user log out of GitHub and try again.`,
+            }),
+            {
+              headers: { 'Set-Cookie': await sessionStorage.destroySession(session) },
+            },
+          );
+        }
+
+        const providerSetCookie = getSetProviderCookie(config.api.authCookieSecret, 'github', {
+          profile,
+        });
+
+        return {
+          userId: dbUserViaGithub.id,
+          primaryProvider: dbUserViaGithub.primaryProvider ?? 'unknown',
+          provider: 'github',
+          pending: dbUserViaGithub.pending,
+          ready_for_approval: dbUserViaGithub.ready_for_approval,
+          providerSetCookie,
+        };
+      },
+    ),
+    'github',
+  );
+}

--- a/packages/scms-server/src/modules/auth/index.ts
+++ b/packages/scms-server/src/modules/auth/index.ts
@@ -2,6 +2,7 @@
 export * from './auth.server.js';
 export * from './common.server.js';
 export * as firebase from './firebase/index.js';
+export * as github from './github/index.js';
 export * as google from './google/index.js';
 export * as okta from './okta/index.js';
 export * as orcid from './orcid/index.js';

--- a/platform/scms/app/routes/_auth/github/auth.callback.tsx
+++ b/platform/scms/app/routes/_auth/github/auth.callback.tsx
@@ -1,0 +1,74 @@
+import { redirect, type LoaderFunctionArgs } from 'react-router';
+import {
+  withContext,
+  sessionStorageFactory,
+  failureRedirectUrl,
+  handleCallbackErrorsWithoutCatchingRedirects,
+  getReturnToUrl,
+} from '@curvenote/scms-server';
+import type { AuthenticatedUserWithProviderCookie } from '@curvenote/scms-server';
+
+export async function loader(args: LoaderFunctionArgs) {
+  const ctx = await withContext(args);
+
+  const sessionStorage = await sessionStorageFactory();
+  const session = await sessionStorage.getSession(args.request.headers.get('Cookie'));
+  const loggedInUser = session.get('user');
+  const headers = new Headers();
+
+  let authResponse: AuthenticatedUserWithProviderCookie | undefined;
+  try {
+    authResponse = await ctx.$auth.authenticate('github', args.request);
+  } catch (errorOrRedirect: any) {
+    console.warn('GITHUB /auth/callback - linking failed');
+    handleCallbackErrorsWithoutCatchingRedirects('github', errorOrRedirect);
+  }
+
+  if (!authResponse) {
+    throw redirect(
+      failureRedirectUrl({
+        provider: 'github',
+        message: 'Unable to authenticate with GitHub. Please try again or contact support.',
+      }),
+      { headers: { 'Set-Cookie': await sessionStorage.destroySession(session) } },
+    );
+  }
+
+  const { providerSetCookie, ...user } = authResponse;
+  headers.append('Set-Cookie', providerSetCookie);
+
+  if (loggedInUser) {
+    console.log('GITHUB /auth/callback - linking complete');
+    if (loggedInUser.ready_for_approval) {
+      console.log('GITHUB /auth/callback - redirect to /awaiting-approval');
+      throw redirect('/awaiting-approval');
+    } else if (loggedInUser.pending) {
+      console.log('GITHUB /auth/callback - redirect to /new-account/pending');
+      throw redirect('/new-account/pending', { headers });
+    }
+
+    const returnToUrl = await getReturnToUrl(session, sessionStorage, headers);
+    if (returnToUrl) {
+      throw redirect(returnToUrl, { headers });
+    }
+
+    throw redirect('/app/settings/linked-accounts', { headers });
+  }
+
+  if (!user) {
+    console.warn('GITHUB /auth/callback - user not found');
+    throw redirect(
+      failureRedirectUrl({
+        provider: 'github',
+        message: `Unable to authenticate with GitHub (user not found). Please try again or contact support.`,
+      }),
+      {
+        headers: { 'Set-Cookie': await sessionStorage.destroySession(session) },
+      },
+    );
+  }
+
+  session.set('user', user);
+  headers.append('Set-Cookie', await sessionStorage.commitSession(session));
+  throw redirect('/app', { headers });
+}

--- a/platform/scms/app/routes/_auth/github/auth.callback.tsx
+++ b/platform/scms/app/routes/_auth/github/auth.callback.tsx
@@ -70,5 +70,13 @@ export async function loader(args: LoaderFunctionArgs) {
 
   session.set('user', user);
   headers.append('Set-Cookie', await sessionStorage.commitSession(session));
+
+  if (user.ready_for_approval) {
+    throw redirect('/awaiting-approval', { headers });
+  }
+  if (user.pending) {
+    throw redirect('/new-account/pending', { headers });
+  }
+
   throw redirect('/app', { headers });
 }

--- a/platform/scms/app/routes/_auth/github/auth.callback.tsx
+++ b/platform/scms/app/routes/_auth/github/auth.callback.tsx
@@ -41,7 +41,7 @@ export async function loader(args: LoaderFunctionArgs) {
     console.log('GITHUB /auth/callback - linking complete');
     if (loggedInUser.ready_for_approval) {
       console.log('GITHUB /auth/callback - redirect to /awaiting-approval');
-      throw redirect('/awaiting-approval');
+      throw redirect('/awaiting-approval', { headers });
     } else if (loggedInUser.pending) {
       console.log('GITHUB /auth/callback - redirect to /new-account/pending');
       throw redirect('/new-account/pending', { headers });

--- a/platform/scms/app/routes/_auth/github/auth.tsx
+++ b/platform/scms/app/routes/_auth/github/auth.tsx
@@ -1,0 +1,25 @@
+import type { ActionFunctionArgs } from 'react-router';
+import { redirect } from 'react-router';
+import { withContext, sessionStorageFactory, handleAuthWithReturnTo } from '@curvenote/scms-server';
+
+export function loader() {
+  return redirect('/login');
+}
+
+export async function action(args: ActionFunctionArgs) {
+  const ctx = await withContext(args);
+
+  const sessionStorage = await sessionStorageFactory();
+  const session = await sessionStorage.getSession(args.request.headers.get('Cookie'));
+  const allowLogin = ctx.$config.auth?.github?.allowLogin;
+  const adminLogin = ctx.$config.auth?.github?.adminLogin;
+  const loggedInUser = session.get('user');
+  if (!allowLogin && !adminLogin && !loggedInUser) {
+    throw redirect('/login');
+  }
+
+  await handleAuthWithReturnTo(args.request, async () =>
+    ctx.$auth.authenticate('github', args.request),
+  );
+  return null;
+}

--- a/platform/scms/app/routes/_auth/google/auth.callback.tsx
+++ b/platform/scms/app/routes/_auth/google/auth.callback.tsx
@@ -63,5 +63,13 @@ export async function loader(args: LoaderFunctionArgs) {
 
   session.set('user', user);
   headers.append('Set-Cookie', await sessionStorage.commitSession(session));
+
+  if (user.ready_for_approval) {
+    throw redirect('/awaiting-approval', { headers });
+  }
+  if (user.pending) {
+    throw redirect('/new-account/pending', { headers });
+  }
+
   throw redirect('/app', { headers });
 }

--- a/platform/scms/app/routes/_auth/google/auth.callback.tsx
+++ b/platform/scms/app/routes/_auth/google/auth.callback.tsx
@@ -32,7 +32,7 @@ export async function loader(args: LoaderFunctionArgs) {
     console.log('GOOGLE /auth/callback - linking complete');
     if (loggedInUser.ready_for_approval) {
       console.log('GOOGLE /auth/callback - redirecting to awaiting-approval');
-      throw redirect('/awaiting-approval');
+      throw redirect('/awaiting-approval', { headers });
     } else if (loggedInUser.pending) {
       console.log('GOOGLE /auth/callback - returning to signup flow');
       throw redirect('/new-account/pending', { headers });

--- a/platform/scms/app/routes/_auth/route.login._index.tsx
+++ b/platform/scms/app/routes/_auth/route.login._index.tsx
@@ -1,4 +1,4 @@
-import { useDeploymentConfig, google, okta, orcid, firebase, ui } from '@curvenote/scms-core';
+import { useDeploymentConfig, firebase, github, google, okta, orcid, ui } from '@curvenote/scms-core';
 import { useEffect, useState } from 'react';
 import { OrDivider } from './OrDivider';
 import type { ClientSideSafeAuthOptions, ClientSigninSignupConfig } from '@curvenote/scms-core';
@@ -52,6 +52,7 @@ function AllProviderLoginArea({
     loginAuthProviders.length > 0 &&
     loginAuthProviders.map(({ provider }) => provider).includes('firebase');
   const firebaseProvider = loginAuthProviders.find((p) => p.provider === 'firebase');
+  const githubProvider = loginAuthProviders.find((p) => p.provider === 'github');
   const orcidProvider = loginAuthProviders.find((p) => p.provider === 'orcid');
   const googleProvider = loginAuthProviders.find((p) => p.provider === 'google');
   const oktaProvider = loginAuthProviders.find((p) => p.provider === 'okta');
@@ -71,6 +72,9 @@ function AllProviderLoginArea({
         )}
         {googleProvider && googleProvider.allowLogin && (
           <google.LoginUI disabled={submitting} setSubmitting={setSubmitting} className="w-full" />
+        )}
+        {githubProvider && githubProvider.allowLogin && (
+          <github.LoginUI disabled={submitting} setSubmitting={setSubmitting} className="w-full" />
         )}
         {oktaProvider && oktaProvider.allowLogin && (
           <okta.LoginUI disabled={submitting} setSubmitting={setSubmitting} className="w-full" />

--- a/platform/scms/app/routes/_auth/utils.tsx
+++ b/platform/scms/app/routes/_auth/utils.tsx
@@ -1,4 +1,4 @@
-import { firebase, google, okta, orcid } from '@curvenote/scms-core';
+import { firebase, github, google, okta, orcid } from '@curvenote/scms-core';
 
 export function getProviderUI({
   provider,
@@ -10,6 +10,10 @@ export function getProviderUI({
   setSubmitting: (submitting: boolean) => void;
 }) {
   switch (provider) {
+    case 'github':
+      return (
+        <github.LoginUI disabled={submitting} setSubmitting={setSubmitting} className="w-full" />
+      );
     case 'google':
       return (
         <google.LoginUI disabled={submitting} setSubmitting={setSubmitting} className="w-full" />

--- a/platform/scms/app/routes/new-account/LinkProviders.tsx
+++ b/platform/scms/app/routes/new-account/LinkProviders.tsx
@@ -1,7 +1,7 @@
 import { useFetcher, useLoaderData } from 'react-router';
 import type { ActionResponse, LoaderData } from './types';
 import { TaskListStep } from './TaskListStep';
-import { ui, useDeploymentConfig, google, okta, orcid, cn } from '@curvenote/scms-core';
+import { ui, useDeploymentConfig, github, google, okta, orcid, cn } from '@curvenote/scms-core';
 import { useEffect, useState } from 'react';
 import type { LinkProvidersStepData, UserData } from '@curvenote/scms-core';
 import type { AlternativePrompt } from '@/types/app-config';
@@ -78,7 +78,7 @@ export function LinkProvidersStep({
 
   let providersToShow = providers
     .filter((p) =>
-      linkableAuthProviderNames.includes(p as 'firebase' | 'google' | 'okta' | 'orcid'),
+      linkableAuthProviderNames.includes(p as 'firebase' | 'github' | 'google' | 'okta' | 'orcid'),
     )
     .filter((provider) => provider !== user.primaryProvider);
 
@@ -199,6 +199,23 @@ export function LinkProvidersStep({
                     <LinkAccountDuringSignupButton
                       provider={provider}
                       badge={<orcid.Badge />}
+                      disabled={submitting || skipped}
+                      submitting={submitting}
+                      setSubmitting={setSubmitting}
+                      className={cn('w-full', { 'pointer-not-allowed': skipped })}
+                    />
+                  )}
+                  {provider === 'github' && linkedProviderNames.includes('github') && (
+                    <div className="flex items-center w-full gap-2">
+                      <CheckCircle className="w-5 h-5 stroke-green-700 fill-green-50" />
+                      <github.Badge />
+                      <div className="pb-[2px] opacity-50">successfully linked</div>
+                    </div>
+                  )}
+                  {provider === 'github' && !linkedProviderNames.includes('github') && (
+                    <LinkAccountDuringSignupButton
+                      provider={provider}
+                      badge={<github.Badge />}
                       disabled={submitting || skipped}
                       submitting={submitting}
                       setSubmitting={setSubmitting}

--- a/platform/scms/app/routes/new-account/actionHelpers.server.ts
+++ b/platform/scms/app/routes/new-account/actionHelpers.server.ts
@@ -15,6 +15,7 @@ import type {
   UserData,
   GeneralError,
   orcid,
+  github,
   AuthProvider,
 } from '@curvenote/scms-core';
 import { TrackEvent } from '@curvenote/scms-core';
@@ -511,7 +512,11 @@ async function enrichUserObject(
   // Only proceed if user is missing data and we have a valid provider to extract data from
   const prisma = await getPrismaClient();
   if (userIsMissingData) {
-    if (currentProviderBeingLinked === 'orcid' || currentProviderBeingLinked === 'okta') {
+    if (
+      currentProviderBeingLinked === 'orcid' ||
+      currentProviderBeingLinked === 'okta' ||
+      currentProviderBeingLinked === 'github'
+    ) {
       // Initialize object to hold data extracted from the authentication provider
       let providerData: { email?: string; display_name?: string; username?: string } = {};
 
@@ -542,6 +547,22 @@ async function enrichUserObject(
             email: oktaAccount.email ?? undefined,
             display_name: oktaProfile?.name,
             username: oktaProfile?.preferred_username,
+          };
+        }
+      }
+
+      // Extract data from GitHub provider
+      if (currentProviderBeingLinked === 'github') {
+        const githubAccount = user.linkedAccounts?.find((account) => account.provider === 'github');
+        if (githubAccount) {
+          const githubProfile = githubAccount?.profile as unknown as github.GitHubProfile;
+          const name = githubProfile?.name ?? githubProfile?.login;
+          providerData = {
+            email: githubAccount.email ?? githubProfile?.email ?? undefined,
+            display_name: name ?? undefined,
+            username: name
+              ? name.toLowerCase().replace(/\s/g, '_') + '_' + uuidv7().substring(0, 6)
+              : undefined,
           };
         }
       }


### PR DESCRIPTION
built on the remix-oauth2 adapator

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new OAuth provider and modifies core authentication/signup flows (strategy registration, callback routing, user provisioning/linking), which can impact login reliability and account security if misconfigured. Also introduces new external API calls to GitHub for profile data and new redirect/error paths that need careful testing.
> 
> **Overview**
> **Adds GitHub as a new OAuth2 authentication provider** configurable via `auth.github` (client ID/secret/redirect URL plus `allowLogin`, `allowLinking`, `provisionNewUser`, `adminLogin`).
> 
> Implements a new server strategy (`registerGitHubStrategy`) using `remix-auth-oauth2`, including GitHub profile fetch, linked-account lookup/update, optional new-user provisioning (with an email-required guard), analytics/Slack events, and provider-cookie/session handling.
> 
> Wires GitHub into the product surfaces: core auth provider types/components, login UI (including preferred-provider rendering), signup “link providers” step UI, signup data enrichment from a linked GitHub profile, and new app routes for `/auth/github` and `/auth/github/callback`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73973983ad53abb3e9b1595cd6f78b755bd6f225. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->