### PR TITLE
📱remove blocking dev on mobile nav

### DIFF
--- a/.changeset/quiet-baths-brake.md
+++ b/.changeset/quiet-baths-brake.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-core': patch
+'@curvenote/scms': patch
+---
+
+Removing block out div on mobile navigation drawer

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "curvenote",
       "hasInstallScript": true,
       "workspaces": [
         "mystmd/packages/*",
@@ -14697,6 +14698,21 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/concurrently": {
       "version": "9.2.1",
@@ -40629,6 +40645,7 @@
         "@tailwindcss/vite": "^4.1.18",
         "@vercel/react-router": "^1.2.3",
         "classnames": "^2.5.1",
+        "concat-stream": "^2.0.0",
         "date-fns": "3.6.0",
         "fuse.js": "^7.1.0",
         "isbot": "^5",
@@ -40960,6 +40977,13 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "platform/scms/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "curvenote",
+  "name": "mobile-ux",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -5686,18 +5686,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "dev": true,
@@ -9219,15 +9207,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/@rgrove/parse-xml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@rgrove/parse-xml/-/parse-xml-4.2.0.tgz",
-      "integrity": "sha512-UuBOt7BOsKVOkFXRe4Ypd/lADuNIfqJXv8GvHqtXaTYXPPKkj2nS2zPllVsrtRjcomDhIJVBnZwfmlI222WH8g==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rjsf/utils": {
       "version": "5.24.13",
       "license": "Apache-2.0",
@@ -11156,43 +11135,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/ssh2": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
-      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^18.11.18"
-      }
-    },
-    "node_modules/@types/ssh2-sftp-client": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@types/ssh2-sftp-client/-/ssh2-sftp-client-9.0.6.tgz",
-      "integrity": "sha512-4+KvXO/V77y9VjI2op2T8+RCGI/GXQAwR0q5Qkj/EJ5YSeyKszqZP6F8i3H3txYoBqjc7sgorqyvBP3+w1EHyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/ssh2": "^1.0.0"
-      }
-    },
-    "node_modules/@types/ssh2/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@types/ssh2/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/supports-color": {
       "version": "8.1.3",
       "license": "MIT"
@@ -11242,15 +11184,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/xast": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/xast/-/xast-2.0.4.tgz",
-      "integrity": "sha512-6Q6HWhHXR5EEKcxgF5YBW5XPAAtCi/GgyCWHx6wR7dZTXF5rv2B2fm0hgpSscJqaVDVm6n1DAVbsM8RSM5PlMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -12889,6 +12822,7 @@
     },
     "node_modules/asn1": {
       "version": "0.2.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
@@ -13169,6 +13103,7 @@
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
@@ -13473,15 +13408,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/buildcheck": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
-      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/builtins": {
@@ -14772,21 +14698,6 @@
       "version": "0.0.1",
       "license": "MIT"
     },
-    "node_modules/concat-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-      "engines": [
-        "node >= 6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "node_modules/concurrently": {
       "version": "9.2.1",
       "dev": true,
@@ -14982,20 +14893,6 @@
       "license": "MIT",
       "dependencies": {
         "layout-base": "^1.0.0"
-      }
-    },
-    "node_modules/cpu-features": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
-      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "buildcheck": "~0.0.6",
-        "nan": "^2.19.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/cpx": {
@@ -15518,22 +15415,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/css-selector-parser": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
-      "integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/mdevils"
-        },
-        {
-          "type": "patreon",
-          "url": "https://patreon.com/mdevils"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -26363,6 +26244,7 @@
     },
     "node_modules/nan": {
       "version": "2.25.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -28923,277 +28805,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/pmc-node-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/pmc-node-utils/-/pmc-node-utils-0.3.1.tgz",
-      "integrity": "sha512-ofCqphRccMNw32sugWWU3BMNnj7Yis3XkNRntq2+SfpQy60pji28tlhwrnxW/cZuWVpVGuHg6k241X0Lv60SQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/xast": "^2.0.4",
-        "adm-zip": "^0.5.10",
-        "chalk": "^5.3.0",
-        "commander": "^11.1.0",
-        "css-selector-parser": "^3.0.5",
-        "doi-utils": "^2.0.3",
-        "inquirer": "^9.2.23",
-        "js-yaml": "^4.1.0",
-        "myst-cli": "^1.3.1",
-        "myst-cli-utils": "^2.0.10",
-        "myst-common": "^1.5.1",
-        "myst-frontmatter": "^1.5.1",
-        "myst-to-jats": "^1.0.27",
-        "nanoid": "^5.0.9",
-        "pmc-utils": "0.3.1",
-        "tar": "^7.4.3",
-        "unist-builder": "^4.0.0",
-        "unist-util-select": "^5.1.0",
-        "unist-util-visit": "^5.0.0",
-        "uuid": "^10.0.0",
-        "vfile": "^5.0.0",
-        "which": "^4.0.0",
-        "xast-util-to-xml": "^4.0.0",
-        "zod": "^3.23.8"
-      },
-      "bin": {
-        "pmc": "dist/pmc.cjs"
-      }
-    },
-    "node_modules/pmc-node-utils/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/pmc-node-utils/node_modules/unist-builder": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-4.0.0.tgz",
-      "integrity": "sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/pmc-node-utils/node_modules/unist-util-is": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
-      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/pmc-node-utils/node_modules/unist-util-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-5.1.0.tgz",
-      "integrity": "sha512-4A5mfokSHG/rNQ4g7gSbdEs+H586xyd24sdJqF1IWamqrLHvYb+DH48fzxowyOhOfK7YSqX+XlCojAyuuyyT2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "css-selector-parser": "^3.0.0",
-        "devlop": "^1.1.0",
-        "nth-check": "^2.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/pmc-node-utils/node_modules/unist-util-visit": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
-      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/pmc-node-utils/node_modules/unist-util-visit-parents": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
-      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/pmc-node-utils/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/pmc-node-utils/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/pmc-node-utils/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/pmc-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/pmc-utils/-/pmc-utils-0.3.1.tgz",
-      "integrity": "sha512-ri9DmmEf4375ES9+xjLqdfX4Y++QzBVfXkSgsrepBmYVnoF4j8CJy/Cqt/0gcLWjWaB2Ilih7v83yJP3+Vdj3w==",
-      "license": "MIT",
-      "dependencies": {
-        "adm-zip": "^0.5.10",
-        "css-selector-parser": "^3.0.5",
-        "doi-utils": "^2.0.3",
-        "js-yaml": "^4.1.0",
-        "myst-common": "^1.5.1",
-        "myst-frontmatter": "^1.5.1",
-        "myst-to-jats": "^1.0.27",
-        "nanoid": "^5.0.9",
-        "unist-builder": "^4.0.0",
-        "unist-util-select": "^5.1.0",
-        "unist-util-visit": "^5.0.0",
-        "uuid": "^10.0.0",
-        "xast-util-from-xml": "^4.0.0",
-        "xast-util-to-xml": "^4.0.0",
-        "xml-formatter": "^3.6.3",
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/pmc-utils/node_modules/unist-builder": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-4.0.0.tgz",
-      "integrity": "sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/pmc-utils/node_modules/unist-util-is": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
-      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/pmc-utils/node_modules/unist-util-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-5.1.0.tgz",
-      "integrity": "sha512-4A5mfokSHG/rNQ4g7gSbdEs+H586xyd24sdJqF1IWamqrLHvYb+DH48fzxowyOhOfK7YSqX+XlCojAyuuyyT2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "css-selector-parser": "^3.0.0",
-        "devlop": "^1.1.0",
-        "nth-check": "^2.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/pmc-utils/node_modules/unist-util-visit": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
-      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/pmc-utils/node_modules/unist-util-visit-parents": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
-      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/pmc-utils/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/pmc-utils/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/points-on-curve": {
@@ -33182,52 +32793,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tar/node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tar/node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/teeny-request": {
       "version": "7.2.0",
       "license": "Apache-2.0",
@@ -34968,6 +34533,7 @@
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/type-check": {
@@ -37854,64 +37420,6 @@
         }
       }
     },
-    "node_modules/xast-util-from-xml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xast-util-from-xml/-/xast-util-from-xml-4.0.0.tgz",
-      "integrity": "sha512-Pwj6Bw5XARduMeTWpeEfmfgT8/Ma3oiMI4bBIRzCd7GH26A/dn3x7jDc2BHBCQxxdQniTh0MjVUYbjaj4Ljb+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@rgrove/parse-xml": "^4.1.0",
-        "@types/xast": "^2.0.0",
-        "vfile-location": "^5.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/xast-util-from-xml/node_modules/unist-util-stringify-position": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/xast-util-from-xml/node_modules/vfile-message": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
-      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/xast-util-to-xml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xast-util-to-xml/-/xast-util-to-xml-4.0.0.tgz",
-      "integrity": "sha512-r1euIWS5yZJUNpfN+ReE4m7Vld2iytaOPJtuXVuRQacRZwqRN1MAb+dv0aGLrdXOZrpGLyvUFf1Upyrb3R5qBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/xast": "^2.0.0",
-        "ccount": "^2.0.0",
-        "stringify-entities": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
       "license": "MIT",
@@ -37922,18 +37430,6 @@
     "node_modules/xml": {
       "version": "1.0.1",
       "license": "MIT"
-    },
-    "node_modules/xml-formatter": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/xml-formatter/-/xml-formatter-3.7.0.tgz",
-      "integrity": "sha512-+8qTc3zv2UcJ1v9IsSIce37Dl4MQG14Cp7tWrwmy202UaI1wqRukw5QMX1JHsV+DX64yw77EgGsj2s5wGvuMbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "xml-parser-xo": "^4.1.5"
-      },
-      "engines": {
-        "node": ">= 16"
-      }
     },
     "node_modules/xml-js": {
       "version": "1.6.11",
@@ -37950,15 +37446,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/xml-parser-xo": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/xml-parser-xo/-/xml-parser-xo-4.1.5.tgz",
-      "integrity": "sha512-TxyRxk9sTOUg3glxSIY6f0nfuqRll2OEF8TspLgh5mZkLuBgheCn3zClcDSGJ58TvNmiwyCCuat4UajPud/5Og==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/xmlchars": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mobile-ux",
+  "name": "curvenote",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "curvenote",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/scms-core/src/components/navigation/Mobile.tsx
+++ b/packages/scms-core/src/components/navigation/Mobile.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from '../ui/button.js';
-import { Menu } from 'lucide-react';
+import { Menu, X } from 'lucide-react';
 
 type MobileContextType = {
   open: boolean;
@@ -18,6 +18,26 @@ const MobileContext = React.createContext<MobileContextType>({
 export function Mobile({ children }: React.PropsWithChildren) {
   const [open, setMobileOpen] = useState(false);
 
+  useEffect(() => {
+    if (!open) return;
+    const html = document.documentElement;
+    const body = document.body;
+    const prevHtmlOverflow = html.style.overflow;
+    const prevBodyOverflow = body.style.overflow;
+    const prevHtmlOverscroll = html.style.overscrollBehavior;
+    const prevBodyOverscroll = body.style.overscrollBehavior;
+    html.style.overflow = 'hidden';
+    body.style.overflow = 'hidden';
+    html.style.overscrollBehavior = 'none';
+    body.style.overscrollBehavior = 'none';
+    return () => {
+      html.style.overflow = prevHtmlOverflow;
+      body.style.overflow = prevBodyOverflow;
+      html.style.overscrollBehavior = prevHtmlOverscroll;
+      body.style.overscrollBehavior = prevBodyOverscroll;
+    };
+  }, [open]);
+
   return (
     <MobileContext.Provider value={{ open, setMobileOpen }}>{children}</MobileContext.Provider>
   );
@@ -30,8 +50,18 @@ export function useMobile() {
 export function MobileControls() {
   const { open, setMobileOpen } = useMobile();
   return (
-    <div className="flex fixed top-2 right-2 z-30 justify-center items-center xl:hidden">
-      {!open && (
+    <div className="flex fixed top-2 left-1 z-30 justify-start items-center w-[110px] xl:hidden">
+      {open ? (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-white hover:bg-white/10 hover:text-white"
+          aria-label="Close menu"
+          onClick={() => setMobileOpen(false)}
+        >
+          <X className="stroke-[1.5px] w-12 h-12" />
+        </Button>
+      ) : (
         <Button
           variant="ghost"
           size="icon"

--- a/packages/scms-core/src/components/navigation/Mobile.tsx
+++ b/packages/scms-core/src/components/navigation/Mobile.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Button } from '../ui/button.js';
-import { Menu, X } from 'lucide-react';
+import { Menu } from 'lucide-react';
 
 type MobileContextType = {
   open: boolean;
@@ -30,22 +30,17 @@ export function useMobile() {
 export function MobileControls() {
   const { open, setMobileOpen } = useMobile();
   return (
-    <>
-      {open && (
-        <div className="absolute inset-0 z-10 xl:hidden bg-stone-50/90 dark:bg-stone-900/90" />
+    <div className="flex fixed top-2 right-2 z-30 justify-center items-center xl:hidden">
+      {!open && (
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Open menu"
+          onClick={() => setMobileOpen(true)}
+        >
+          <Menu className="stroke-[1.5px] w-12 h-12" />
+        </Button>
       )}
-      <div className="flex fixed top-2 right-2 z-30 justify-center items-center xl:hidden">
-        {!open && (
-          <Button variant="ghost" size="icon" onClick={() => setMobileOpen(!open)}>
-            <Menu className="stroke-[1.5px] w-12 h-12" />
-          </Button>
-        )}
-        {open && (
-          <Button variant="ghost" size="icon" onClick={() => setMobileOpen(!open)}>
-            <X className="stroke-[1.5px] w-12 h-12" />
-          </Button>
-        )}
-      </div>
-    </>
+    </div>
   );
 }

--- a/packages/scms-core/src/components/navigation/PrimaryNav.tsx
+++ b/packages/scms-core/src/components/navigation/PrimaryNav.tsx
@@ -8,6 +8,8 @@ import { UserMenu } from './UserMenu.js';
 import { NavHelpItem } from './NavHelpItem.js';
 import { useMyUser } from '../../providers/MyUserProvider.js';
 import type { ClientExtension } from '../../modules/extensions/types.js';
+import { Button } from '../ui/button.js';
+import { X } from 'lucide-react';
 
 function CurvenoteIconLogo({ className }: { className?: string }) {
   return (
@@ -80,7 +82,7 @@ function PrimaryNavItem({
 
 export function PrimaryNav({ extensions }: { extensions?: ClientExtension[] }) {
   const { navigation, branding } = useDeploymentConfig();
-  const { open } = useMobile();
+  const { open, setMobileOpen } = useMobile();
   const user = useMyUser();
 
   let logo = <CurvenoteIconLogo className="my-[60px]" />;
@@ -106,12 +108,26 @@ export function PrimaryNav({ extensions }: { extensions?: ClientExtension[] }) {
 
   return (
     <nav
+      onPointerDown={(event) => event.stopPropagation()}
       className={cn(
         'flex fixed z-20 flex-col items-center py-1 space-y-2 h-full text-white bg-blue-900 transition-transform duration-150 ease-in-out transform w-[110px]',
         { '-translate-x-full xl:translate-x-0': !open },
         { 'translate-x-0': open },
       )}
     >
+      {open && (
+        <div className="absolute top-2 right-2 xl:hidden">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-white hover:bg-white/10"
+            aria-label="Close menu"
+            onClick={() => setMobileOpen(false)}
+          >
+            <X className="stroke-[1.5px] w-8 h-8" />
+          </Button>
+        </div>
+      )}
       {logo}
       <div className="flex overflow-y-auto flex-col items-center pb-4 w-full scrollbar scrollbar-thin scrollbar-track-slate-700 scrollbar-thumb-slate-400 grow">
         {navigation.items.map((item) => (

--- a/packages/scms-core/src/components/navigation/PrimaryNav.tsx
+++ b/packages/scms-core/src/components/navigation/PrimaryNav.tsx
@@ -8,8 +8,6 @@ import { UserMenu } from './UserMenu.js';
 import { NavHelpItem } from './NavHelpItem.js';
 import { useMyUser } from '../../providers/MyUserProvider.js';
 import type { ClientExtension } from '../../modules/extensions/types.js';
-import { Button } from '../ui/button.js';
-import { X } from 'lucide-react';
 
 function CurvenoteIconLogo({ className }: { className?: string }) {
   return (
@@ -82,7 +80,7 @@ function PrimaryNavItem({
 
 export function PrimaryNav({ extensions }: { extensions?: ClientExtension[] }) {
   const { navigation, branding } = useDeploymentConfig();
-  const { open, setMobileOpen } = useMobile();
+  const { open } = useMobile();
   const user = useMyUser();
 
   let logo = <CurvenoteIconLogo className="my-[60px]" />;
@@ -115,19 +113,6 @@ export function PrimaryNav({ extensions }: { extensions?: ClientExtension[] }) {
         { 'translate-x-0': open },
       )}
     >
-      {open && (
-        <div className="absolute top-2 right-2 xl:hidden">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="text-white hover:bg-white/10"
-            aria-label="Close menu"
-            onClick={() => setMobileOpen(false)}
-          >
-            <X className="stroke-[1.5px] w-8 h-8" />
-          </Button>
-        </div>
-      )}
       {logo}
       <div className="flex overflow-y-auto flex-col items-center pb-4 w-full scrollbar scrollbar-thin scrollbar-track-slate-700 scrollbar-thumb-slate-400 grow">
         {navigation.items.map((item) => (

--- a/packages/scms-core/src/components/navigation/SecondaryNav.tsx
+++ b/packages/scms-core/src/components/navigation/SecondaryNav.tsx
@@ -21,12 +21,13 @@ export function SecondaryNav({
   subtitle?: string;
   extensions?: ClientExtension[];
 }) {
-  const { open } = useMobile();
+  const { open, setMobileOpen } = useMobile();
 
   const displayUrl = branding?.url?.replace(/^https?:\/\//i, '') ?? '';
 
   return (
     <aside
+      onPointerDown={(event) => event.stopPropagation()}
       className={cn(
         'fixed z-20 flex-col space-y-2 h-full duration-500 left-[110px] xl:shadow-lg bg-stone-100 xl:dark:shadow-dark-visible dark:bg-stone-800',
         'transition-transform duration-150 ease-in-out transform',
@@ -95,7 +96,12 @@ export function SecondaryNav({
                   </div>
                 </li>
               )}
-              <MenuItem menus={menus} open={open} extensions={extensions} />
+              <MenuItem
+                menus={menus}
+                open={open}
+                onMobileSidebarOpened={() => setMobileOpen(false)}
+                extensions={extensions}
+              />
             </>
           </ul>
         ))}

--- a/platform/scms/app/routes/app/route.tsx
+++ b/platform/scms/app/routes/app/route.tsx
@@ -9,6 +9,7 @@ import {
   PrimaryNav,
   cn,
   getBrandingFromMetaMatches,
+  useMobile,
 } from '@curvenote/scms-core';
 import { extensions as serverExtensions } from '../../extensions/server';
 import { extensions as clientExtensions } from '../../extensions/client';
@@ -40,23 +41,38 @@ export default function App() {
   return (
     <div data-name="app-route" className="flex relative w-full min-h-screen">
       <Mobile>
-        <MobileControls />
-        <PrimaryNav extensions={clientExtensions} />
-        <div className="flex relative flex-col flex-1 w-full">
-          <div className="fixed top-0 z-50 w-full">
-            <LoadingBar />
-          </div>
-          <div
-            data-name="app-layout"
-            className={cn(
-              'flex min-h-screen mx-auto w-[calc(100%-20px)] xl:ml-[110px] md:w-[calc(100%-40px)] lg:w-[calc(100%-110px)]',
-            )}
-          >
-            <Outlet />
-          </div>
-        </div>
+        <AppShell />
       </Mobile>
     </div>
+  );
+}
+
+function AppShell() {
+  const { open, setMobileOpen } = useMobile();
+
+  return (
+    <>
+      <MobileControls />
+      <PrimaryNav extensions={clientExtensions} />
+      <div className="flex relative flex-col flex-1 w-full">
+        <div className="fixed top-0 z-50 w-full">
+          <LoadingBar />
+        </div>
+        <div
+          data-name="app-layout"
+          onPointerDown={() => {
+            if (!open) return;
+            if (window.matchMedia('(min-width: 1280px)').matches) return;
+            setMobileOpen(false);
+          }}
+          className={cn(
+            'flex min-h-screen mx-auto w-[calc(100%-20px)] xl:ml-[110px] md:w-[calc(100%-40px)] lg:w-[calc(100%-110px)]',
+          )}
+        >
+          <Outlet />
+        </div>
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
Removes the full screen div placed by the mobile navigation components. Background content is now visible, scrollable and clicking away will close the navigation drawer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to mobile navigation behavior (scroll locking, click-away handling, event propagation) plus lockfile churn; no auth/data-path logic touched.
> 
> **Overview**
> Improves the mobile navigation drawer UX by **removing the full-screen blocking overlay**, allowing background content to remain visible and enabling *click-away to close* behavior.
> 
> Adds scroll/overscroll locking while the drawer is open, stops pointer events from bubbling from `PrimaryNav`/`SecondaryNav`, and closes the drawer when selecting a secondary menu item or when tapping the main content area on small screens.
> 
> Includes a patch changeset for `@curvenote/scms-core` and `@curvenote/scms`, and updates `package.json`/`package-lock.json` (including dependency/metadata churn such as adding `name` and `concat-stream`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85e144494e307473645b8294f46ee684152d41ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->