### PR TITLE
fix main page frame layout

### DIFF
--- a/.changeset/contain-main-wrapper-width.md
+++ b/.changeset/contain-main-wrapper-width.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-core': patch
+'@curvenote/scms': patch
+---
+
+Fix page width containment regression in `MainWrapper`. Restores flex-child width clamping by adding `min-w-0`, so wide descendant content no longer overflows the main column and blows out the layout when the primary and secondary navs are shown. This preserves the previous behaviour without reintroducing `overflow-hidden`, keeping sticky/overflowing children visible.

--- a/packages/scms-core/src/components/layout/MainWrapper.tsx
+++ b/packages/scms-core/src/components/layout/MainWrapper.tsx
@@ -13,7 +13,7 @@ export function MainWrapper({
       data-name="main-wrapper"
       className={cn(
         'max-w-none',
-        'flex-1 w-full h-full hide-scrollbar',
+        'min-w-0 flex-1 w-full h-full hide-scrollbar',
         'mx-2', // mobile padding
         'pb-6', // bottom padding for status bar (24px)
         'relative', // for absolute positioning of status bar

--- a/packages/scms-core/src/components/navigation/PrimaryNav.tsx
+++ b/packages/scms-core/src/components/navigation/PrimaryNav.tsx
@@ -40,10 +40,11 @@ function PrimaryNavItem({
 }) {
   const { path, label, icon, end, beta } = item;
   const iconIsImage = icon.match(/^http[s]:\/\//) != null;
+  const normalizedPath = path.replace(/^\/+|\/+$/g, '');
 
   return (
     <NavLink
-      to={`/app/${path}`}
+      to={`/app/${normalizedPath}`}
       end={end}
       className={({ isActive }) =>
         cn(


### PR DESCRIPTION
Recent changes to prevent content truncation broke page width limits, fixing that

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes, but the nav link path normalization could affect routing if any configured `path` values intentionally include leading/trailing slashes.
> 
> **Overview**
> Fixes a layout regression where wide descendants could overflow the main column when primary/secondary navs are visible by restoring flex width clamping in `MainWrapper` via `min-w-0` (without reintroducing `overflow-hidden`).
> 
> Also normalizes `PrimaryNav` item paths (trimming leading/trailing slashes) before building the `/app/...` route to avoid malformed URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58ca718e89e826afa50fd4ecea1f567abc07e2c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->