### PR TITLE
💂‍♀️ Improvements to the work checks page

### DIFF
--- a/.changeset/brown-days-eat.md
+++ b/.changeset/brown-days-eat.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-core': patch
+'@curvenote/scms': patch
+---
+
+Improve works /check page UI and wiring to check service extensions

--- a/package-lock.json
+++ b/package-lock.json
@@ -41214,13 +41214,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "platform/scms/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "platform/scms/node_modules/vite-tsconfig-paths": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",

--- a/packages/scms-core/src/modules/extensions/ServiceLogo.tsx
+++ b/packages/scms-core/src/modules/extensions/ServiceLogo.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { cn } from '../../utils/cn.js';
+
+/**
+ * Renders the upstream service logo for a check extension.
+ *
+ * Resolution order (consumer-driven):
+ *   1. `logoUrl` — if provided and the `<img>` loads, render the image.
+ *   2. `fallback` — any React node (text, SVG icon component, etc.) otherwise.
+ *
+ * The component handles the SSR edge case where the image fails to load
+ * before React hydrates by re-checking `HTMLImageElement.complete` /
+ * `naturalWidth` on mount.
+ *
+ * Consumers compose their own fallback chain. For example, a "configured logo
+ * → configured title → hardcoded default" chain can be expressed as:
+ *
+ *   <ServiceLogo
+ *     logoUrl={manifest?.logo}
+ *     fallback={<span>{manifest?.title ?? 'My Service'}</span>}
+ *   />
+ */
+export function ServiceLogo({
+  logoUrl,
+  fallback,
+  alt,
+  className,
+}: {
+  /** Remote URL to render as an `<img>`; falls back to `fallback` when missing or failed. */
+  logoUrl?: string;
+  /** React node rendered when no logo URL is supplied or the image fails to load. */
+  fallback?: ReactNode;
+  /** Alt text for the `<img>`. Ignored when falling back. */
+  alt?: string;
+  className?: string;
+}) {
+  const imgRef = useRef<HTMLImageElement>(null);
+  const [imgFailed, setImgFailed] = useState(false);
+
+  useEffect(() => {
+    const img = imgRef.current;
+    if (img && img.complete && img.naturalWidth === 0) {
+      setImgFailed(true);
+    }
+  }, []);
+
+  if (logoUrl && !imgFailed) {
+    return (
+      <img
+        ref={imgRef}
+        src={logoUrl}
+        alt={alt ?? 'Service logo'}
+        className={className}
+        onError={() => setImgFailed(true)}
+      />
+    );
+  }
+
+  if (fallback == null) return null;
+  return <span className={cn(className, 'h-auto')}>{fallback}</span>;
+}

--- a/packages/scms-core/src/modules/extensions/index.ts
+++ b/packages/scms-core/src/modules/extensions/index.ts
@@ -1,5 +1,6 @@
 export * from './analytics.js';
 export * from './ExtensionAdminCard.js';
+export * from './ServiceLogo.js';
 export * from './checks.js';
 export * from './email-templates.js';
 export * from './icons.js';

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -151,7 +151,22 @@ export interface ExtensionCheckService {
    */
   checksActionPath?: string;
   // Client-side component to render on checks screen
-  sectionHeaderComponent: React.ComponentType<{ tag: React.ReactNode }>;
+  sectionHeaderComponent: React.ComponentType<{
+    tag: React.ReactNode;
+    /**
+     * Optional action slot (e.g. "Run on latest version" button) justified to the far right of
+     * the header. Supplied by the platform when contextually appropriate; extensions should render
+     * it in their header layout.
+     */
+    action?: React.ReactNode;
+    /**
+     * Same shape as {@link ExtensionCheckSectionActivityProps.metadata} — the `serviceData`
+     * of the run being displayed at the top card. Extensions can read run-stamped branding
+     * (e.g. a service manifest snapshot) from here without needing admin config access.
+     * `undefined` when no run exists yet for this service.
+     */
+    metadata?: any;
+  }>;
   sectionActivityComponent: React.ComponentType<ExtensionCheckSectionActivityProps>;
   /** Optional summary badge for timeline (e.g. "All clear", "2 problems", "Awaiting review"). Same metadata as sectionActivityComponent. */
   sectionSummaryBadgeComponent?: React.ComponentType<{ metadata: any }>;

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -106,11 +106,11 @@ export type ExtensionCheckSectionActivityProps = {
   /** POST target for check UI mutations (extension-owned route or legacy work checks path). */
   remoteStatusActionPath?: string;
   /**
-   * When true, this check run is the most recently modified run for its `kind` on this work version
-   * (e.g. latest Proofig run). Used for one-shot behaviours such as hydrating remote status on
-   * work details load. Omitted on routes that do not compute it (treated as false).
+   * When true, this check run's UI should be expanded/open by default on initial render.
+   * Used for one-shot behaviours such as hydrating remote status on work details load.
+   * Omitted on routes that do not compute it (treated as false).
    */
-  isLatestRunForKind?: boolean;
+  defaultExpanded?: boolean;
 };
 
 /**
@@ -127,8 +127,8 @@ export type ExtensionCheckRunTimelineMountProps = {
   metadata: unknown;
   /** POST target for check UI mutations. */
   remoteStatusActionPath: string;
-  /** See `ExtensionCheckSectionActivityProps.isLatestRunForKind`. */
-  isLatestRunForKind?: boolean;
+  /** See `ExtensionCheckSectionActivityProps.defaultExpanded`. */
+  defaultExpanded?: boolean;
 };
 
 /**

--- a/platform/scms/app/routes/app/works.$workId.checks/RunCheckOnLatestVersionButton.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/RunCheckOnLatestVersionButton.tsx
@@ -1,0 +1,41 @@
+import { useFetcher } from 'react-router';
+import { GitBranch } from 'lucide-react';
+import { ui } from '@curvenote/scms-core';
+
+type RunCheckOnLatestVersionButtonProps = {
+  /** POST target (extension checksActionPath or platform fallback). */
+  actionPath: string;
+  /** Latest non-draft work version id to run the check against. */
+  workVersionId: string;
+};
+
+/**
+ * Header action shown when a check service's latest run is from an older version.
+ * Submits `intent=execute` for the given `workVersionId`, mirroring the "Run checks now"
+ * CTA rendered inside extension activity placeholder panels.
+ */
+export function RunCheckOnLatestVersionButton({
+  actionPath,
+  workVersionId,
+}: RunCheckOnLatestVersionButtonProps) {
+  const fetcher = useFetcher();
+  const isSubmitting = fetcher.state === 'submitting';
+  return (
+    <fetcher.Form method="post" action={actionPath}>
+      <input type="hidden" name="workVersionId" value={workVersionId} />
+      <ui.StatefulButton
+        type="submit"
+        variant="default"
+        size="sm"
+        name="intent"
+        value="execute"
+        busy={isSubmitting}
+      >
+        <span className="flex gap-1 items-center">
+          <GitBranch className="w-3 h-3" aria-hidden />
+          Check Latest Version
+        </span>
+      </ui.StatefulButton>
+    </fetcher.Form>
+  );
+}

--- a/platform/scms/app/routes/app/works.$workId.checks/Tag.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/Tag.tsx
@@ -1,8 +1,18 @@
 import { GitBranch } from 'lucide-react';
 
-export function Tag({ tag }: { tag: string }) {
+export type TagVariant = 'default' | 'latest' | 'previous';
+
+const variantClassName: Record<TagVariant, string> = {
+  default: 'text-white bg-black dark:text-black dark:bg-white',
+  latest: 'text-white bg-green-600 dark:text-white dark:bg-green-600',
+  previous: 'text-white bg-gray-500 dark:text-white dark:bg-gray-500',
+};
+
+export function Tag({ tag, variant = 'default' }: { tag: string; variant?: TagVariant }) {
   return (
-    <div className="flex gap-1 items-center px-[6px] py-1 text-xs text-white bg-black dark:text-black dark:bg-white rounded-xs">
+    <div
+      className={`flex gap-1 items-center px-[6px] py-1 text-xs rounded-xs ${variantClassName[variant]}`}
+    >
       <GitBranch className="w-3 h-3" />
       {tag}
     </div>

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -124,6 +124,31 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
     { app: { extensions: extensionsConfig } } as unknown as AppConfig,
     extensions,
   );
+  const sortedCheckServices = checkServices
+    .map((service, index) => {
+      const latestRunDateCreated = [
+        ...checkServiceRuns,
+        ...(previousVersionsWithRunsByService[service.id] ?? []).map((entry) => entry.run),
+      ]
+        .filter((run) => run.kind === service.id)
+        .reduce<number | null>((latest, run) => {
+          const runTime = Date.parse(run.date_created);
+          if (Number.isNaN(runTime)) return latest;
+          if (latest == null) return runTime;
+          return Math.max(latest, runTime);
+        }, null);
+
+      return { service, index, latestRunDateCreated };
+    })
+    .sort((a, b) => {
+      if (a.latestRunDateCreated != null && b.latestRunDateCreated != null) {
+        return b.latestRunDateCreated - a.latestRunDateCreated;
+      }
+      if (a.latestRunDateCreated != null) return -1;
+      if (b.latestRunDateCreated != null) return 1;
+      return a.index - b.index;
+    })
+    .map(({ service }) => service);
 
   const tag = (
     <ui.TooltipProvider delayDuration={1000}>
@@ -142,9 +167,12 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
   const basePath = `/app/works/${work.id}`;
 
   return (
-    <PageFrame title="Check My Work">
+    <PageFrame
+      title="Checks"
+      description="View the status and results of check services that have been run on your work. The page below shows the most recent run for each available check service"
+    >
       <div className="mt-4 space-y-6">
-        {checkServices.map((service) => {
+        {sortedCheckServices.map((service) => {
           const HeaderComponent = service.sectionHeaderComponent;
           const ActivityComponent = service.sectionActivityComponent;
 

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -23,6 +23,7 @@ import {
   type CheckServiceRunRow,
 } from '../works.$workId/db.server';
 import { extensions } from '../../../extensions/client';
+import { extensions as serverExtensions } from '../../../extensions/server';
 import { Tag } from './Tag';
 import { RunCheckOnLatestVersionButton } from './RunCheckOnLatestVersionButton';
 import { Timeline } from '../works.$workId.details/timeline/Timeline';
@@ -107,12 +108,61 @@ export async function loader(args: Route.LoaderArgs) {
     previousRunsByServiceKind[kind] = rest;
   }
 
+  // -------------------------------------------------------------------------
+  // TEMPORARY (stepping-stone): service-manifest fallback for kinds with no run.
+  //
+  // Section header and activity components currently read the service manifest
+  // (logo, title, ...) from each run's `serviceData.manifest`, which is only
+  // stamped at execute time. The page renders a section for every check
+  // service configured in the deployment (not just those in
+  // `metadata.checks.enabled` for this work), so for any service without a
+  // run we still want the correct logo + CTA. We ask each server extension
+  // for its merged config and keep only the `manifest` here. The render path
+  // below synthesizes `{ manifest }` as a stand-in `serviceData`.
+  //
+  // Remove this block (and the matching `fallbackManifest` logic in the
+  // component) once the CTA rework lands and sections can render without a
+  // run-derived manifest.
+  // -------------------------------------------------------------------------
+  const extensionByCheckServiceId = new Map<string, (typeof serverExtensions)[number]>();
+  for (const ext of serverExtensions) {
+    const services = ext.getChecks?.() ?? [];
+    for (const svc of services) {
+      extensionByCheckServiceId.set(svc.id, ext);
+    }
+  }
+  // Mirror the list of services the page will render (same util the component
+  // uses). Any service id that doesn't yet have a run needs a manifest fallback.
+  const pageCheckServices = getExtensionCheckServicesFromServerConfig(
+    ctx.$config,
+    serverExtensions,
+  );
+  const kindsNeedingManifest = pageCheckServices
+    .map((s) => s.id)
+    .filter((kind) => latestRunByServiceKind[kind] == null);
+  const manifestByServiceKind: Record<string, unknown> = {};
+  for (const kind of kindsNeedingManifest) {
+    const ext = extensionByCheckServiceId.get(kind);
+    if (!ext?.getExtensionConfiguration) continue;
+    try {
+      const cfg = await ext.getExtensionConfiguration(ctx);
+      const m = (cfg as Record<string, unknown> | undefined)?.manifest;
+      if (m && typeof m === 'object') {
+        manifestByServiceKind[kind] = m;
+      }
+    } catch (err) {
+      console.warn(`[works.$workId.checks] failed to load manifest fallback for kind=${kind}`, err);
+    }
+  }
+  // ------------------------------- END TEMPORARY ---------------------------
+
   return {
     work: ctx.workDTO,
     latestNonDraftWorkVersion,
     metadata,
     latestRunByServiceKind,
     previousRunsByServiceKind,
+    manifestByServiceKind,
   };
 }
 
@@ -122,8 +172,13 @@ export const meta: Route.MetaFunction = ({ matches }) => {
 };
 
 export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
-  const { work, latestNonDraftWorkVersion, latestRunByServiceKind, previousRunsByServiceKind } =
-    loaderData;
+  const {
+    work,
+    latestNonDraftWorkVersion,
+    latestRunByServiceKind,
+    previousRunsByServiceKind,
+    manifestByServiceKind,
+  } = loaderData;
 
   const deploymentConfig = useDeploymentConfig();
   const extensionsConfig: Record<string, { checks?: boolean }> = {};
@@ -192,10 +247,18 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
           const previous = previousRunsByServiceKind[service.id] ?? [];
 
           const runData = latest?.run.data;
-          const serviceMetadata =
+          const runServiceData =
             runData != null && typeof runData === 'object' && 'serviceData' in runData
               ? (runData as { serviceData: unknown }).serviceData
               : undefined;
+          // TEMPORARY (stepping-stone): see loader block of the same name.
+          // When a kind has no run yet, fall back to a synthetic serviceData
+          // object carrying just the manifest so the header logo / CTA can
+          // render. Remove alongside the loader block once the CTA rework lands.
+          const fallbackManifest = manifestByServiceKind[service.id];
+          const serviceMetadata: unknown =
+            runServiceData ??
+            (fallbackManifest ? ({ manifest: fallbackManifest } as any) : undefined);
 
           const workVersionIdForActivity = latest?.workVersionId ?? latestNonDraftWorkVersion.id;
           const tag = latest ? renderVersionTag(latest) : null;

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -16,7 +16,6 @@ import {
   getExtensionCheckServicesFromServerConfig,
   useDeploymentConfig,
   ui,
-  formatDate,
 } from '@curvenote/scms-core';
 import { formatWorkVersionDTO } from './db.server';
 import {
@@ -25,16 +24,20 @@ import {
 } from '../works.$workId/db.server';
 import { extensions } from '../../../extensions/client';
 import { Tag } from './Tag';
+import { RunCheckOnLatestVersionButton } from './RunCheckOnLatestVersionButton';
 import { Timeline } from '../works.$workId.details/timeline/Timeline';
 import { TimelineSection } from '../works.$workId.details/timeline/TimelineSection';
 import { CheckServiceRunTimelineItem } from '../works.$workId.details/timeline/CheckServiceRunTimelineItem';
+import { DateWithPopover } from '../works.$workId.details/timeline/DateWithPopover';
 
-export type PreviousVersionWithRun = {
-  workVersionId: string;
-  date_created: string;
-  /** Version number by date_created order (v1 = oldest) */
-  versionNumber: number;
+/** A check service run paired with the version context needed for display. */
+export type ServiceRunEntry = {
   run: CheckServiceRunRow;
+  workVersionId: string;
+  /** Version number by date_created order (v1 = oldest). */
+  versionNumber: number;
+  /** ISO date for the work version (used for tooltip on the version tag). */
+  versionDateCreated: string;
 };
 
 export async function loader(args: Route.LoaderArgs) {
@@ -55,45 +58,61 @@ export async function loader(args: Route.LoaderArgs) {
     FileMetadataSection &
     ChecksMetadataSection;
 
-  const workVersionDTO = formatWorkVersionDTO(ctx, ctx.work.id, latestVersion);
+  const latestNonDraftWorkVersion = formatWorkVersionDTO(ctx, ctx.work.id, latestVersion);
 
   const nonDraftVersionIds = nonDraftVersions.map((v) => v.id);
   const runsByVersionId = await dbGetCheckServiceRunsByWorkVersionIds(nonDraftVersionIds);
-  const checkServiceRuns = runsByVersionId[latestVersion.id] ?? [];
 
+  // Version numbering: v1 = oldest (by date_created).
+  // `nonDraftVersions` is ordered desc by date_created (latest first), so the highest number is first.
   const versionNumberByWorkVersionId: Record<string, number> = {};
   nonDraftVersions.forEach((v, i) => {
     versionNumberByWorkVersionId[v.id] = nonDraftVersions.length - i;
   });
 
-  const previousVersions = nonDraftVersions.slice(1);
-  const previousVersionsWithRunsByService: Record<string, PreviousVersionWithRun[]> = {};
-  for (const version of previousVersions) {
+  // Build per-kind entries: for each version (newest → oldest) dedupe to that version's latest run
+  // of that kind, then sort each kind's list desc by run.date_created.
+  const entriesByKind: Record<string, ServiceRunEntry[]> = {};
+  for (const version of nonDraftVersions) {
     const runs = runsByVersionId[version.id] ?? [];
     const seenKind = new Set<string>();
     for (const run of runs) {
       if (seenKind.has(run.kind)) continue;
       seenKind.add(run.kind);
-      const list = previousVersionsWithRunsByService[run.kind] ?? [];
+      const list = entriesByKind[run.kind] ?? [];
       list.push({
-        workVersionId: version.id,
-        date_created: version.date_created,
-        versionNumber: versionNumberByWorkVersionId[version.id] ?? 0,
         run,
+        workVersionId: version.id,
+        versionNumber: versionNumberByWorkVersionId[version.id] ?? 0,
+        versionDateCreated: version.date_created,
       });
-      previousVersionsWithRunsByService[run.kind] = list;
+      entriesByKind[run.kind] = list;
     }
   }
+  for (const kind of Object.keys(entriesByKind)) {
+    entriesByKind[kind].sort((a, b) =>
+      a.run.date_created > b.run.date_created
+        ? -1
+        : a.run.date_created < b.run.date_created
+          ? 1
+          : 0,
+    );
+  }
 
-  const latestVersionNumber = versionNumberByWorkVersionId[latestVersion.id] ?? 0;
+  const latestRunByServiceKind: Record<string, ServiceRunEntry> = {};
+  const previousRunsByServiceKind: Record<string, ServiceRunEntry[]> = {};
+  for (const [kind, list] of Object.entries(entriesByKind)) {
+    const [head, ...rest] = list;
+    latestRunByServiceKind[kind] = head;
+    previousRunsByServiceKind[kind] = rest;
+  }
 
   return {
     work: ctx.workDTO,
-    workVersion: workVersionDTO,
+    latestNonDraftWorkVersion,
     metadata,
-    checkServiceRuns,
-    previousVersionsWithRunsByService,
-    latestVersionNumber,
+    latestRunByServiceKind,
+    previousRunsByServiceKind,
   };
 }
 
@@ -103,13 +122,8 @@ export const meta: Route.MetaFunction = ({ matches }) => {
 };
 
 export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
-  const {
-    work,
-    workVersion,
-    checkServiceRuns,
-    previousVersionsWithRunsByService,
-    latestVersionNumber,
-  } = loaderData;
+  const { work, latestNonDraftWorkVersion, latestRunByServiceKind, previousRunsByServiceKind } =
+    loaderData;
 
   const deploymentConfig = useDeploymentConfig();
   const extensionsConfig: Record<string, { checks?: boolean }> = {};
@@ -124,25 +138,22 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
     { app: { extensions: extensionsConfig } } as unknown as AppConfig,
     extensions,
   );
-  const sortedCheckServices = checkServices
-    .map((service, index) => {
-      const latestRunDateCreated = [
-        ...checkServiceRuns,
-        ...(previousVersionsWithRunsByService[service.id] ?? []).map((entry) => entry.run),
-      ]
-        .filter((run) => run.kind === service.id)
-        .reduce<number | null>((latest, run) => {
-          const runTime = Date.parse(run.date_created);
-          if (Number.isNaN(runTime)) return latest;
-          if (latest == null) return runTime;
-          return Math.max(latest, runTime);
-        }, null);
 
-      return { service, index, latestRunDateCreated };
-    })
+  // Order services: those with any run first (desc by latest run date_created),
+  // then services with no runs in original config order.
+  const sortedCheckServices = checkServices
+    .map((service, index) => ({
+      service,
+      index,
+      latestRunDateCreated: latestRunByServiceKind[service.id]?.run.date_created ?? null,
+    }))
     .sort((a, b) => {
       if (a.latestRunDateCreated != null && b.latestRunDateCreated != null) {
-        return b.latestRunDateCreated - a.latestRunDateCreated;
+        return a.latestRunDateCreated > b.latestRunDateCreated
+          ? -1
+          : a.latestRunDateCreated < b.latestRunDateCreated
+            ? 1
+            : 0;
       }
       if (a.latestRunDateCreated != null) return -1;
       if (b.latestRunDateCreated != null) return 1;
@@ -150,47 +161,57 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
     })
     .map(({ service }) => service);
 
-  const tag = (
-    <ui.TooltipProvider delayDuration={1000}>
-      <ui.Tooltip delayDuration={1000}>
-        <ui.TooltipTrigger asChild>
-          <span className="inline-block cursor-default">
-            <Tag tag={`v${latestVersionNumber}`} />
-          </span>
-        </ui.TooltipTrigger>
-        <ui.TooltipContent side="top" className="text-sm">
-          {formatDate(workVersion.date_created, 'MMM d, yyyy h:mm:ss a')}
-        </ui.TooltipContent>
-      </ui.Tooltip>
-    </ui.TooltipProvider>
-  );
   const basePath = `/app/works/${work.id}`;
+
+  const renderVersionTag = (entry: ServiceRunEntry) => {
+    const variant = entry.workVersionId === latestNonDraftWorkVersion.id ? 'latest' : 'previous';
+    return (
+      <span className="inline-flex gap-2 items-center">
+        <Tag tag={`v${entry.versionNumber}`} variant={variant} />
+        <DateWithPopover
+          date={entry.run.date_modified}
+          dateCreated={entry.run.date_created}
+          dateModified={entry.run.date_modified}
+          className="text-xs text-muted-foreground"
+        />
+      </span>
+    );
+  };
 
   return (
     <PageFrame
       title="Checks"
-      description="View the status and results of check services that have been run on your work. The page below shows the most recent run for each available check service"
+      description="Results of all check services run on the work are shown below. Each type of check is shown in a separate section and the most recent run is shown at the top. Where checks have been run on mulitple versions use the timeline to explore the history."
     >
-      <div className="mt-4 space-y-6">
+      <div className="mt-4 space-y-12">
         {sortedCheckServices.map((service) => {
           const HeaderComponent = service.sectionHeaderComponent;
           const ActivityComponent = service.sectionActivityComponent;
 
-          const existingRunFromThisService = checkServiceRuns.find(
-            (run) => run.kind === service.id,
-          );
-          const runData = existingRunFromThisService?.data;
+          const latest = latestRunByServiceKind[service.id];
+          const previous = previousRunsByServiceKind[service.id] ?? [];
+
+          const runData = latest?.run.data;
           const serviceMetadata =
             runData != null && typeof runData === 'object' && 'serviceData' in runData
               ? (runData as { serviceData: unknown }).serviceData
               : undefined;
 
-          const previousEntries = previousVersionsWithRunsByService[service.id] ?? [];
-          const showTimeline = previousEntries.length >= 1;
+          const workVersionIdForActivity = latest?.workVersionId ?? latestNonDraftWorkVersion.id;
+          const tag = latest ? renderVersionTag(latest) : null;
+          const isLatestRunOnLatestVersion =
+            latest != null && latest.workVersionId === latestNonDraftWorkVersion.id;
+          const headerAction =
+            latest != null && !isLatestRunOnLatestVersion ? (
+              <RunCheckOnLatestVersionButton
+                actionPath={service.checksActionPath ?? `${basePath}/checks`}
+                workVersionId={latestNonDraftWorkVersion.id}
+              />
+            ) : null;
 
           return (
             <div key={service.id} className="space-y-4">
-              <HeaderComponent tag={tag} />
+              <HeaderComponent tag={tag} action={headerAction} metadata={serviceMetadata} />
               <div className="space-y-0">
                 <ui.Card>
                   <ui.CardContent className="pt-6">
@@ -200,29 +221,18 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
                           FileMetadataSection &
                           ChecksMetadataSection
                       }
-                      workVersionId={workVersion.id}
-                      checkRunId={existingRunFromThisService?.id}
+                      workVersionId={workVersionIdForActivity}
+                      checkRunId={latest?.run.id}
                       remoteStatusActionPath={service.checksActionPath ?? `${basePath}/checks`}
                     />
                   </ui.CardContent>
                 </ui.Card>
-                {showTimeline && (
+                {previous.length > 0 && (
                   <Timeline className="ml-3" nested>
-                    {previousEntries.map((entry) => (
+                    {previous.map((entry) => (
                       <TimelineSection
                         key={entry.workVersionId}
-                        label={
-                          <ui.TooltipProvider delayDuration={1000}>
-                            <ui.Tooltip delayDuration={1000}>
-                              <ui.TooltipTrigger asChild>
-                                <span className="cursor-default">v{entry.versionNumber}</span>
-                              </ui.TooltipTrigger>
-                              <ui.TooltipContent side="top" className="text-sm">
-                                {formatDate(entry.date_created, 'MMM d, yyyy h:mm:ss a')}
-                              </ui.TooltipContent>
-                            </ui.Tooltip>
-                          </ui.TooltipProvider>
-                        }
+                        label={renderVersionTag(entry)}
                         nested
                       >
                         <CheckServiceRunTimelineItem

--- a/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
@@ -46,14 +46,32 @@ type TimelineEntry =
       version: WorkVersionWithSubmissionVersions;
     };
 
-/** Latest run id for a given check `kind` on this work version (by `date_modified`). */
-function getLatestCheckRunIdForKind(runs: CheckServiceRunRow[], kind: string): string | undefined {
-  let best: CheckServiceRunRow | undefined;
-  for (const r of runs) {
-    if (r.kind !== kind) continue;
-    if (!best || r.date_modified > best.date_modified) best = r;
+/** Latest run id for each check `kind` across all versions (by `date_created`). */
+function getLatestCheckRunIdByKind(
+  checkServiceRunsByWorkVersionId: Record<string, CheckServiceRunRow[]>,
+): Record<string, string> {
+  const latestRunByKind: Record<string, CheckServiceRunRow> = {};
+  for (const runs of Object.values(checkServiceRunsByWorkVersionId)) {
+    for (const run of runs) {
+      const currentBest = latestRunByKind[run.kind];
+      if (!currentBest || run.date_created > currentBest.date_created) {
+        latestRunByKind[run.kind] = run;
+      }
+    }
   }
-  return best?.id;
+  return Object.fromEntries(Object.entries(latestRunByKind).map(([kind, run]) => [kind, run.id]));
+}
+
+/** Single entrypoint for timeline auto-expand behavior (easy to A/B later). */
+function shouldExpandByDefault(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  run: CheckServiceRunRow,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  checkServiceRunsByWorkVersionId: Record<string, CheckServiceRunRow[]>,
+): boolean {
+  return false; // disable for now
+  // const latestRunIdByKind = getLatestCheckRunIdByKind(checkServiceRunsByWorkVersionId);
+  // return run.id === latestRunIdByKind[run.kind];
 }
 
 /** Truncate to minute resolution for sort comparison (items in same minute are tied). */
@@ -256,10 +274,10 @@ function WorkVersionTimelineInner({
                     run={entry.run}
                     checkService={service}
                     basePath={basePath}
-                    isLatestRunForKind={
-                      entry.run.id ===
-                      getLatestCheckRunIdForKind(checkRunsForVersion, entry.run.kind)
-                    }
+                    defaultExpanded={shouldExpandByDefault(
+                      entry.run,
+                      checkServiceRunsByWorkVersionId,
+                    )}
                   />
                 );
               }

--- a/platform/scms/app/routes/app/works.$workId.details/timeline/CheckServiceRunTimelineItem.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/timeline/CheckServiceRunTimelineItem.tsx
@@ -10,8 +10,8 @@ type CheckServiceRunTimelineItemProps = {
   /** When no matching extension is registered, show a generic fallback (no extension UI). */
   checkService: ClientExtensionCheckService | null;
   basePath: string;
-  /** True when this run is the latest for its `kind` on this work version (work details timeline). */
-  isLatestRunForKind?: boolean;
+  /** Controls default expanded state of this timeline row. */
+  defaultExpanded?: boolean;
 };
 
 const serviceDataFromRun = (run: CheckServiceRunRow): unknown =>
@@ -30,7 +30,7 @@ export function CheckServiceRunTimelineItem({
   run,
   checkService,
   basePath,
-  isLatestRunForKind,
+  defaultExpanded,
 }: CheckServiceRunTimelineItemProps) {
   const date = (
     <DateWithPopover
@@ -86,7 +86,7 @@ export function CheckServiceRunTimelineItem({
             checkKind={run.kind}
             metadata={serviceData}
             remoteStatusActionPath={checksActionPath}
-            isLatestRunForKind={isLatestRunForKind}
+            defaultExpanded={defaultExpanded}
           />
         ) : null}
         <TimelineItemExpandable
@@ -94,7 +94,7 @@ export function CheckServiceRunTimelineItem({
           message={message}
           date={date}
           pill={pill}
-          defaultExpanded={Boolean(isLatestRunForKind)}
+          defaultExpanded={Boolean(defaultExpanded)}
           className="py-2"
         >
           {tray}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/CheckOptionItem.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/CheckOptionItem.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import { useFetcher } from 'react-router';
 import { ui } from '@curvenote/scms-core';
 import type { Route } from './+types/route';
@@ -7,7 +7,7 @@ import type { WorkVersionCheckName } from '@curvenote/scms-server';
 interface CheckOptionItemProps {
   intent: 'toggle-check';
   name: WorkVersionCheckName;
-  label: string;
+  label: ReactNode;
   description: string;
   checked: boolean;
   disabled?: boolean;
@@ -47,12 +47,12 @@ export function CheckOptionItem({
       />
       <label
         htmlFor={name}
-        className="flex flex-col space-y-1 cursor-pointer peer-disabled:cursor-not-allowed"
+        className={`flex flex-col space-y-1 ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
       >
-        <span className="text-sm font-medium leading-none peer-disabled:opacity-70 peer-disabled:text-red-500">
+        <span className="text-sm font-medium leading-none">
           {label}
         </span>
-        <span className="text-sm text-muted-foreground peer-disabled:opacity-50">
+        <span className="text-sm text-muted-foreground">
           {description}
         </span>
       </label>

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/CheckOptionItem.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/CheckOptionItem.tsx
@@ -47,14 +47,10 @@ export function CheckOptionItem({
       />
       <label
         htmlFor={name}
-        className={`flex flex-col space-y-1 ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
+        className={`flex flex-col space-y-1 ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
       >
-        <span className="text-sm font-medium leading-none">
-          {label}
-        </span>
-        <span className="text-sm text-muted-foreground">
-          {description}
-        </span>
+        <span className="text-sm font-medium leading-none">{label}</span>
+        <span className="text-sm text-muted-foreground">{description}</span>
       </label>
     </div>
   );

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/ContinueForm.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/ContinueForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useFetcher, Link, useParams, useLocation } from 'react-router';
+import { useFetcher, useFetchers, Link, useParams, useLocation } from 'react-router';
 import { ui } from '@curvenote/scms-core';
 import type { FileMetadataSection } from '@curvenote/scms-core';
 import type { WorkVersionMetadata, ChecksMetadataSection } from '@curvenote/scms-server';
@@ -12,6 +12,7 @@ interface ContinueFormProps {
 
 export function ContinueForm({ title, authors, metadata }: ContinueFormProps) {
   const fetcher = useFetcher();
+  const fetchers = useFetchers();
   const { workId } = useParams();
   const location = useLocation();
   const fromNewFlow = new URLSearchParams(location.search).get('from') === 'new';
@@ -34,8 +35,15 @@ export function ContinueForm({ title, authors, metadata }: ContinueFormProps) {
   // Check if at least one file is uploaded
   const hasFiles = true; //'files' in metadata && metadata.files && Object.keys(metadata.files).length > 0;
 
-  // Button is only enabled if both conditions are met
-  const disabled = !hasTitle || !hasFiles;
+  // Block continue while any `toggle-check` fetcher is in flight. Otherwise the
+  // server-side `confirm-work` action may read stale `checks.enabled` metadata,
+  // causing the wrong redirect target and — worse — failing to dispatch a check
+  // that the user just selected. See confirm-work in ./route.tsx.
+  const hasPendingToggleCheck = fetchers.some(
+    (f) => f.state !== 'idle' && f.formData?.get('intent') === 'toggle-check',
+  );
+
+  const disabled = !hasTitle || !hasFiles || hasPendingToggleCheck;
 
   const handleContinue = () => {
     const formData = new FormData();

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/WorkUploadChecksForm.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/WorkUploadChecksForm.tsx
@@ -26,7 +26,11 @@ export function WorkUploadChecksForm({ enabled, checkServices }: WorkUploadCheck
       <CheckOptionItem
         intent="toggle-check"
         name="curvenote-structure"
-        label="Article Structure"
+        label={
+          <span>
+            Article Structure <sup className="text-xs font-light">(coming soon)</sup>
+          </span>
+        }
         description="Validate document structure, metadata, and formatting."
         checked={enabled.includes('curvenote-structure')}
         disabled={true}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
@@ -380,10 +380,16 @@ export async function action(args: Route.ActionArgs) {
           }
         }
 
-        // Redirect to work details unless redirect=false (e.g. when called from manuscript-checks dialog)
+        // Redirect unless redirect=false (e.g. when called from manuscript-checks dialog).
+        // If at least one check was selected during upload, redirect to /checks so the
+        // user can see check progress; otherwise redirect to /details.
         const shouldRedirect = redirectParam !== 'false';
         if (shouldRedirect) {
-          return redirect(`/app/works/${workId}/details`);
+          const target =
+            enabledChecks.length > 0
+              ? `/app/works/${workId}/checks`
+              : `/app/works/${workId}/details`;
+          return redirect(target);
         }
         return data({ success: true });
       }

--- a/platform/scms/app/routes/app/works.$workId/menu.ts
+++ b/platform/scms/app/routes/app/works.$workId/menu.ts
@@ -26,7 +26,7 @@ export function buildMenu(
     if (userScopes.includes(scopes.app.works.checks.feature)) {
       menus.push({
         name: 'work.checks',
-        label: 'Check My Work',
+        label: 'Checks',
         url: `${baseUrl}/checks`,
       });
     }


### PR DESCRIPTION
updates to timeline, orderig and CTA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches check rendering and extension integration points (new header props, manifest fallback loading, redirect logic), which can affect how checks dispatch and display across multiple routes, though changes are mostly additive and UI-focused.
> 
> **Overview**
> Updates the work `/checks` page to better present check runs: services are now sorted by most recent activity, each section shows the latest run plus a per-version history timeline with clearer version/date tags, and a new header CTA (`Check Latest Version`) appears when the newest run is from an older work version.
> 
> Extends the checks extension API to support richer headers (`action` slot + run `metadata`) and renames the auto-expand hint to `defaultExpanded` (plumbed through timeline items, currently disabled by default). Adds a temporary server-side manifest fallback so check sections can still render branding/CTAs even when a service has no runs yet.
> 
> Tightens the upload checks flow: disabled check options render correctly, “Continue” is blocked while `toggle-check` requests are in flight, and confirming a work redirects to `/checks` when any checks were selected (menu label also changes from “Check My Work” to “Checks”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64ba92dfbcfb792c38733d74394396ac1746cd2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->