### PR TITLE
📄 min ver in config

### DIFF
--- a/.changeset/cozy-showers-invent.md
+++ b/.changeset/cozy-showers-invent.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms': patch
+---
+
+Return min client version in v1/config

--- a/packages/scms-server/src/backend/index.ts
+++ b/packages/scms-server/src/backend/index.ts
@@ -31,3 +31,5 @@ export * from './storage/index.js';
 export * from './services/index.js';
 export * from './signup/index.js';
 export * from './uploads/index.js';
+
+export { CURVENOTE_CLIENT_MINIMUM_VERSION } from './minimumClient.server.js';

--- a/packages/scms-server/src/backend/minimumClient.server.ts
+++ b/packages/scms-server/src/backend/minimumClient.server.ts
@@ -6,7 +6,7 @@ const CLIENT_NAME_HEADER = `x-client-name`;
 const CLIENT_VERSION_HEADER = `x-client-version`;
 const MINIMUM_VERSION_RESPONSE_HEADER = `x-minimum-client-version`;
 const CURVENOTE_CLIENT_NAME = 'Curvenote Javascript Client';
-const CURVENOTE_CLIENT_MINIMUM_VERSION = '0.14.2';
+export const CURVENOTE_CLIENT_MINIMUM_VERSION = '0.14.2';
 
 export async function throwOnMinimumCurvenoteClientVersion(ctx: Context, request: Request) {
   const clientName = request.headers.get(CLIENT_NAME_HEADER);

--- a/platform/scms/app/routes/api/v1.config.tsx
+++ b/platform/scms/app/routes/api/v1.config.tsx
@@ -1,8 +1,9 @@
 import type { Route } from './+types/v1.config';
 import { error401 } from '@curvenote/scms-core';
-import { withContext } from '@curvenote/scms-server';
+import { CURVENOTE_CLIENT_MINIMUM_VERSION, withContext } from '@curvenote/scms-server';
 
 type CLIConfigData = {
+  minClientVersion: string;
   apiUrl: string;
   adminUrl: string;
   editorApiUrl: string;
@@ -24,6 +25,7 @@ export async function loader(args: Route.LoaderArgs) {
   const ctx = await withContext(args);
   if (!ctx.user) return error401();
 
+  const minClientVersion = CURVENOTE_CLIENT_MINIMUM_VERSION;
   const apiUrl = ctx.$config.api.url;
   const adminUrl = ctx.$config.app.adminUrl;
   const editorApiUrl = ctx.$config.api.editorApiUrl;
@@ -34,6 +36,7 @@ export async function loader(args: Route.LoaderArgs) {
   const deploymentCdnUrl = ctx.$config.api.knownBucketInfoMap.cdn?.cdn ?? '';
 
   const dto: CLIConfigData = {
+    minClientVersion,
     apiUrl,
     adminUrl,
     editorApiUrl,


### PR DESCRIPTION
- **return min client version in v1/config**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, additive config response change and a constant export; main impact is a new required field for consumers of `v1/config`.
> 
> **Overview**
> `v1/config` now includes a `minClientVersion` field so clients can discover the minimum supported Curvenote client version at runtime.
> 
> To support this, `CURVENOTE_CLIENT_MINIMUM_VERSION` is exported from `scms-server` (made a named export and re-exported via `backend/index.ts`) for reuse by the route loader.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c66309dc2201057a1b789bad7550090240f4e6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->