### PR TITLE
👮 restrict iframe and add CSP

### DIFF
--- a/.changeset/rich-carpets-flash.md
+++ b/.changeset/rich-carpets-flash.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms': patch
+---
+
+Restrict iframes and add CSP in report mode

--- a/package-lock.json
+++ b/package-lock.json
@@ -40986,7 +40986,6 @@
         "@tailwindcss/vite": "^4.1.18",
         "@vercel/react-router": "^1.2.3",
         "classnames": "^2.5.1",
-        "concat-stream": "^2.0.0",
         "date-fns": "3.6.0",
         "fuse.js": "^7.1.0",
         "isbot": "^5",
@@ -41028,7 +41027,7 @@
         "concurrently": "^9.1.2",
         "docx": "^7.8.2",
         "dotenv-cli": "^11.0.0",
-        "esbuild": "^0.15.12",
+        "esbuild": "^0.28.0",
         "eslint-config-curvenote": "^0.0.4",
         "glob": "^11.1.0",
         "madge": "^8.0.0",
@@ -41048,15 +41047,15 @@
         "npm": ">=10.0.0"
       },
       "optionalDependencies": {
-        "@esbuild/linux-x64": "^0.25.1",
+        "@esbuild/linux-x64": "^0.28.0",
         "@rollup/rollup-linux-x64-gnu": "^4.35.0",
         "@tailwindcss/oxide-linux-x64-gnu": "4.2.1"
       }
     },
     "platform/scms/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
       ],
@@ -41067,16 +41066,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "platform/scms/node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "platform/scms/node_modules/@types/react": {

--- a/packages/scms-server/src/entry.server.tsx
+++ b/packages/scms-server/src/entry.server.tsx
@@ -10,16 +10,36 @@ export const streamTimeout = 30_000; // 30 seconds
 
 const CSP_REPORT_PATH = '/app/resources/csp-report';
 const ENFORCED_CSP = `frame-ancestors 'none'`;
+const IS_PROD = process.env.NODE_ENV === 'production';
+// 'unsafe-inline' is required for React Router's inline hydration script.
+// 'unsafe-eval' is only permitted in non-production builds (Vite dev uses eval).
+// 'apis.google.com' is required by the Firebase Auth popup/gapi loader.
+const SCRIPT_SRC = IS_PROD
+  ? `script-src 'self' 'unsafe-inline' https://apis.google.com`
+  : `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://apis.google.com`;
+// Browser-initiated connections only. Server→external calls are not covered by CSP.
+// `*.googleapis.com` covers Firebase Auth (identitytoolkit / securetoken / www).
+// `apis.google.com` is used by the Firebase Auth popup.
+// Dev also needs Vite HMR over localhost WebSocket.
+const CONNECT_SRC = IS_PROD
+  ? `connect-src 'self' https://*.googleapis.com https://apis.google.com`
+  : `connect-src 'self' https://*.googleapis.com https://apis.google.com ws://localhost:* ws://127.0.0.1:*`;
+// Firebase Auth helper iframe lives at `<authDomain>/__/auth/iframe`; default auth
+// domains are `<project>.firebaseapp.com` / `<project>.web.app`. Custom auth domains
+// are not covered by this wildcard and will need to be added explicitly.
+// `apis.google.com` covers the OAuth handler iframe used during the popup flow.
+const FRAME_SRC = `frame-src https://*.firebaseapp.com https://*.web.app https://apis.google.com`;
 const REPORT_ONLY_CSP = [
   `default-src 'self'`,
   `object-src 'none'`,
   `base-uri 'self'`,
-  `script-src 'self' 'unsafe-inline' 'unsafe-eval' https:`,
-  `style-src 'self' 'unsafe-inline' https:`,
+  SCRIPT_SRC,
+  `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`,
+  // TODO: narrow `img-src` to configured CDN origins (see $config.cdn.*) instead of bare `https:`.
   `img-src 'self' data: blob: https:`,
-  `font-src 'self' data: https:`,
-  `connect-src 'self' https: wss:`,
-  `frame-src 'none'`,
+  `font-src 'self' data: https://fonts.gstatic.com`,
+  CONNECT_SRC,
+  FRAME_SRC,
   `report-uri ${CSP_REPORT_PATH}`,
   `report-to csp-endpoint`,
 ].join('; ');
@@ -29,6 +49,9 @@ function setSecurityHeaders(responseHeaders: Headers, request: Request) {
 
   responseHeaders.set('Content-Security-Policy', ENFORCED_CSP);
   responseHeaders.set('Content-Security-Policy-Report-Only', REPORT_ONLY_CSP);
+  // Modern Reporting API (Chromium 96+). Paired with the `report-to` directive above.
+  responseHeaders.set('Reporting-Endpoints', `csp-endpoint="${cspReportUrl}"`);
+  // Legacy Reporting API v0, kept for older browsers that understand `Report-To` but not `Reporting-Endpoints`.
   responseHeaders.set(
     'Report-To',
     JSON.stringify({
@@ -43,7 +66,7 @@ function setSecurityHeaders(responseHeaders: Headers, request: Request) {
   responseHeaders.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
 
   const requestUrl = new URL(request.url);
-  if (process.env.NODE_ENV === 'production' && requestUrl.protocol === 'https:') {
+  if (IS_PROD && requestUrl.protocol === 'https:') {
     responseHeaders.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
   }
 }

--- a/packages/scms-server/src/entry.server.tsx
+++ b/packages/scms-server/src/entry.server.tsx
@@ -8,6 +8,46 @@ import { renderToPipeableStream } from 'react-dom/server';
 
 export const streamTimeout = 30_000; // 30 seconds
 
+const CSP_REPORT_PATH = '/app/resources/csp-report';
+const ENFORCED_CSP = `frame-ancestors 'none'`;
+const REPORT_ONLY_CSP = [
+  `default-src 'self'`,
+  `object-src 'none'`,
+  `base-uri 'self'`,
+  `script-src 'self' 'unsafe-inline' 'unsafe-eval' https:`,
+  `style-src 'self' 'unsafe-inline' https:`,
+  `img-src 'self' data: blob: https:`,
+  `font-src 'self' data: https:`,
+  `connect-src 'self' https: wss:`,
+  `frame-src 'none'`,
+  `report-uri ${CSP_REPORT_PATH}`,
+  `report-to csp-endpoint`,
+].join('; ');
+
+function setSecurityHeaders(responseHeaders: Headers, request: Request) {
+  const cspReportUrl = new URL(CSP_REPORT_PATH, request.url).toString();
+
+  responseHeaders.set('Content-Security-Policy', ENFORCED_CSP);
+  responseHeaders.set('Content-Security-Policy-Report-Only', REPORT_ONLY_CSP);
+  responseHeaders.set(
+    'Report-To',
+    JSON.stringify({
+      group: 'csp-endpoint',
+      max_age: 60 * 60 * 24 * 30,
+      endpoints: [{ url: cspReportUrl }],
+    }),
+  );
+  responseHeaders.set('X-Frame-Options', 'DENY');
+  responseHeaders.set('X-Content-Type-Options', 'nosniff');
+  responseHeaders.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  responseHeaders.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+
+  const requestUrl = new URL(request.url);
+  if (process.env.NODE_ENV === 'production' && requestUrl.protocol === 'https:') {
+    responseHeaders.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+  }
+}
+
 export default function handleRequest(
   request: Request,
   responseStatusCode: number,
@@ -50,6 +90,7 @@ export default function handleRequest(
           const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set('Content-Type', 'text/html');
+          setSecurityHeaders(responseHeaders, request);
 
           pipe(body);
 

--- a/packages/scms-server/src/index.ts
+++ b/packages/scms-server/src/index.ts
@@ -4,6 +4,7 @@ export * from './session.server.js';
 export * from './cookies.server.js';
 export * from './theme.server.js';
 export * from './entry.server.js';
+export { default as handleRequest } from './entry.server.js';
 export * from './utils/index.js';
 export * from './utils.server.js';
 export * from './api.schemas.js';

--- a/platform/scms/app/entry.server.tsx
+++ b/platform/scms/app/entry.server.tsx
@@ -1,0 +1,4 @@
+// React Router framework mode picks up `app/entry.server.tsx` automatically.
+// We delegate to the shared handler in @curvenote/scms-server so all SCMS-based
+// apps get the same streaming + CSP/security header behaviour.
+export { handleRequest as default, streamTimeout } from '@curvenote/scms-server';

--- a/platform/scms/app/routes.ts
+++ b/platform/scms/app/routes.ts
@@ -125,6 +125,7 @@ export default [
       route('design', 'routes/app/system.design/route.tsx'),
       route('users', 'routes/app/system.users/route.tsx'),
       route('analytics-dashboards', 'routes/app/system.analytics-dashboards/route.tsx'),
+      route('csp-reports', 'routes/app/system.csp-reports/route.tsx'),
       route('roles', 'routes/app/system.roles/route.tsx'),
     ]),
 

--- a/platform/scms/app/routes.ts
+++ b/platform/scms/app/routes.ts
@@ -33,6 +33,7 @@ function getRoutesForMountPoint(mountPoint: string): RouteConfigEntry[] {
 export default [
   // Resource Routes
   route('resources/set-theme', 'routes/resources.set-theme.tsx'),
+  route('app/resources/csp-report', 'routes/app/resources.csp-report.tsx'),
 
   // Build Routes
   route('build/:jobId', 'routes/build.$jobId.tsx'),

--- a/platform/scms/app/routes/app/resources.csp-report.tsx
+++ b/platform/scms/app/routes/app/resources.csp-report.tsx
@@ -115,8 +115,8 @@ type ExtractedReport = {
 };
 
 function extractReport(report: Record<string, unknown>, request: Request): ExtractedReport {
-  const blockedUri = asString(report['blocked-uri']) ?? asString(report.blockedUri);
-  const documentUri = asString(report['document-uri']) ?? asString(report.documentUri);
+  const blockedUri = asString(report['blocked-uri']) ?? asString(report.blockedURL);
+  const documentUri = asString(report['document-uri']) ?? asString(report.documentURL);
   const effectiveDirective =
     asString(report['effective-directive']) ?? asString(report.effectiveDirective);
   const blockedOrigin = originFromUri(blockedUri);

--- a/platform/scms/app/routes/app/resources.csp-report.tsx
+++ b/platform/scms/app/routes/app/resources.csp-report.tsx
@@ -1,0 +1,126 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
+
+const MAX_BODY_BYTES = 32 * 1024;
+const ACCEPTED_CONTENT_TYPES = new Set([
+  'application/csp-report',
+  'application/reports+json',
+  'application/json',
+]);
+
+type CspLegacyPayload = {
+  'csp-report': Record<string, unknown>;
+};
+
+type CspReportToPayload = Array<{
+  type?: unknown;
+  body?: Record<string, unknown>;
+}>;
+
+function isAcceptedContentType(contentTypeHeader: string | null) {
+  if (!contentTypeHeader) return false;
+  const contentType = contentTypeHeader.split(';')[0]?.trim().toLowerCase();
+  return ACCEPTED_CONTENT_TYPES.has(contentType);
+}
+
+function asString(value: unknown, maxLength = 512) {
+  if (typeof value !== 'string') return undefined;
+  return value.slice(0, maxLength);
+}
+
+function toPathOnlyUrl(value: unknown) {
+  if (typeof value !== 'string') return undefined;
+  try {
+    const url = new URL(value);
+    return `${url.origin}${url.pathname}`.slice(0, 1024);
+  } catch {
+    return value.slice(0, 1024);
+  }
+}
+
+function normalizeReports(payload: unknown): Record<string, unknown>[] {
+  if (!payload || typeof payload !== 'object') return [];
+  if ('csp-report' in payload && payload['csp-report'] && typeof payload['csp-report'] === 'object') {
+    return [payload['csp-report'] as Record<string, unknown>];
+  }
+  if (Array.isArray(payload)) {
+    return payload
+      .filter((entry): entry is CspReportToPayload[number] => !!entry && typeof entry === 'object')
+      .filter((entry) => entry.type === 'csp-violation' && !!entry.body && typeof entry.body === 'object')
+      .map((entry) => entry.body!);
+  }
+  return [];
+}
+
+function readContentLength(request: Request) {
+  const contentLength = Number(request.headers.get('content-length'));
+  if (!Number.isFinite(contentLength) || contentLength < 0) return undefined;
+  return contentLength;
+}
+
+function logCspReport(report: Record<string, unknown>, request: Request) {
+  const payload = {
+    event: 'csp_violation_report',
+    ts: new Date().toISOString(),
+    effectiveDirective: asString(report['effective-directive']) ?? asString(report.effectiveDirective),
+    violatedDirective: asString(report['violated-directive']) ?? asString(report.violatedDirective),
+    blockedUri: asString(report['blocked-uri']) ?? asString(report.blockedUri),
+    documentUri: toPathOnlyUrl(report['document-uri']) ?? toPathOnlyUrl(report.documentUri),
+    disposition: asString(report.disposition, 32),
+    sourceFile: asString(report['source-file']) ?? asString(report.sourceFile),
+    lineNumber: typeof report['line-number'] === 'number' ? report['line-number'] : report.lineNumber,
+    columnNumber:
+      typeof report['column-number'] === 'number' ? report['column-number'] : report.columnNumber,
+    host: new URL(request.url).host,
+    userAgent: asString(request.headers.get('user-agent'), 512),
+  };
+  console.info(JSON.stringify(payload));
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  if (request.method.toUpperCase() !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 });
+  }
+
+  const contentLength = readContentLength(request);
+  if (contentLength != null && contentLength > MAX_BODY_BYTES) {
+    return new Response(null, { status: 204 });
+  }
+
+  if (!isAcceptedContentType(request.headers.get('content-type'))) {
+    return new Response(null, { status: 204 });
+  }
+
+  let textBody: string;
+  try {
+    textBody = await request.text();
+  } catch {
+    return new Response(null, { status: 204 });
+  }
+
+  if (!textBody || textBody.length > MAX_BODY_BYTES) {
+    return new Response(null, { status: 204 });
+  }
+
+  let parsed: CspLegacyPayload | CspReportToPayload | Record<string, unknown>;
+  try {
+    parsed = JSON.parse(textBody);
+  } catch {
+    return new Response(null, { status: 204 });
+  }
+
+  const reports = normalizeReports(parsed);
+  if (reports.length === 0) return new Response(null, { status: 204 });
+
+  for (const report of reports) {
+    logCspReport(report, request);
+  }
+
+  return new Response(null, { status: 204 });
+}
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  if (request.method.toUpperCase() !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 });
+  }
+  return new Response(null, { status: 204 });
+}

--- a/platform/scms/app/routes/app/resources.csp-report.tsx
+++ b/platform/scms/app/routes/app/resources.csp-report.tsx
@@ -39,13 +39,19 @@ function toPathOnlyUrl(value: unknown) {
 
 function normalizeReports(payload: unknown): Record<string, unknown>[] {
   if (!payload || typeof payload !== 'object') return [];
-  if ('csp-report' in payload && payload['csp-report'] && typeof payload['csp-report'] === 'object') {
+  if (
+    'csp-report' in payload &&
+    payload['csp-report'] &&
+    typeof payload['csp-report'] === 'object'
+  ) {
     return [payload['csp-report'] as Record<string, unknown>];
   }
   if (Array.isArray(payload)) {
     return payload
       .filter((entry): entry is CspReportToPayload[number] => !!entry && typeof entry === 'object')
-      .filter((entry) => entry.type === 'csp-violation' && !!entry.body && typeof entry.body === 'object')
+      .filter(
+        (entry) => entry.type === 'csp-violation' && !!entry.body && typeof entry.body === 'object',
+      )
       .map((entry) => entry.body!);
   }
   return [];
@@ -61,13 +67,15 @@ function logCspReport(report: Record<string, unknown>, request: Request) {
   const payload = {
     event: 'csp_violation_report',
     ts: new Date().toISOString(),
-    effectiveDirective: asString(report['effective-directive']) ?? asString(report.effectiveDirective),
+    effectiveDirective:
+      asString(report['effective-directive']) ?? asString(report.effectiveDirective),
     violatedDirective: asString(report['violated-directive']) ?? asString(report.violatedDirective),
     blockedUri: asString(report['blocked-uri']) ?? asString(report.blockedUri),
     documentUri: toPathOnlyUrl(report['document-uri']) ?? toPathOnlyUrl(report.documentUri),
     disposition: asString(report.disposition, 32),
     sourceFile: asString(report['source-file']) ?? asString(report.sourceFile),
-    lineNumber: typeof report['line-number'] === 'number' ? report['line-number'] : report.lineNumber,
+    lineNumber:
+      typeof report['line-number'] === 'number' ? report['line-number'] : report.lineNumber,
     columnNumber:
       typeof report['column-number'] === 'number' ? report['column-number'] : report.columnNumber,
     host: new URL(request.url).host,

--- a/platform/scms/app/routes/app/resources.csp-report.tsx
+++ b/platform/scms/app/routes/app/resources.csp-report.tsx
@@ -1,4 +1,7 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
+import crypto from 'node:crypto';
+import type { ActionFunctionArgs } from 'react-router';
+import { getPrismaClient } from '@curvenote/scms-server';
+import { uuidv7 as uuid } from 'uuidv7';
 
 const MAX_BODY_BYTES = 32 * 1024;
 const ACCEPTED_CONTENT_TYPES = new Set([
@@ -27,14 +30,31 @@ function asString(value: unknown, maxLength = 512) {
   return value.slice(0, maxLength);
 }
 
-function toPathOnlyUrl(value: unknown) {
+function asInt(value: unknown): number | undefined {
+  if (typeof value !== 'number') return undefined;
+  if (!Number.isFinite(value)) return undefined;
+  return Math.trunc(value);
+}
+
+function parseUrl(value: unknown) {
   if (typeof value !== 'string') return undefined;
   try {
-    const url = new URL(value);
-    return `${url.origin}${url.pathname}`.slice(0, 1024);
+    return new URL(value);
   } catch {
-    return value.slice(0, 1024);
+    return undefined;
   }
+}
+
+function originFromUri(value: unknown) {
+  const url = parseUrl(value);
+  if (!url) return typeof value === 'string' ? value.slice(0, 256) : undefined;
+  return url.origin.slice(0, 256);
+}
+
+function pathFromUri(value: unknown) {
+  const url = parseUrl(value);
+  if (!url) return undefined;
+  return url.pathname.slice(0, 1024);
 }
 
 function normalizeReports(payload: unknown): Record<string, unknown>[] {
@@ -63,25 +83,105 @@ function readContentLength(request: Request) {
   return contentLength;
 }
 
-function logCspReport(report: Record<string, unknown>, request: Request) {
-  const payload = {
-    event: 'csp_violation_report',
-    ts: new Date().toISOString(),
-    effectiveDirective:
-      asString(report['effective-directive']) ?? asString(report.effectiveDirective),
+function buildFingerprint(parts: {
+  effectiveDirective?: string;
+  blockedOrigin?: string;
+  documentPath?: string;
+  disposition?: string;
+}) {
+  const input = [
+    parts.effectiveDirective ?? '',
+    parts.blockedOrigin ?? '',
+    parts.documentPath ?? '',
+    parts.disposition ?? '',
+  ].join('|');
+  return crypto.createHash('sha256').update(input).digest('hex');
+}
+
+type ExtractedReport = {
+  fingerprint: string;
+  effectiveDirective?: string;
+  violatedDirective?: string;
+  blockedUri?: string;
+  blockedOrigin?: string;
+  documentOrigin?: string;
+  documentPath?: string;
+  disposition?: string;
+  sourceFile?: string;
+  lineNumber?: number;
+  columnNumber?: number;
+  userAgentSample?: string;
+  latestPayload: Record<string, unknown>;
+};
+
+function extractReport(report: Record<string, unknown>, request: Request): ExtractedReport {
+  const blockedUri = asString(report['blocked-uri']) ?? asString(report.blockedUri);
+  const documentUri = asString(report['document-uri']) ?? asString(report.documentUri);
+  const effectiveDirective =
+    asString(report['effective-directive']) ?? asString(report.effectiveDirective);
+  const blockedOrigin = originFromUri(blockedUri);
+  const documentOrigin = originFromUri(documentUri);
+  const documentPath = pathFromUri(documentUri);
+  const disposition = asString(report.disposition, 32);
+  return {
+    fingerprint: buildFingerprint({
+      effectiveDirective,
+      blockedOrigin,
+      documentPath,
+      disposition,
+    }),
+    effectiveDirective,
     violatedDirective: asString(report['violated-directive']) ?? asString(report.violatedDirective),
-    blockedUri: asString(report['blocked-uri']) ?? asString(report.blockedUri),
-    documentUri: toPathOnlyUrl(report['document-uri']) ?? toPathOnlyUrl(report.documentUri),
-    disposition: asString(report.disposition, 32),
+    blockedUri: blockedUri?.slice(0, 1024),
+    blockedOrigin,
+    documentOrigin,
+    documentPath,
+    disposition,
     sourceFile: asString(report['source-file']) ?? asString(report.sourceFile),
-    lineNumber:
-      typeof report['line-number'] === 'number' ? report['line-number'] : report.lineNumber,
-    columnNumber:
-      typeof report['column-number'] === 'number' ? report['column-number'] : report.columnNumber,
-    host: new URL(request.url).host,
-    userAgent: asString(request.headers.get('user-agent'), 512),
+    lineNumber: asInt(report['line-number']) ?? asInt(report.lineNumber),
+    columnNumber: asInt(report['column-number']) ?? asInt(report.columnNumber),
+    userAgentSample: asString(request.headers.get('user-agent'), 512),
+    latestPayload: report,
   };
-  console.info(JSON.stringify(payload));
+}
+
+async function persistReport(extracted: ExtractedReport) {
+  const prisma = await getPrismaClient();
+  const now = new Date().toISOString();
+  await prisma.cspViolationReport.upsert({
+    where: { fingerprint: extracted.fingerprint },
+    create: {
+      id: uuid(),
+      fingerprint: extracted.fingerprint,
+      effective_directive: extracted.effectiveDirective,
+      violated_directive: extracted.violatedDirective,
+      blocked_uri: extracted.blockedUri,
+      blocked_origin: extracted.blockedOrigin,
+      document_origin: extracted.documentOrigin,
+      document_path: extracted.documentPath,
+      disposition: extracted.disposition,
+      source_file: extracted.sourceFile,
+      line_number: extracted.lineNumber,
+      column_number: extracted.columnNumber,
+      user_agent_sample: extracted.userAgentSample,
+      latest_payload: extracted.latestPayload as object,
+      count: 1,
+      date_first_seen: now,
+      date_last_seen: now,
+    },
+    update: {
+      count: { increment: 1 },
+      date_last_seen: now,
+      violated_directive: extracted.violatedDirective,
+      blocked_uri: extracted.blockedUri,
+      document_origin: extracted.documentOrigin,
+      source_file: extracted.sourceFile,
+      line_number: extracted.lineNumber,
+      column_number: extracted.columnNumber,
+      user_agent_sample: extracted.userAgentSample,
+      latest_payload: extracted.latestPayload as object,
+    },
+  });
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -120,15 +220,17 @@ export async function action({ request }: ActionFunctionArgs) {
   if (reports.length === 0) return new Response(null, { status: 204 });
 
   for (const report of reports) {
-    logCspReport(report, request);
+    try {
+      await persistReport(extractReport(report, request));
+    } catch (err) {
+      // Never let a misbehaving report take down the endpoint or surface DB errors to the reporter.
+      console.warn('csp_violation_report_persist_failed', err);
+    }
   }
 
   return new Response(null, { status: 204 });
 }
 
-export async function loader({ request }: LoaderFunctionArgs) {
-  if (request.method.toUpperCase() !== 'POST') {
-    return new Response('Method Not Allowed', { status: 405 });
-  }
-  return new Response(null, { status: 204 });
+export async function loader() {
+  return new Response('Method Not Allowed', { status: 405 });
 }

--- a/platform/scms/app/routes/app/system.csp-reports/db.server.ts
+++ b/platform/scms/app/routes/app/system.csp-reports/db.server.ts
@@ -1,0 +1,29 @@
+import { getPrismaClient } from '@curvenote/scms-server';
+import type { Prisma } from '@curvenote/scms-db';
+
+export type CspViolationReportDTO = Prisma.CspViolationReportGetPayload<{}>;
+
+const DEFAULT_LIMIT = 200;
+
+export async function dbGetCspViolationReports(limit = DEFAULT_LIMIT) {
+  const prisma = await getPrismaClient();
+  return prisma.cspViolationReport.findMany({
+    orderBy: { date_last_seen: 'desc' },
+    take: limit,
+  });
+}
+
+export async function dbDeleteCspViolationReport(id: string) {
+  const prisma = await getPrismaClient();
+  return prisma.cspViolationReport.delete({ where: { id } });
+}
+
+export async function dbClearCspViolationReports() {
+  const prisma = await getPrismaClient();
+  return prisma.cspViolationReport.deleteMany({});
+}
+
+export async function dbCountCspViolationReports() {
+  const prisma = await getPrismaClient();
+  return prisma.cspViolationReport.count();
+}

--- a/platform/scms/app/routes/app/system.csp-reports/db.server.ts
+++ b/platform/scms/app/routes/app/system.csp-reports/db.server.ts
@@ -1,7 +1,7 @@
 import { getPrismaClient } from '@curvenote/scms-server';
 import type { Prisma } from '@curvenote/scms-db';
 
-export type CspViolationReportDTO = Prisma.CspViolationReportGetPayload<{}>;
+export type CspViolationReportDTO = Prisma.CspViolationReportGetPayload<object>;
 
 const DEFAULT_LIMIT = 200;
 

--- a/platform/scms/app/routes/app/system.csp-reports/route.tsx
+++ b/platform/scms/app/routes/app/system.csp-reports/route.tsx
@@ -1,0 +1,205 @@
+import type { Route } from './+types/route';
+import { Form, useActionData } from 'react-router';
+import { useEffect } from 'react';
+import { withAppAdminContext, withValidFormData } from '@curvenote/scms-server';
+import { PageFrame, getBrandingFromMetaMatches, joinPageTitle, ui } from '@curvenote/scms-core';
+import { Trash2, ShieldAlert } from 'lucide-react';
+import { z } from 'zod';
+import { zfd } from 'zod-form-data';
+import {
+  dbClearCspViolationReports,
+  dbCountCspViolationReports,
+  dbDeleteCspViolationReport,
+  dbGetCspViolationReports,
+  type CspViolationReportDTO,
+} from './db.server';
+
+const FormSchema = zfd.formData({
+  intent: z.enum(['delete-one', 'clear-all']),
+  id: zfd.text(z.string().optional()),
+});
+
+export const meta: Route.MetaFunction = ({ matches }) => {
+  const branding = getBrandingFromMetaMatches(matches);
+  return [{ title: joinPageTitle('CSP Reports', 'System Administration', branding.title) }];
+};
+
+export async function loader(args: Route.LoaderArgs) {
+  await withAppAdminContext(args, { redirectTo: '/app' });
+  const [reports, total] = await Promise.all([
+    dbGetCspViolationReports(),
+    dbCountCspViolationReports(),
+  ]);
+  return { reports, total };
+}
+
+export async function action(args: Route.ActionArgs) {
+  await withAppAdminContext(args);
+  const formData = await args.request.formData();
+  return withValidFormData(FormSchema, formData, async (payload) => {
+    switch (payload.intent) {
+      case 'delete-one': {
+        if (!payload.id) throw new Error('id is required for delete-one');
+        await dbDeleteCspViolationReport(payload.id);
+        return { success: true, message: 'Report deleted' };
+      }
+      case 'clear-all': {
+        const { count } = await dbClearCspViolationReports();
+        return { success: true, message: `Cleared ${count} report${count === 1 ? '' : 's'}` };
+      }
+      default:
+        throw new Error('Invalid intent');
+    }
+  });
+}
+
+function formatDate(iso: string | null | undefined) {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+function directiveBadgeVariant(
+  directive: string | null | undefined,
+): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (!directive) return 'outline';
+  if (directive.startsWith('script-')) return 'destructive';
+  if (directive.startsWith('frame-')) return 'destructive';
+  if (directive.startsWith('style-') || directive.startsWith('font-')) return 'secondary';
+  return 'default';
+}
+
+function ReportRow({ report }: { report: CspViolationReportDTO }) {
+  return (
+    <tr className="border-b last:border-b-0">
+      <td className="py-2 pr-3 align-top whitespace-nowrap">
+        <ui.Badge variant={directiveBadgeVariant(report.effective_directive)}>
+          {report.effective_directive ?? 'unknown'}
+        </ui.Badge>
+      </td>
+      <td className="py-2 pr-3 align-top">
+        <span className="font-mono text-xs break-all">{report.blocked_origin ?? '—'}</span>
+        {report.blocked_uri && report.blocked_uri !== report.blocked_origin && (
+          <div
+            className="font-mono text-xs break-all text-muted-foreground"
+            title={report.blocked_uri}
+          >
+            {report.blocked_uri}
+          </div>
+        )}
+      </td>
+      <td className="py-2 pr-3 align-top">
+        <span className="font-mono text-xs break-all">{report.document_path ?? '—'}</span>
+      </td>
+      <td className="py-2 pr-3 tabular-nums text-right align-top">{report.count}</td>
+      <td className="py-2 pr-3 align-top whitespace-nowrap text-xs text-muted-foreground">
+        {formatDate(report.date_first_seen)}
+      </td>
+      <td className="py-2 pr-3 align-top whitespace-nowrap text-xs text-muted-foreground">
+        {formatDate(report.date_last_seen)}
+      </td>
+      <td className="py-2 align-top whitespace-nowrap">
+        <Form method="post" className="inline">
+          <input type="hidden" name="intent" value="delete-one" />
+          <input type="hidden" name="id" value={report.id} />
+          <ui.Button type="submit" variant="ghost" size="sm" className="text-destructive">
+            <Trash2 className="w-4 h-4" />
+          </ui.Button>
+        </Form>
+      </td>
+    </tr>
+  );
+}
+
+export default function CspReportsAdmin({ loaderData }: Route.ComponentProps) {
+  const { reports, total } = loaderData;
+  const actionData = useActionData<typeof action>();
+
+  useEffect(() => {
+    if (!actionData) return;
+    if ('success' in actionData && actionData.success && 'message' in actionData) {
+      ui.toastSuccess(actionData.message);
+    } else if ('error' in actionData && actionData.error) {
+      ui.toastError(actionData.error.message);
+    }
+  }, [actionData]);
+
+  return (
+    <PageFrame title="CSP Reports">
+      <div className="space-y-6">
+        <ui.Card className="p-6 bg-card">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <h2 className="flex items-center gap-2 text-lg font-semibold">
+                <ShieldAlert className="w-5 h-5" />
+                Content Security Policy violations
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Aggregated violation reports submitted by browsers to{' '}
+                <code className="font-mono text-xs">/app/resources/csp-report</code>. Rows are
+                deduplicated on <code className="font-mono text-xs">directive</code>,{' '}
+                <code className="font-mono text-xs">blocked origin</code>,{' '}
+                <code className="font-mono text-xs">document path</code>, and{' '}
+                <code className="font-mono text-xs">disposition</code>.
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Showing {reports.length} of {total}
+                {total > reports.length ? ` (top ${reports.length} by last seen)` : ''}.
+              </p>
+            </div>
+            <Form method="post">
+              <input type="hidden" name="intent" value="clear-all" />
+              <ui.Button
+                type="submit"
+                variant="outline"
+                size="sm"
+                disabled={total === 0}
+                onClick={(e) => {
+                  if (!window.confirm('Clear all CSP violation reports?')) e.preventDefault();
+                }}
+              >
+                <Trash2 className="w-4 h-4 mr-1" />
+                Clear all
+              </ui.Button>
+            </Form>
+          </div>
+        </ui.Card>
+
+        <ui.Card className="p-6 bg-card">
+          {reports.length === 0 ? (
+            <div className="py-8 text-center">
+              <p className="text-muted-foreground">No CSP violations recorded.</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Violations submitted by browsers will appear here, aggregated and counted.
+              </p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="py-2 pr-3 font-medium">Directive</th>
+                    <th className="py-2 pr-3 font-medium">Blocked origin</th>
+                    <th className="py-2 pr-3 font-medium">Document path</th>
+                    <th className="py-2 pr-3 font-medium text-right">Count</th>
+                    <th className="py-2 pr-3 font-medium">First seen</th>
+                    <th className="py-2 pr-3 font-medium">Last seen</th>
+                    <th className="py-2 font-medium" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {reports.map((report) => (
+                    <ReportRow key={report.id} report={report} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </ui.Card>
+      </div>
+    </PageFrame>
+  );
+}

--- a/platform/scms/app/routes/app/system/menu.ts
+++ b/platform/scms/app/routes/app/system/menu.ts
@@ -63,6 +63,12 @@ export function buildMenu(baseUrl: string, userScopes: string[]) {
           label: 'Analytics Dashboards',
           url: `${baseUrl}/analytics-dashboards`,
         },
+        {
+          name: 'admin.csp-reports',
+          icon: 'file-text',
+          label: 'CSP Reports',
+          url: `${baseUrl}/csp-reports`,
+        },
       ],
     },
   ];

--- a/prisma/schema/csp-report.prisma
+++ b/prisma/schema/csp-report.prisma
@@ -1,0 +1,23 @@
+model CspViolationReport {
+  id                  String  @id
+  fingerprint         String  @unique
+  effective_directive String?
+  violated_directive  String?
+  blocked_uri         String?
+  blocked_origin      String?
+  document_origin     String?
+  document_path       String?
+  disposition         String?
+  source_file         String?
+  line_number         Int?
+  column_number       Int?
+  user_agent_sample   String?
+  latest_payload      Json
+  count               Int     @default(1)
+  date_first_seen     String
+  date_last_seen      String
+
+  @@index([date_last_seen])
+  @@index([effective_directive])
+  @@index([disposition])
+}

--- a/prisma/schema/migrations/20260420120000_add_csp_violation_reports/migration.sql
+++ b/prisma/schema/migrations/20260420120000_add_csp_violation_reports/migration.sql
@@ -1,0 +1,34 @@
+-- CreateTable
+CREATE TABLE "CspViolationReport" (
+    "id" TEXT NOT NULL,
+    "fingerprint" TEXT NOT NULL,
+    "effective_directive" TEXT,
+    "violated_directive" TEXT,
+    "blocked_uri" TEXT,
+    "blocked_origin" TEXT,
+    "document_origin" TEXT,
+    "document_path" TEXT,
+    "disposition" TEXT,
+    "source_file" TEXT,
+    "line_number" INTEGER,
+    "column_number" INTEGER,
+    "user_agent_sample" TEXT,
+    "latest_payload" JSONB NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 1,
+    "date_first_seen" TEXT NOT NULL,
+    "date_last_seen" TEXT NOT NULL,
+
+    CONSTRAINT "CspViolationReport_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CspViolationReport_fingerprint_key" ON "CspViolationReport"("fingerprint");
+
+-- CreateIndex
+CREATE INDEX "CspViolationReport_date_last_seen_idx" ON "CspViolationReport"("date_last_seen");
+
+-- CreateIndex
+CREATE INDEX "CspViolationReport_effective_directive_idx" ON "CspViolationReport"("effective_directive");
+
+-- CreateIndex
+CREATE INDEX "CspViolationReport_disposition_idx" ON "CspViolationReport"("disposition");


### PR DESCRIPTION
immediately restrict loading in iframes and enable reporting accross the CSP. Report violation are available to System Admins and can be used to tighten and enforce in a second pass

<img width="2676" height="1792" alt="image" src="https://github.com/user-attachments/assets/af012125-b977-41c9-b06b-e456a2411aa5" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global response security headers and introduces CSP reporting/storage; misconfigured directives or the new DB migration/endpoint could break auth popups/asset loading or add operational load if reports spike.
> 
> **Overview**
> Adds security headers to server-rendered HTML responses, **blocking embedding via `frame-ancestors 'none'`/`X-Frame-Options: DENY`** and enabling a broad **CSP in report-only mode** with reporting configured to `/app/resources/csp-report`.
> 
> Introduces a CSP report ingestion endpoint that accepts/normalizes browser report payloads, deduplicates them via a fingerprint, and upserts aggregated counts into a new `CspViolationReport` Prisma model (with migration). Exposes a new System Admin page (`/app/system/csp-reports`) to review, delete, or clear stored reports, and wires the shared `handleRequest` into the platform app entry so all SCMS apps get the same header behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0421f77921435e810f21ece592f56afe82e91f9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->