### PR TITLE
👀 `build --watch` for building `_build/site`

### DIFF
--- a/.changeset/short-tides-resolve.md
+++ b/.changeset/short-tides-resolve.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/cli': minor
+'curvenote': minor
+---
+
+Added `start --watch-only` to curvenote cli

--- a/.changeset/short-tides-resolve.md
+++ b/.changeset/short-tides-resolve.md
@@ -3,4 +3,4 @@
 'curvenote': minor
 ---
 
-Added `start --watch-only` to curvenote cli
+Added `build --watch` to curvenote cli for site content as well those targets supported by `mystmd`.

--- a/packages/curvenote-cli/README.md
+++ b/packages/curvenote-cli/README.md
@@ -27,7 +27,7 @@ curvenote start
 curvenote deploy
 ```
 
-Use `curvenote start --watch-only` to build and watch for changes without starting a content or app server (useful when another process serves the built site).
+Use `curvenote build --watch` to build the site and watch for changes (useful when another process serves the built site).
 
 [![](images/cli-init.png)](https://curvenote.com/docs/web)
 

--- a/packages/curvenote-cli/README.md
+++ b/packages/curvenote-cli/README.md
@@ -27,6 +27,8 @@ curvenote start
 curvenote deploy
 ```
 
+Use `curvenote start --watch-only` to build and watch for changes without starting a content or app server (useful when another process serves the built site).
+
 [![](images/cli-init.png)](https://curvenote.com/docs/web)
 
 ## Built with Curvenote

--- a/packages/curvenote-cli/src/web/index.ts
+++ b/packages/curvenote-cli/src/web/index.ts
@@ -1,23 +1,66 @@
+import path from 'node:path';
 import type { BuildOpts } from 'myst-cli';
-import { build, startServer, buildSite, watchContent } from 'myst-cli';
+import {
+  build,
+  startServer,
+  buildSite,
+  watchContent,
+  buildHtml,
+  exportSite,
+  collectAllBuildExportOptions,
+  localArticleExport,
+  selectors,
+  writeJsonLogs,
+  readableName,
+} from 'myst-cli';
 import { addTransformersToOpts } from '../utils/utils.js';
 import type { ISession } from '../session/types.js';
 
-type StartOpts = BuildOpts & { watchOnly?: boolean };
-
 export const curvenoteBuild = async (session: ISession, files: string[], opts: BuildOpts) => {
-  await build(session, files, addTransformersToOpts(session, opts));
-};
+  const optsWithTransformers = addTransformersToOpts(session, opts);
+  const performSiteBuild =
+    opts.all ||
+    (files.length === 0 && exportSite(session, opts)) ||
+    !!opts.writeDOIBib;
 
-export const curvenoteStart = async (session: ISession, opts: StartOpts) => {
-  if (opts.watchOnly) {
-    await session.reload();
-    const optsWithTransformers = addTransformersToOpts(session, opts);
-    await buildSite(session, optsWithTransformers);
-    watchContent(session, () => {}, optsWithTransformers);
-    session.log.info('\n🤖 Watching for changes (no server started). Press Ctrl+C to stop.\n');
+  if (opts.watch && performSiteBuild) {
+    const exportOptionsList = await collectAllBuildExportOptions(
+      session,
+      files,
+      optsWithTransformers,
+    );
+    const buildLog: Record<string, unknown> = {
+      input: { files, opts, performSiteBuild },
+      exports: exportOptionsList,
+    };
+    if (exportOptionsList.length > 0) {
+      const exportLogList = exportOptionsList.map(
+        (exp) => `${path.relative('.', exp.$file)} -> ${exp.output}`,
+      );
+      session.log.info(`📬 Performing exports:\n   ${exportLogList.join('\n   ')}`);
+      await localArticleExport(session, exportOptionsList, optsWithTransformers);
+    }
+    const siteConfig = selectors.selectCurrentSiteConfig(session.store.getState());
+    if (siteConfig) {
+      session.log.info(`🌎 Building ${readableName()} site`);
+      if (opts.html) {
+        buildLog.buildHtml = true;
+        await buildHtml(session, optsWithTransformers);
+      } else {
+        buildLog.buildSite = true;
+        await buildSite(session, optsWithTransformers);
+        watchContent(session, () => {}, optsWithTransformers);
+        session.log.info('\nWatching for changes. Press Ctrl+C to stop.\n');
+      }
+    }
+    writeJsonLogs(session, 'myst.build.json', buildLog);
     return;
   }
+
+  await build(session, files, optsWithTransformers);
+};
+
+export const curvenoteStart = async (session: ISession, opts: BuildOpts) => {
   await startServer(session, addTransformersToOpts(session, opts));
 };
 

--- a/packages/curvenote-cli/src/web/index.ts
+++ b/packages/curvenote-cli/src/web/index.ts
@@ -1,13 +1,23 @@
 import type { BuildOpts } from 'myst-cli';
-import { build, startServer } from 'myst-cli';
+import { build, startServer, buildSite, watchContent } from 'myst-cli';
 import { addTransformersToOpts } from '../utils/utils.js';
 import type { ISession } from '../session/types.js';
+
+type StartOpts = BuildOpts & { watchOnly?: boolean };
 
 export const curvenoteBuild = async (session: ISession, files: string[], opts: BuildOpts) => {
   await build(session, files, addTransformersToOpts(session, opts));
 };
 
-export const curvenoteStart = async (session: ISession, opts: BuildOpts) => {
+export const curvenoteStart = async (session: ISession, opts: StartOpts) => {
+  if (opts.watchOnly) {
+    await session.reload();
+    const optsWithTransformers = addTransformersToOpts(session, opts);
+    await buildSite(session, optsWithTransformers);
+    watchContent(session, () => {}, optsWithTransformers);
+    session.log.info('\n🤖 Watching for changes (no server started). Press Ctrl+C to stop.\n');
+    return;
+  }
   await startServer(session, addTransformersToOpts(session, opts));
 };
 

--- a/packages/curvenote/src/options.ts
+++ b/packages/curvenote/src/options.ts
@@ -145,9 +145,3 @@ export function makeSkipRebuildOption() {
   );
 }
 
-export function makeWatchOnlyOption() {
-  return new Option(
-    '--watch-only',
-    'Build and watch only; do not start content or app server',
-  ).default(false);
-}

--- a/packages/curvenote/src/options.ts
+++ b/packages/curvenote/src/options.ts
@@ -144,3 +144,10 @@ export function makeSkipRebuildOption() {
     false,
   );
 }
+
+export function makeWatchOnlyOption() {
+  return new Option(
+    '--watch-only',
+    'Build and watch only; do not start content or app server',
+  ).default(false);
+}

--- a/packages/curvenote/src/web.ts
+++ b/packages/curvenote/src/web.ts
@@ -16,20 +16,17 @@ import {
   makeVenueOption,
   makeResumeOption,
   makeMaxSizeWebpOption,
-  makeWatchOnlyOption,
 } from './options.js';
 
 function makeCurvenoteStartCLI(program: Command) {
-  const command = makeStartCommand()
-    .addOption(makeWatchOnlyOption())
-    .action(
-      clirun(web.curvenoteStart, {
-        program,
-        requireSiteConfig: true,
-        keepAlive: true,
-        hideNoTokenWarning: true,
-      }),
-    );
+  const command = makeStartCommand().action(
+    clirun(web.curvenoteStart, {
+      program,
+      requireSiteConfig: true,
+      keepAlive: true,
+      hideNoTokenWarning: true,
+    }),
+  );
   return command;
 }
 

--- a/packages/curvenote/src/web.ts
+++ b/packages/curvenote/src/web.ts
@@ -16,17 +16,20 @@ import {
   makeVenueOption,
   makeResumeOption,
   makeMaxSizeWebpOption,
+  makeWatchOnlyOption,
 } from './options.js';
 
 function makeCurvenoteStartCLI(program: Command) {
-  const command = makeStartCommand().action(
-    clirun(web.curvenoteStart, {
-      program,
-      requireSiteConfig: true,
-      keepAlive: true,
-      hideNoTokenWarning: true,
-    }),
-  );
+  const command = makeStartCommand()
+    .addOption(makeWatchOnlyOption())
+    .action(
+      clirun(web.curvenoteStart, {
+        program,
+        requireSiteConfig: true,
+        keepAlive: true,
+        hideNoTokenWarning: true,
+      }),
+    );
   return command;
 }
 


### PR DESCRIPTION
Added a `--watch-only` option to `curvenote start` that allows for content rebuilds but with no servers started or template installation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the control flow of the CLI build command and introduces a long-running watch mode, which could impact build/export behavior and process lifecycle, but does not touch auth or sensitive data handling.
> 
> **Overview**
> Adds support for `curvenote build --watch` when doing a *site-level build/export*, running initial exports/site build and then watching content for incremental rebuilds instead of exiting.
> 
> `curvenoteBuild` now branches on `opts.watch` + site-build conditions to invoke `myst-cli`’s `buildSite`/`buildHtml`, perform local article exports, emit a `myst.build.json` log, and print watch status messages; README and changeset are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 762439f5db94769494d7f3f496df7d4fb4789ee4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->