### PR TITLE
👮‍♂️ Increase min client version to v0.14.2

### DIFF
--- a/.changeset/fruity-bars-unite.md
+++ b/.changeset/fruity-bars-unite.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-server': patch
+---
+
+Increase min client version to v0.14.2

--- a/packages/scms-server/src/backend/minimumClient.server.ts
+++ b/packages/scms-server/src/backend/minimumClient.server.ts
@@ -6,7 +6,7 @@ const CLIENT_NAME_HEADER = `x-client-name`;
 const CLIENT_VERSION_HEADER = `x-client-version`;
 const MINIMUM_VERSION_RESPONSE_HEADER = `x-minimum-client-version`;
 const CURVENOTE_CLIENT_NAME = 'Curvenote Javascript Client';
-const CURVENOTE_CLIENT_MINIMUM_VERSION = '0.12.10';
+const CURVENOTE_CLIENT_MINIMUM_VERSION = '0.14.2';
 
 export async function throwOnMinimumCurvenoteClientVersion(ctx: Context, request: Request) {
   const clientName = request.headers.get(CLIENT_NAME_HEADER);


### PR DESCRIPTION
Due to recent changes to OAUTH flows that require different redirect behaviour in the client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version-gate change: it only tightens the minimum allowed Curvenote JS client version and will reject older clients with a 403, so impact is limited to client compatibility.
> 
> **Overview**
> **Raises the enforced minimum Curvenote JS client version** from `0.12.10` to `0.14.2` in `minimumClient.server.ts`, causing requests from older versions (identified via `x-client-name`/`x-client-version`) to receive a `403` plus the `x-minimum-client-version` header.
> 
> Adds a changeset to publish `@curvenote/scms-server` as a patch release reflecting the new minimum version requirement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7b55fc11399d4f4b79a27ed60563ac9debcd4d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->