### PR TITLE
🤺 add caching

### DIFF
--- a/.changeset/beige-moons-love.md
+++ b/.changeset/beige-moons-love.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms': patch
+---
+
+Add caching headers to endpoints affected by burt traffic

--- a/platform/scms/app/lib/vercel-cache.ts
+++ b/platform/scms/app/lib/vercel-cache.ts
@@ -1,0 +1,90 @@
+/**
+ * Options for building a Vercel Cache-Control header. All values are in seconds.
+ * See: https://vercel.com/docs/caching/cache-control-headers
+ */
+export type VercelCacheOptionsPublic = {
+  /** Browser cache TTL. Sent to the client. */
+  maxAge: number;
+  /** CDN cache TTL. Consumed by Vercel's edge; not forwarded to the client. */
+  sMaxAge: number;
+  /**
+   * After the response is stale, how long the CDN may serve it while revalidating in the background.
+   * Use 0 to omit. Typically less than sMaxAge.
+   * See: https://vercel.com/docs/caching/cache-control-headers#stale-while-revalidate
+   */
+  staleWhileRevalidate?: number;
+  /**
+   * How long the CDN may serve a stale response when the origin returns an error (e.g. 5xx).
+   * Use 0 to omit.
+   * See: https://vercel.com/docs/caching/cache-control-headers#stale-if-error
+   */
+  staleIfError?: number;
+};
+
+/** Use for auth-gated responses. CDN must not cache; browser may cache for the same user. */
+export type VercelCacheOptionsPrivate = {
+  private: true;
+  maxAge: number;
+};
+
+export type VercelCacheOptions = VercelCacheOptionsPublic | VercelCacheOptionsPrivate;
+
+/**
+ * Which response header to set with the cache directive value.
+ * - Cache-Control: web standard; Vercel uses it for edge cache and forwards to the client.
+ * - CDN-Cache-Control: used by Vercel and other CDNs; overrides Cache-Control for CDN behavior.
+ * - Vercel-CDN-Cache-Control: Vercel-only; highest priority for Vercel's edge.
+ *
+ * @see https://vercel.com/docs/caching/cache-control-headers#cdn-cache-control-header
+ */
+export type VercelCacheHeader = 'Cache-Control' | 'CDN-Cache-Control' | 'Vercel-CDN-Cache-Control';
+
+/**
+ * Builds a cache header object for Vercel's CDN from explicit options.
+ * Use with `Response.json(body, { headers: vercelCacheHeaders(options) })`.
+ *
+ * When options.private is true, returns Cache-Control: private, max-age=N (no CDN cache; browser may cache for N seconds).
+ * Otherwise builds a public directive from maxAge, sMaxAge, and optional stale-*.
+ *
+ * @param options - Public: maxAge, sMaxAge, and optionally staleWhileRevalidate/staleIfError (use 0 to omit). Private: { private: true, maxAge }.
+ * @param header - Which header to set. Defaults to `'Cache-Control'`.
+ *
+ * @see https://vercel.com/docs/caching/cache-control-headers
+ * @see https://vercel.com/docs/caching/cache-control-headers#stale-while-revalidate
+ */
+export function vercelCacheHeaders(
+  options: VercelCacheOptions,
+  header: VercelCacheHeader = 'Cache-Control',
+): Record<string, string> {
+  if ('private' in options && options.private === true) {
+    const { maxAge } = options;
+    return { [header]: `private, max-age=${maxAge}` };
+  }
+
+  const opts = options as VercelCacheOptionsPublic;
+  const { maxAge, sMaxAge, staleWhileRevalidate, staleIfError } = opts;
+
+  let value = `public, max-age=${maxAge}, s-maxage=${sMaxAge}`;
+  if (staleWhileRevalidate && staleWhileRevalidate > 0) {
+    value += `, stale-while-revalidate=${staleWhileRevalidate}`;
+  }
+  if (staleIfError && staleIfError > 0) {
+    value += `, stale-if-error=${staleIfError}`;
+  }
+
+  return { [header]: value };
+}
+
+/** Preset for semi-static list endpoints (e.g. site lists): short browser cache, 2 min CDN, SWR and stale-if-error. */
+export const SEMI_STATIC_BURST_PROTECTION: VercelCacheOptionsPublic = {
+  maxAge: 10,
+  sMaxAge: 60,
+  staleWhileRevalidate: 60,
+  staleIfError: 3600,
+};
+
+/** Use for auth-gated responses (e.g. private sites). Pass to vercelCacheHeaders(). */
+export const PRIVATE_CACHE_OPTIONS: VercelCacheOptionsPrivate = {
+  private: true,
+  maxAge: 60,
+};

--- a/platform/scms/app/routes/api/v1.sites.$siteName.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.tsx
@@ -9,12 +9,14 @@ import {
 } from '@curvenote/scms-server';
 import { error401, httpError, site } from '@curvenote/scms-core';
 import { z } from 'zod';
+import { SEMI_STATIC_BURST_PROTECTION, vercelCacheHeaders } from 'app/lib/vercel-cache';
 
 export async function loader(args: Route.LoaderArgs) {
   const ctx = await withInsecureSiteContext(args);
   const contentVersion = await sites.dbGetSiteContent(ctx.site);
   const dto = sites.formatSiteWithContentDTO(ctx, ctx.site, contentVersion);
-  return Response.json(dto);
+  const headers = vercelCacheHeaders(SEMI_STATIC_BURST_PROTECTION);
+  return Response.json(dto, { headers });
 }
 
 const UpdateSitePatchBodySchema = z.object({

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works.$workIdOrSlug.published.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works.$workIdOrSlug.published.tsx
@@ -1,12 +1,19 @@
 import type { Route } from './+types/v1.sites.$siteName.works.$workIdOrSlug.published';
 import { httpError } from '@curvenote/scms-core';
 import { withSecureSiteContext, sites } from '@curvenote/scms-server';
+import {
+  PRIVATE_CACHE_OPTIONS,
+  SEMI_STATIC_BURST_PROTECTION,
+  vercelCacheHeaders,
+} from 'app/lib/vercel-cache';
 
 export async function loader(args: Route.LoaderArgs) {
   const ctx = await withSecureSiteContext(args);
   const { workIdOrSlug } = args.params;
   if (!workIdOrSlug) throw httpError(400, 'Missing workId or slug');
   const dto = await sites.submissions.published.get(ctx, workIdOrSlug);
-  // redirect if not primary slug
-  return Response.json(dto);
+  const headers = vercelCacheHeaders(
+    ctx.site.private ? PRIVATE_CACHE_OPTIONS : SEMI_STATIC_BURST_PROTECTION,
+  );
+  return Response.json(dto, { headers });
 }

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works.$workIdOrSlug.social.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works.$workIdOrSlug.social.tsx
@@ -1,6 +1,7 @@
 import type { Route } from './+types/v1.sites.$siteName.works.$workIdOrSlug.social';
 import { error404, httpError } from '@curvenote/scms-core';
 import { withInsecureSiteContext, sites } from '@curvenote/scms-server';
+import { vercelCacheHeaders } from 'app/lib/vercel-cache';
 
 export async function loader(args: Route.LoaderArgs) {
   const ctx = await withInsecureSiteContext(args);
@@ -15,10 +16,15 @@ export async function loader(args: Route.LoaderArgs) {
   const social = await sites.works.social(ctx, workIdOrSlug);
   if (!social) throw error404('Social image not found');
 
+  const headers = vercelCacheHeaders({
+    maxAge: 3600,
+    sMaxAge: 86400,
+    staleIfError: 86400,
+  });
   return new Response(social, {
     headers: {
       'Content-Type': 'image/png',
-      'Cache-Control': 'max-age=86400',
+      ...headers,
     },
   });
 }

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works.$workIdOrSlug.thumbnail.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works.$workIdOrSlug.thumbnail.tsx
@@ -1,6 +1,7 @@
 import type { Route } from './+types/v1.sites.$siteName.works.$workIdOrSlug.thumbnail';
 import { error404, httpError } from '@curvenote/scms-core';
 import { withInsecureSiteContext, sortSignedUrlQuery, sites } from '@curvenote/scms-server';
+import { vercelCacheHeaders } from 'app/lib/vercel-cache';
 
 export async function loader(args: Route.LoaderArgs) {
   const ctx = await withInsecureSiteContext(args);
@@ -18,9 +19,11 @@ export async function loader(args: Route.LoaderArgs) {
   const thumbnail = await sites.works.thumbnail(ctx, workIdOrSlug, query);
   if (!thumbnail) throw error404('Thumbnail not found');
 
-  return new Response(thumbnail, {
-    headers: {
-      'Cache-Control': 'max-age=3600',
-    },
+  const headers = vercelCacheHeaders({
+    maxAge: 3600,
+    sMaxAge: 3600,
+    staleWhileRevalidate: 3600,
+    staleIfError: 86400,
   });
+  return new Response(thumbnail, { headers });
 }

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works.$workIdOrSlug.versions.$versionId.social.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works.$workIdOrSlug.versions.$versionId.social.tsx
@@ -1,6 +1,7 @@
 import type { Route } from './+types/v1.sites.$siteName.works.$workIdOrSlug.versions.$versionId.social';
 import { error404, httpError } from '@curvenote/scms-core';
 import { withInsecureSiteContext, sites } from '@curvenote/scms-server';
+import { vercelCacheHeaders } from 'app/lib/vercel-cache';
 
 export async function loader(args: Route.LoaderArgs) {
   const ctx = await withInsecureSiteContext(args);
@@ -19,10 +20,15 @@ export async function loader(args: Route.LoaderArgs) {
   // TODO - serve up a default curvenote journals thumbnail?
   if (!social) throw error404('Social image only available for published works');
 
+  const headers = vercelCacheHeaders({
+    maxAge: 3600,
+    sMaxAge: 86400,
+    staleIfError: 86400,
+  });
   return new Response(social, {
     headers: {
       'Content-Type': 'image/png',
-      'Cache-Control': 'max-age=86400',
+      ...headers,
     },
   });
 }

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works.$workIdOrSlug.versions.$versionId.thumbnail.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works.$workIdOrSlug.versions.$versionId.thumbnail.tsx
@@ -1,6 +1,7 @@
 import type { Route } from './+types/v1.sites.$siteName.works.$workIdOrSlug.versions.$versionId.thumbnail';
 import { error404, httpError } from '@curvenote/scms-core';
 import { withInsecureSiteContext, sites, sortSignedUrlQuery } from '@curvenote/scms-server';
+import { vercelCacheHeaders } from 'app/lib/vercel-cache';
 
 export async function loader(args: Route.LoaderArgs) {
   const ctx = await withInsecureSiteContext(args);
@@ -19,9 +20,13 @@ export async function loader(args: Route.LoaderArgs) {
   // this just gets the thumbnail from the version directly, workIdOrSlug is not actually used
   const thumbnail = await sites.works.versions.thumbnail(ctx, versionId, query);
   if (!thumbnail) throw error404('Thumbnail not found');
+  const headers = vercelCacheHeaders({
+    maxAge: 3600,
+    sMaxAge: 3600,
+    staleWhileRevalidate: 3600,
+    staleIfError: 86400,
+  });
   return new Response(thumbnail, {
-    headers: {
-      'Cache-Control': 'max-age=3600',
-    },
+    headers,
   });
 }

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works.tsx
@@ -2,6 +2,11 @@ import type { Route } from './+types/v1.sites.$siteName.works';
 import { z } from 'zod';
 import { validate, withSecureSiteContext, sites } from '@curvenote/scms-server';
 import { extensions } from '../../extensions/server';
+import {
+  PRIVATE_CACHE_OPTIONS,
+  SEMI_STATIC_BURST_PROTECTION,
+  vercelCacheHeaders,
+} from 'app/lib/vercel-cache';
 
 const ParamsSchema = z.object({
   collection: z.string().min(1).max(64).optional(),
@@ -17,7 +22,10 @@ export async function loader(args: Route.LoaderArgs) {
 
   // External sites do not list works, no matter the status
   if (ctx.site.external) {
-    return Response.json({ items: [], total: 0, links: {} });
+    const headers = vercelCacheHeaders(
+      ctx.site.private ? PRIVATE_CACHE_OPTIONS : SEMI_STATIC_BURST_PROTECTION,
+    );
+    return Response.json({ items: [], total: 0, links: {} }, { headers });
   }
 
   const { limit, page, ...where } = validate(ParamsSchema, {
@@ -30,5 +38,8 @@ export async function loader(args: Route.LoaderArgs) {
 
   // offset based pagination
   const dto = await sites.submissions.published.list(ctx, extensions, where, { page, limit });
-  return Response.json(dto);
+  const headers = vercelCacheHeaders(
+    ctx.site.private ? PRIVATE_CACHE_OPTIONS : SEMI_STATIC_BURST_PROTECTION,
+  );
+  return Response.json(dto, { headers });
 }

--- a/platform/scms/app/routes/api/v1.sites.tsx
+++ b/platform/scms/app/routes/api/v1.sites.tsx
@@ -1,6 +1,7 @@
 import type { Route } from './+types/v1.sites';
 import type { Prisma } from '@curvenote/scms-db';
 import { withContext, sites } from '@curvenote/scms-server';
+import { SEMI_STATIC_BURST_PROTECTION, vercelCacheHeaders } from '../../lib/vercel-cache';
 
 export async function loader(args: Route.LoaderArgs) {
   const ctx = await withContext(args);
@@ -19,12 +20,22 @@ export async function loader(args: Route.LoaderArgs) {
     };
     // Use the listing function that includes additional landing content query
     const dto = await sites.listSitesWithContent(ctx, where);
-    return Response.json(dto);
+    return Response.json(dto, {
+      headers: vercelCacheHeaders(SEMI_STATIC_BURST_PROTECTION),
+    });
   }
   where = {
     ...where,
     private: false,
   };
   const dto = await sites.list(ctx, where);
-  return Response.json(dto);
+
+  // Apply burst protection headers
+  // We are applying accros the board here but could target
+  // - user agent: 'Curvenote Journal Theme v1'
+  // - client name header: 'Curvenote Javascript Client`
+  // - others...
+  // All differently, right now all clients are treated the same.
+  const headers = vercelCacheHeaders(SEMI_STATIC_BURST_PROTECTION);
+  return Response.json(dto, { headers });
 }


### PR DESCRIPTION
Adding caching here to protect against burst traffic from themes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP caching behavior for several public API and image endpoints; misconfiguration could cause stale data or unintended caching semantics (especially around private sites), though private-site responses explicitly avoid CDN caching.
> 
> **Overview**
> Adds a shared `vercel-cache` helper to generate Vercel-friendly `Cache-Control` directives (including `s-maxage`, `stale-while-revalidate`, and `stale-if-error`) plus presets for *semi-static* and *private* responses.
> 
> Applies these caching headers across multiple high-traffic endpoints (`v1/sites`, `v1/sites/:siteName`, works list, published work fetch, thumbnails, and social images), replacing ad-hoc `max-age` headers and selecting private vs public caching based on `ctx.site.private` where applicable. Also includes a changeset bump for `@curvenote/scms`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61182d7785df5381f6f34753c0e09637b476669c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->