### PR TITLE
feat/better identify user

### DIFF
--- a/.changeset/happy-boats-join.md
+++ b/.changeset/happy-boats-join.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms': patch
+---
+
+Improving the package sent with the analytics.identify call to include roles and scopes. Updating the user via identify when the user's settigns are changed by the platform administrator

--- a/packages/scms-server/src/backend/context.server.ts
+++ b/packages/scms-server/src/backend/context.server.ts
@@ -44,8 +44,11 @@ import type { TemplatedResendEmail } from './services/emails/resend.server.js';
 import { $sendEmail, $sendEmailBatch, getResend } from './services/emails/resend.server.js';
 import { createUnsubscribeToken } from './sign.tokens.server.js';
 import { dbGetUnsubscribedEmail } from './loaders/unsubscribe.js';
-import { addSegmentAnalytics, AnalyticsContext } from './services/analytics/segment.server.js';
-import type { User } from '@curvenote/scms-db';
+import {
+  addSegmentAnalytics,
+  AnalyticsContext,
+  type SegmentIdentifyUser,
+} from './services/analytics/segment.server.js';
 import { getPrismaClient } from './prisma.server.js';
 
 /**
@@ -399,7 +402,7 @@ export class Context implements ContextType {
    *
    * @param user - Optional user to identify. If not provided, the current user from context will be used.
    */
-  async identifyEvent(user?: User): Promise<void> {
+  async identifyEvent(user?: SegmentIdentifyUser): Promise<void> {
     const userToIdentify = user ?? this.user;
     if (!userToIdentify) {
       console.log('identifyEvent called but no user in context');

--- a/packages/scms-server/src/backend/loaders/sites/submissions/create.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/create.server.ts
@@ -208,7 +208,7 @@ export default async function create(
   const submissionUrl = asSiteSubmissionUrl(ctx.asBaseUrl, ctx.site.name, submission.id);
   await ctx.sendSlackNotification({
     eventType: SlackEventType.SUBMISSION_VERSION_CREATED,
-    message: `New submission: ${ctx.asBaseUrl(`/app/sites/${ctx.site.name}/submissions/${submission.id}`)}`,
+    message: `New submission: ${submission.versions[0].work_version.title ?? 'Untitled'}`,
     user: ctx.user,
     metadata: {
       title: submission.versions[0].work_version.title,

--- a/packages/scms-server/src/backend/services/analytics/segment.server.ts
+++ b/packages/scms-server/src/backend/services/analytics/segment.server.ts
@@ -11,8 +11,30 @@ import type {
 } from '@segment/analytics-node';
 import { Analytics } from '@segment/analytics-node';
 import type { Segment as SegmentConfig } from '@/types/app-config.js';
-import type { User } from '@curvenote/scms-db';
 import type { AllTrackEvent } from '@curvenote/scms-core';
+
+/**
+ * Exact fields read by {@link AnalyticsContext.identifyEvent}. Callers may pass any
+ * object that structurally satisfies this (e.g. Prisma rows, `UserWithRolesDBO`, or
+ * partial updates).
+ */
+export type SegmentIdentifyUser = {
+  id: string;
+  email: string | null;
+  username: string | null;
+  display_name: string | null;
+  primaryProvider: string | null;
+  pending: boolean;
+  disabled: boolean;
+  ready_for_approval: boolean;
+  system_role: string;
+  roles?: Array<{
+    role?: {
+      name?: string | null;
+      scopes?: unknown;
+    } | null;
+  } | null> | null;
+};
 
 /**
  * Context for handling all analytics events.
@@ -36,20 +58,63 @@ export class AnalyticsContext {
    * Identify an event for a user. Only called if user is defined.
    * @param user - The user to identify.
    */
-  async identifyEvent(user: User): Promise<void> {
-    await this.segment?.identify({
-      userId: user.id,
-      traits: {
-        email: user.email,
-        name: user.display_name,
-        username: user.username,
-        primaryProvider: user.primaryProvider,
-        pending: user.pending,
-        disabled: user.disabled,
-        readyForApproval: user.ready_for_approval,
-        system_role: user.system_role,
-      },
-    });
+  async identifyEvent(user: SegmentIdentifyUser): Promise<void> {
+    try {
+      if (!user || typeof user !== 'object') {
+        console.error('identifyEvent called with invalid user shape');
+        return;
+      }
+
+      if (typeof user.id !== 'string' || user.id.length === 0) {
+        console.error('identifyEvent called with invalid/missing user.id:', {
+          userId: (user as any)?.id,
+        });
+        return;
+      }
+
+      const safeStringOrNull = (v: unknown): string | null => (typeof v === 'string' ? v : null);
+      const safeBoolean = (v: unknown): boolean => (typeof v === 'boolean' ? v : false);
+      const safeString = (v: unknown): string => (typeof v === 'string' ? v : '');
+
+      const roles = Array.isArray(user.roles) ? user.roles : [];
+
+      const roleNames: string[] = [];
+      const roleScopesSet = new Set<string>();
+
+      for (const roleEntry of roles) {
+        const role = roleEntry?.role;
+        const roleName = safeString(role?.name);
+        if (roleName) roleNames.push(roleName);
+
+        const scopes = role?.scopes;
+        if (Array.isArray(scopes)) {
+          for (const scope of scopes) {
+            if (typeof scope === 'string' && scope.length > 0) roleScopesSet.add(scope);
+          }
+        }
+      }
+
+      await this.segment?.identify({
+        userId: user.id,
+        traits: {
+          email: safeStringOrNull(user.email),
+          name: safeStringOrNull(user.display_name),
+          username: safeStringOrNull(user.username),
+          primaryProvider: safeStringOrNull(user.primaryProvider),
+          pending: safeBoolean(user.pending),
+          disabled: safeBoolean(user.disabled),
+          readyForApproval: safeBoolean(user.ready_for_approval),
+          system_role: safeString(user.system_role),
+          role_names: roleNames,
+          role_scopes: Array.from(roleScopesSet),
+        },
+      });
+    } catch (error) {
+      console.error('Analytics identifyEvent failed:', {
+        userId: (user as any)?.id,
+        error,
+      });
+    }
   }
 
   async trackEvent(

--- a/packages/scms-server/src/modules/auth/common.server.ts
+++ b/packages/scms-server/src/modules/auth/common.server.ts
@@ -51,7 +51,19 @@ export async function dbGetUserById(id: string) {
   const prisma = await getPrismaClient();
   return prisma.user.findUnique({
     where: { id },
-    include: { linkedAccounts: true },
+    include: {
+      linkedAccounts: true,
+      roles: {
+        include: {
+          role: {
+            select: {
+              name: true,
+              scopes: true,
+            },
+          },
+        },
+      },
+    },
   });
 }
 
@@ -149,6 +161,16 @@ export async function dbGetUserByLinkedAccount(provider: string, idAtProvider: s
         where: {
           provider,
           idAtProvider,
+        },
+      },
+      roles: {
+        include: {
+          role: {
+            select: {
+              name: true,
+              scopes: true,
+            },
+          },
         },
       },
     },

--- a/platform/scms/app/routes/app/platform.users/db.server.ts
+++ b/platform/scms/app/routes/app/platform.users/db.server.ts
@@ -2,7 +2,7 @@ import { getPrismaClient } from '@curvenote/scms-server';
 import { KnownResendEvents } from '@curvenote/scms-core';
 import { ActivityType } from '@curvenote/scms-db';
 import { uuidv7 as uuid } from 'uuidv7';
-import type { SecureContext } from '@curvenote/scms-server';
+import type { SecureContext, withAppPlatformAdminContext } from '@curvenote/scms-server';
 
 export type UserDTO = Awaited<ReturnType<typeof dbGetUsers>>[0];
 
@@ -56,34 +56,57 @@ export async function dbGetUsers() {
 }
 
 export async function dbGetUserByIdForAnalytics(userId: string) {
-  const prisma = await getPrismaClient();
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: {
-      id: true,
-      email: true,
-      username: true,
-      display_name: true,
-      system_role: true,
-      primaryProvider: true,
-      pending: true,
-      ready_for_approval: true,
-      disabled: true,
-      roles: {
-        include: {
-          role: {
-            select: {
-              name: true,
-              scopes: true,
+  try {
+    const prisma = await getPrismaClient();
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        email: true,
+        username: true,
+        display_name: true,
+        system_role: true,
+        primaryProvider: true,
+        pending: true,
+        ready_for_approval: true,
+        disabled: true,
+        roles: {
+          include: {
+            role: {
+              select: {
+                name: true,
+                scopes: true,
+              },
             },
           },
         },
       },
-    },
-  });
+    });
+    return user;
+  } catch (error) {
+    console.error('dbGetUserByIdForAnalytics failed:', { userId, error });
+    return null;
+  }
+}
 
-  if (!user) throw new Error('User not found');
-  return user;
+/**
+ * Best-effort analytics after a platform user mutation. Must not throw: the DB action
+ * has already succeeded; failures here should not surface as 500 or prompt retries.
+ */
+export async function runPlatformUserAnalytics(
+  ctx: Awaited<ReturnType<typeof withAppPlatformAdminContext>>,
+  userId: string,
+  run: () => Promise<void>,
+) {
+  try {
+    const updatedUser = await dbGetUserByIdForAnalytics(userId);
+    if (updatedUser) {
+      await ctx.identifyEvent(updatedUser);
+    }
+    await run();
+  } catch (error) {
+    console.error('Platform user analytics failed:', { userId, error });
+  }
 }
 
 export async function dbCountUsers() {

--- a/platform/scms/app/routes/app/platform.users/db.server.ts
+++ b/platform/scms/app/routes/app/platform.users/db.server.ts
@@ -55,6 +55,37 @@ export async function dbGetUsers() {
   });
 }
 
+export async function dbGetUserByIdForAnalytics(userId: string) {
+  const prisma = await getPrismaClient();
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      email: true,
+      username: true,
+      display_name: true,
+      system_role: true,
+      primaryProvider: true,
+      pending: true,
+      ready_for_approval: true,
+      disabled: true,
+      roles: {
+        include: {
+          role: {
+            select: {
+              name: true,
+              scopes: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!user) throw new Error('User not found');
+  return user;
+}
+
 export async function dbCountUsers() {
   const prisma = await getPrismaClient();
   return prisma.user.count({

--- a/platform/scms/app/routes/app/platform.users/route.tsx
+++ b/platform/scms/app/routes/app/platform.users/route.tsx
@@ -10,6 +10,7 @@ import {
   approveAndNotifyUser,
   dbCountUsers,
   dbGetUsers,
+  dbGetUserByIdForAnalytics,
   dbRejectUser,
   dbToggleUserDisabled,
 } from './db.server';
@@ -48,10 +49,11 @@ export async function action(args: Route.ActionArgs) {
   const formData = await args.request.formData();
 
   return withValidFormData(PlatformUserActionSchema, formData, async (payload) => {
-    console.log('payload', payload);
     switch (payload.intent) {
       case 'approve-user': {
         await approveAndNotifyUser(ctx, payload.userId);
+        const updatedUser = await dbGetUserByIdForAnalytics(payload.userId);
+        await ctx.identifyEvent(updatedUser);
         await ctx.trackEvent(TrackEvent.USER_APPROVED, {
           targetUserId: payload.userId,
         });
@@ -60,6 +62,8 @@ export async function action(args: Route.ActionArgs) {
       }
       case 'reject-user': {
         const user = await dbRejectUser(payload.userId, ctx.user.id);
+        const updatedUser = await dbGetUserByIdForAnalytics(payload.userId);
+        await ctx.identifyEvent(updatedUser);
         await ctx.trackEvent(TrackEvent.USER_REJECTED, {
           targetUserId: payload.userId,
           targetUserEmail: user?.email,
@@ -73,6 +77,8 @@ export async function action(args: Route.ActionArgs) {
           throw new Error('disabled field is required for toggle-disabled intent');
         }
         const user = await dbToggleUserDisabled(payload.userId, payload.disabled, ctx.user.id);
+        const updatedUser = await dbGetUserByIdForAnalytics(payload.userId);
+        await ctx.identifyEvent(updatedUser);
         await ctx.trackEvent(
           payload.disabled ? TrackEvent.USER_DISABLED : TrackEvent.USER_ENABLED,
           {
@@ -85,10 +91,32 @@ export async function action(args: Route.ActionArgs) {
         return { success: true, user };
       }
       case 'assign-role': {
-        return handleAssignRole(ctx, formData);
+        const result = await handleAssignRole(ctx, formData);
+        const success =
+          typeof result === 'object' &&
+          result != null &&
+          'success' in result &&
+          (result as any).success === true;
+        if (success) {
+          const updatedUser = await dbGetUserByIdForAnalytics(payload.userId);
+          await ctx.identifyEvent(updatedUser);
+          await ctx.analytics.flush();
+        }
+        return result;
       }
       case 'remove-role': {
-        return handleRemoveRole(ctx, formData);
+        const result = await handleRemoveRole(ctx, formData);
+        const success =
+          typeof result === 'object' &&
+          result != null &&
+          'success' in result &&
+          (result as any).success === true;
+        if (success) {
+          const updatedUser = await dbGetUserByIdForAnalytics(payload.userId);
+          await ctx.identifyEvent(updatedUser);
+          await ctx.analytics.flush();
+        }
+        return result;
       }
       default: {
         throw new Error('Invalid intent');

--- a/platform/scms/app/routes/app/platform.users/route.tsx
+++ b/platform/scms/app/routes/app/platform.users/route.tsx
@@ -10,9 +10,9 @@ import {
   approveAndNotifyUser,
   dbCountUsers,
   dbGetUsers,
-  dbGetUserByIdForAnalytics,
   dbRejectUser,
   dbToggleUserDisabled,
+  runPlatformUserAnalytics,
 } from './db.server';
 import { handleAssignRole, handleRemoveRole } from './actionHelpers.server';
 import { PlatformUserList } from './PlatformUserList';
@@ -52,24 +52,24 @@ export async function action(args: Route.ActionArgs) {
     switch (payload.intent) {
       case 'approve-user': {
         await approveAndNotifyUser(ctx, payload.userId);
-        const updatedUser = await dbGetUserByIdForAnalytics(payload.userId);
-        await ctx.identifyEvent(updatedUser);
-        await ctx.trackEvent(TrackEvent.USER_APPROVED, {
-          targetUserId: payload.userId,
+        await runPlatformUserAnalytics(ctx, payload.userId, async () => {
+          await ctx.trackEvent(TrackEvent.USER_APPROVED, {
+            targetUserId: payload.userId,
+          });
+          await ctx.analytics.flush();
         });
-        await ctx.analytics.flush();
         return { success: true };
       }
       case 'reject-user': {
         const user = await dbRejectUser(payload.userId, ctx.user.id);
-        const updatedUser = await dbGetUserByIdForAnalytics(payload.userId);
-        await ctx.identifyEvent(updatedUser);
-        await ctx.trackEvent(TrackEvent.USER_REJECTED, {
-          targetUserId: payload.userId,
-          targetUserEmail: user?.email,
-          targetUserDisplayName: user?.display_name,
+        await runPlatformUserAnalytics(ctx, payload.userId, async () => {
+          await ctx.trackEvent(TrackEvent.USER_REJECTED, {
+            targetUserId: payload.userId,
+            targetUserEmail: user?.email,
+            targetUserDisplayName: user?.display_name,
+          });
+          await ctx.analytics.flush();
         });
-        await ctx.analytics.flush();
         return { success: true, user };
       }
       case 'toggle-disabled': {
@@ -77,17 +77,17 @@ export async function action(args: Route.ActionArgs) {
           throw new Error('disabled field is required for toggle-disabled intent');
         }
         const user = await dbToggleUserDisabled(payload.userId, payload.disabled, ctx.user.id);
-        const updatedUser = await dbGetUserByIdForAnalytics(payload.userId);
-        await ctx.identifyEvent(updatedUser);
-        await ctx.trackEvent(
-          payload.disabled ? TrackEvent.USER_DISABLED : TrackEvent.USER_ENABLED,
-          {
-            targetUserId: payload.userId,
-            targetUserEmail: user?.email,
-            targetUserDisplayName: user?.display_name,
-          },
-        );
-        await ctx.analytics.flush();
+        await runPlatformUserAnalytics(ctx, payload.userId, async () => {
+          await ctx.trackEvent(
+            payload.disabled ? TrackEvent.USER_DISABLED : TrackEvent.USER_ENABLED,
+            {
+              targetUserId: payload.userId,
+              targetUserEmail: user?.email,
+              targetUserDisplayName: user?.display_name,
+            },
+          );
+          await ctx.analytics.flush();
+        });
         return { success: true, user };
       }
       case 'assign-role': {
@@ -98,9 +98,9 @@ export async function action(args: Route.ActionArgs) {
           'success' in result &&
           (result as any).success === true;
         if (success) {
-          const updatedUser = await dbGetUserByIdForAnalytics(payload.userId);
-          await ctx.identifyEvent(updatedUser);
-          await ctx.analytics.flush();
+          await runPlatformUserAnalytics(ctx, payload.userId, async () => {
+            await ctx.analytics.flush();
+          });
         }
         return result;
       }
@@ -112,9 +112,9 @@ export async function action(args: Route.ActionArgs) {
           'success' in result &&
           (result as any).success === true;
         if (success) {
-          const updatedUser = await dbGetUserByIdForAnalytics(payload.userId);
-          await ctx.identifyEvent(updatedUser);
-          await ctx.analytics.flush();
+          await runPlatformUserAnalytics(ctx, payload.userId, async () => {
+            await ctx.analytics.flush();
+          });
         }
         return result;
       }


### PR DESCRIPTION
- **🪪 add roles and scopes to identify package, identify on user properties change**
This is to enable better role based filtering on analytics dashboards, like removing platfomr admins. We are also sending the limit set of scopes thst are connected with the roles, as role names are database entries and subject to change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes analytics `identify` payload shape and adds extra DB reads around platform user mutations; failures are handled best-effort but could impact tracking volume and performance.
> 
> **Overview**
> **Improves Segment `identify` user traits** by adding role-derived `role_names` and `role_scopes`, plus defensive validation/error handling around malformed user objects.
> 
> Platform admin user mutations (approve/reject/enable-disable/assign-remove role) now **re-run `identify` for the target user** after changes via a best-effort helper, and auth user lookups now include roles/scopes so updated identify calls have the needed data. Separately, the Slack notification for new submissions now uses the submission title instead of a URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4c9fd147c26784f7b69057ceaa4655721b0de3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->