### PR TITLE
🎛️ enable deploy time default new user system role config and limited…

### DIFF
--- a/.app-config.schema.yml
+++ b/.app-config.schema.yml
@@ -682,6 +682,14 @@ properties:
                   type: string
                 default: []
                 description: Provider names that skip manual approval
+          defaultUserType:
+            type: string
+            enum: ['USER', 'ANON']
+            default: 'USER'
+            description: |
+              System role assigned to newly created pending users. Defaults to USER.
+              Restricted to USER or ANON to prevent self-serve signups from receiving
+              elevated (ADMIN/SERVICE) roles. Manual approval, when enabled, still applies.
           steps:
             type: array
             description: Signup flow steps

--- a/.changeset/rich-eels-post.md
+++ b/.changeset/rich-eels-post.md
@@ -1,0 +1,7 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms-core': patch
+'@curvenote/scms': patch
+---
+
+Allow the default user SystemRole set on signup to be configured at deployment time. Also allow platform admins to cycle a user between the built in ANON and USER SystemRoles.

--- a/packages/scms-core/src/backend/signup/types.ts
+++ b/packages/scms-core/src/backend/signup/types.ts
@@ -27,6 +27,11 @@ export type SignupConfig = {
   progressMessage?: string;
   steps?: Step[];
   approval?: ApprovalConfig;
+  /**
+   * System role assigned to newly created pending users. Defaults to 'USER'.
+   * Restricted to 'USER' or 'ANON' — manual approval (when enabled) still applies.
+   */
+  defaultUserType?: 'USER' | 'ANON';
 };
 
 export type ApprovalConfig = {

--- a/packages/scms-server/src/backend/signup/index.server.ts
+++ b/packages/scms-server/src/backend/signup/index.server.ts
@@ -432,6 +432,15 @@ function validateSigninSignupConfig(
     }
   }
 
+  // Validate default user type for new pending users. Belt-and-braces check —
+  // the JSON schema already restricts this, but we guard against runtime drift.
+  const defaultUserType = config?.signup?.defaultUserType;
+  if (defaultUserType != null && defaultUserType !== 'USER' && defaultUserType !== 'ANON') {
+    throw new Error(
+      `Configuration error - signup.defaultUserType must be "USER" or "ANON", got "${defaultUserType}"`,
+    );
+  }
+
   // Validate step providers
   const steps = config?.signup?.steps ?? [];
   for (const step of steps) {

--- a/packages/scms-server/src/modules/auth/bluesky/register.server.ts
+++ b/packages/scms-server/src/modules/auth/bluesky/register.server.ts
@@ -12,6 +12,7 @@ import {
   dbGetUserByLinkedAccount,
   dbUpdateUserLinkedAccountProfile,
   failureRedirectUrl,
+  getPendingUserSystemRole,
   handleAccountLinking,
 } from '../common.server.js';
 import { getSetProviderCookie } from '../../../cookies.server.js';
@@ -276,6 +277,7 @@ export async function registerBlueskyStrategy(
             displayName,
             primaryProvider: 'bluesky',
             profile: profileForDb,
+            systemRole: getPendingUserSystemRole(config),
           });
           console.log(
             `Bluesky provider - provisioned new user (${displayName}, ${idAtProvider}, ${dbUserViaBluesky.id})`,

--- a/packages/scms-server/src/modules/auth/common.server.ts
+++ b/packages/scms-server/src/modules/auth/common.server.ts
@@ -11,6 +11,29 @@ import { getServerFirestore } from '../database/firebase/firebase.server.js';
 import { randomBytes } from 'node:crypto';
 
 /**
+ * System roles that may be assigned to a freshly-provisioned pending user.
+ * Intentionally excludes ADMIN and SERVICE to prevent self-serve signups from
+ * gaining elevated privileges via configuration.
+ */
+export type PendingUserSystemRole = 'USER' | 'ANON';
+
+/**
+ * Resolve the system role to assign to newly-created pending users based on the
+ * deployment configuration. Defaults to 'USER' when unset or invalid.
+ *
+ * Manual approval (when enabled) still applies regardless of the resolved role.
+ */
+export function getPendingUserSystemRole(config: {
+  app?: { signup?: { defaultUserType?: string } };
+}): PendingUserSystemRole {
+  const configured = config.app?.signup?.defaultUserType;
+  if (configured === 'ANON' || configured === 'USER') {
+    return configured;
+  }
+  return 'USER';
+}
+
+/**
  * Error thrown when an Editor user already exists.
  */
 export class EditorUserExistsError extends Error {
@@ -210,6 +233,8 @@ export async function dbGetUserByEmails(emails: string[]) {
  * @param editorUserNoPendingOverride - If true, creates the user without pending status (default: false).
  *   This is used when provisioning users from the editor API who should bypass the pending state.
  *   NOTE: This parameter will likely be removed once we have closer and editor integrations.
+ * @param systemRole - The system role assigned to the new user. Defaults to 'USER'.
+ *   Restricted to 'USER' or 'ANON' to prevent self-serve signups from receiving elevated roles.
  * @returns The new user record
  */
 export async function dbCreateUserWithPrimaryLinkedAccount<
@@ -222,6 +247,7 @@ export async function dbCreateUserWithPrimaryLinkedAccount<
   displayName,
   profile,
   editorUserNoPendingOverride = false,
+  systemRole = 'USER',
 }: {
   id?: string;
   email?: string;
@@ -230,6 +256,7 @@ export async function dbCreateUserWithPrimaryLinkedAccount<
   displayName?: string;
   profile: T;
   editorUserNoPendingOverride?: boolean;
+  systemRole?: PendingUserSystemRole;
 }) {
   const prisma = await getPrismaClient();
   const timestamp = formatDate();
@@ -260,7 +287,7 @@ export async function dbCreateUserWithPrimaryLinkedAccount<
       email,
       username,
       display_name: displayName,
-      system_role: 'USER',
+      system_role: systemRole,
       primaryProvider,
       pending: editorUserNoPendingOverride ? false : true, // this function create new users, who by definition are pending unless we are provisioning a user from the editor API
       ready_for_approval: false,
@@ -326,6 +353,7 @@ export async function dbCreateUser({
   readyForApproval = false,
   signupData = null,
   externalTimestamp,
+  systemRole = 'USER',
 }: {
   id?: string;
   email?: string;
@@ -336,6 +364,7 @@ export async function dbCreateUser({
   readyForApproval?: boolean;
   signupData?: any;
   externalTimestamp?: string;
+  systemRole?: PendingUserSystemRole;
 }) {
   const prisma = await getPrismaClient();
   const timestamp = externalTimestamp ?? new Date().toISOString();
@@ -348,7 +377,7 @@ export async function dbCreateUser({
       email,
       username,
       display_name: displayName,
-      system_role: 'USER',
+      system_role: systemRole,
       primaryProvider,
       pending,
       ready_for_approval: readyForApproval,
@@ -701,6 +730,8 @@ export async function provisionNewUserFromEditorAPI(
   // Always create SCMS user, whether or not they exist in Editor API
   let user: Awaited<ReturnType<typeof dbCreateUser>>;
 
+  const systemRole = getPendingUserSystemRole(config);
+
   // For Google login via Firebase, create a Google-linked user
   if (providerData && data.provider === 'google') {
     user = await dbCreateUserWithPrimaryLinkedAccount<Exclude<typeof providerData, undefined>>({
@@ -712,6 +743,7 @@ export async function provisionNewUserFromEditorAPI(
       profile: providerData,
       // Only skip signup flow if user was found in Editor API (existing user)
       editorUserNoPendingOverride: !!editorUserProfile,
+      systemRole,
     });
   } else {
     // Email/password login - create non-linked user
@@ -725,6 +757,7 @@ export async function provisionNewUserFromEditorAPI(
       // Only skip signup flow if user was found in Editor API
       pending: !editorUserProfile,
       readyForApproval: false,
+      systemRole,
       signupData: editorUserProfile
         ? {
             completedAt: timestamp,

--- a/packages/scms-server/src/modules/auth/github/register.server.ts
+++ b/packages/scms-server/src/modules/auth/github/register.server.ts
@@ -7,6 +7,7 @@ import {
   dbGetUserByLinkedAccount,
   dbUpdateUserLinkedAccountProfile,
   failureRedirectUrl,
+  getPendingUserSystemRole,
   getProviderDisplayName,
   handleAccountLinking,
 } from '../common.server.js';
@@ -241,6 +242,7 @@ export function registerGitHubStrategy(
               displayName: profile.name ?? profile.login,
               primaryProvider: 'github',
               profile: profileForDb,
+              systemRole: getPendingUserSystemRole(config),
             });
             console.log(
               `GITHUB provider - provisioned new user (${profile.name ?? profile.login}, ${idAtProvider}, ${dbUserViaGithub.id})`,

--- a/packages/scms-server/src/modules/auth/google/register.server.ts
+++ b/packages/scms-server/src/modules/auth/google/register.server.ts
@@ -8,6 +8,7 @@ import {
   dbGetUserByLinkedAccount,
   dbUpdateUserLinkedAccountProfile,
   failureRedirectUrl,
+  getPendingUserSystemRole,
   handleAccountLinking,
 } from '../common.server.js';
 import type { firebase } from '@curvenote/scms-core';
@@ -171,6 +172,7 @@ export function registerGoogleStrategy(
               displayName: profile.name,
               primaryProvider: 'google',
               profile,
+              systemRole: getPendingUserSystemRole(config),
             });
             console.log(
               `GOOGLE provider - provisioned new user (${profile.name}, ${profile.uid}, ${dbUserViaGoogle.id})`,

--- a/packages/scms-server/src/modules/auth/okta/register.server.ts
+++ b/packages/scms-server/src/modules/auth/okta/register.server.ts
@@ -10,6 +10,7 @@ import {
   dbGetUserByLinkedAccount,
   dbUpdateUserLinkedAccountProfile,
   failureRedirectUrl,
+  getPendingUserSystemRole,
   handleAccountLinking,
 } from '../common.server.js';
 import { getSetProviderCookie } from '../../../cookies.server.js';
@@ -178,6 +179,7 @@ export function registerOktaStrategy(
               displayName: profile.name,
               primaryProvider: 'okta',
               profile,
+              systemRole: getPendingUserSystemRole(config),
             });
             console.log(
               `OKTA provider - provisioned new user (${profile.name}, ${profile.id}, ${dbUserViaOkta.id})`,

--- a/packages/scms-server/src/modules/auth/orcid/register.server.ts
+++ b/packages/scms-server/src/modules/auth/orcid/register.server.ts
@@ -9,6 +9,7 @@ import {
   dbGetUserByLinkedAccount,
   dbUpdateUserLinkedAccountProfile,
   failureRedirectUrl,
+  getPendingUserSystemRole,
   getProviderDisplayName,
   handleAccountLinking,
 } from '../common.server.js';
@@ -278,6 +279,7 @@ export function registerOrcidStrategy(config: AppConfig, auth: Authenticator<Aut
               displayName: profile.name,
               primaryProvider: 'orcid',
               profile,
+              systemRole: getPendingUserSystemRole(config),
             });
             console.log(
               `ORCID provider - provisioned new user (${profile.name}, ${profile.id}, ${dbUserViaOrcid.id})`,

--- a/platform/scms/app/routes/app/platform.users/UserListItem.tsx
+++ b/platform/scms/app/routes/app/platform.users/UserListItem.tsx
@@ -7,6 +7,7 @@ import { UserToggleDisabledButton } from './UserToggleDisabledButton';
 import { UserApproveRejectControls } from './UserApproveRejectControls';
 import { AssignRoleDialog } from './AssignRoleDialog';
 import { RoleBadge } from './RoleBadge';
+import { UserSystemRoleToggle } from './UserSystemRoleToggle';
 
 interface UserCardProps {
   user: UserDTO;
@@ -212,13 +213,19 @@ export function UserListItem({ user, availableRoles }: UserCardProps) {
         })()}
 
         {/* System role */}
-        <div className="flex flex-wrap items-center gap-1">
-          <span className="flex-shrink-0 text-sm font-medium text-gray-700 dark:text-gray-300">
-            System Role:
-          </span>
-          {user.system_role !== 'USER' && <ui.Badge variant="outline">{user.system_role}</ui.Badge>}
-          {user.system_role === 'USER' && (
-            <span className="text-xs text-gray-500 dark:text-gray-500">User</span>
+        <div className="flex flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-1">
+            <span className="flex-shrink-0 text-sm font-medium text-gray-700 dark:text-gray-300">
+              System Role:
+            </span>
+            {user.system_role === 'USER' ? (
+              <span className="text-xs text-gray-500 dark:text-gray-500">User</span>
+            ) : (
+              <ui.Badge variant="outline">{user.system_role}</ui.Badge>
+            )}
+          </div>
+          {(user.system_role === 'USER' || user.system_role === 'ANON') && (
+            <UserSystemRoleToggle user={user} />
           )}
         </div>
       </div>

--- a/platform/scms/app/routes/app/platform.users/UserListingHelpers.tsx
+++ b/platform/scms/app/routes/app/platform.users/UserListingHelpers.tsx
@@ -88,7 +88,7 @@ export const STATUS_FILTERS: ui.FilterDefinition[] = [
  * Generate system role filters with groupKey for mutual exclusivity
  */
 export function generateSystemRoleFilters(): ui.FilterDefinition[] {
-  const systemRoles = ['USER', 'ADMIN', 'SERVICE'];
+  const systemRoles = ['USER', 'ANON', 'ADMIN', 'SERVICE'];
 
   return systemRoles.map((role) => ({
     key: 'systemRole',

--- a/platform/scms/app/routes/app/platform.users/UserSystemRoleToggle.tsx
+++ b/platform/scms/app/routes/app/platform.users/UserSystemRoleToggle.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { useFetcher } from 'react-router';
+import { ui } from '@curvenote/scms-core';
+import { RefreshCw } from 'lucide-react';
+import type { UserDTO } from './db.server';
+
+interface UserSystemRoleToggleProps {
+  user: UserDTO;
+}
+
+/**
+ * Toggle a user's system role between USER and ANON.
+ *
+ * Only renders when the user's current system_role is USER or ANON —
+ * ADMIN/SERVICE users are not toggleable here. The server enforces the
+ * same invariant regardless of what the UI submits.
+ */
+export function UserSystemRoleToggle({ user }: UserSystemRoleToggleProps) {
+  const fetcher = useFetcher();
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+
+  if (user.system_role !== 'USER' && user.system_role !== 'ANON') {
+    return null;
+  }
+
+  const currentRole = user.system_role;
+  const nextRole = currentRole === 'USER' ? 'ANON' : 'USER';
+  const isSubmitting = fetcher.state !== 'idle';
+
+  const handleConfirm = () => {
+    const formData = new FormData();
+    formData.append('intent', 'change-system-role');
+    formData.append('userId', user.id);
+    formData.append('systemRole', nextRole);
+    fetcher.submit(formData, { method: 'post' });
+    setShowConfirmDialog(false);
+  };
+
+  return (
+    <>
+      <ui.Button
+        variant="outline"
+        size="xs"
+        onClick={() => setShowConfirmDialog(true)}
+        disabled={isSubmitting}
+        className="text-xs"
+        title={`Change system role to ${nextRole}`}
+      >
+        <RefreshCw className="w-3 h-3 mr-1" />
+        {isSubmitting ? 'Updating...' : `Set ${nextRole}`}
+      </ui.Button>
+
+      <ui.Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+        <ui.DialogContent>
+          <ui.DialogHeader>
+            <ui.DialogTitle>Change System Role</ui.DialogTitle>
+            <ui.DialogDescription>
+              Change the system role for "{user.display_name || user.email || 'Unknown User'}" from{' '}
+              <span className="font-medium">{currentRole}</span> to{' '}
+              <span className="font-medium">{nextRole}</span>?
+              <span className="block mt-2 font-medium text-amber-600">
+                Only USER &#x2194; ANON transitions are permitted here. Scopes derived from the
+                system role will change immediately and may affect the user's access.
+              </span>
+            </ui.DialogDescription>
+          </ui.DialogHeader>
+          <ui.DialogFooter>
+            <ui.Button variant="outline" onClick={() => setShowConfirmDialog(false)}>
+              Cancel
+            </ui.Button>
+            <ui.Button onClick={handleConfirm} disabled={isSubmitting}>
+              {isSubmitting ? 'Updating...' : `Set ${nextRole}`}
+            </ui.Button>
+          </ui.DialogFooter>
+        </ui.DialogContent>
+      </ui.Dialog>
+    </>
+  );
+}

--- a/platform/scms/app/routes/app/platform.users/db.server.ts
+++ b/platform/scms/app/routes/app/platform.users/db.server.ts
@@ -1,8 +1,21 @@
 import { getPrismaClient } from '@curvenote/scms-server';
 import { KnownResendEvents } from '@curvenote/scms-core';
-import { ActivityType } from '@curvenote/scms-db';
+import { ActivityType, SystemRole } from '@curvenote/scms-db';
 import { uuidv7 as uuid } from 'uuidv7';
 import type { SecureContext, withAppPlatformAdminContext } from '@curvenote/scms-server';
+
+/**
+ * System roles that may be toggled between via the platform users UI.
+ * Any other transition (ADMIN, SERVICE, same-value, unknown) is rejected.
+ */
+const TOGGLEABLE_SYSTEM_ROLES = new Set<SystemRole>([SystemRole.USER, SystemRole.ANON]);
+
+export class InvalidSystemRoleTransitionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidSystemRoleTransitionError';
+  }
+}
 
 export type UserDTO = Awaited<ReturnType<typeof dbGetUsers>>[0];
 
@@ -169,6 +182,84 @@ export async function dbToggleUserDisabled(
         activity_type: disabled ? ActivityType.USER_DISABLED : ActivityType.USER_ENABLED,
         user_id: id,
         status: disabled ? 'DISABLED' : 'ENABLED',
+      },
+    });
+
+    return user;
+  });
+}
+
+/**
+ * Change a user's system role, but ONLY between USER and ANON.
+ *
+ * STRICT SERVER-SIDE VALIDATION:
+ * - The requested `nextRole` MUST be 'USER' or 'ANON'.
+ * - The target user's CURRENT `system_role` MUST also be 'USER' or 'ANON'.
+ *   Users with ADMIN or SERVICE roles cannot be changed here — those must be
+ *   managed through proper admin-elevation flows.
+ * - The transition must actually change the role (no-ops are rejected).
+ *
+ * @throws InvalidSystemRoleTransitionError if any of the above invariants fail.
+ */
+export async function dbChangeUserSystemRoleBetweenUserAndAnon(
+  userId: string,
+  nextRole: SystemRole,
+  activityByUserId: string,
+) {
+  if (!TOGGLEABLE_SYSTEM_ROLES.has(nextRole)) {
+    throw new InvalidSystemRoleTransitionError(
+      `system_role can only be changed to USER or ANON via this action (got "${nextRole}")`,
+    );
+  }
+
+  const prisma = await getPrismaClient();
+  const dateCreated = new Date().toISOString();
+
+  return prisma.$transaction(async (tx) => {
+    const current = await tx.user.findUnique({
+      where: { id: userId },
+      select: { system_role: true },
+    });
+
+    if (!current) {
+      throw new InvalidSystemRoleTransitionError(`User ${userId} not found`);
+    }
+
+    if (!TOGGLEABLE_SYSTEM_ROLES.has(current.system_role)) {
+      throw new InvalidSystemRoleTransitionError(
+        `Cannot change system_role for user ${userId} with current role "${current.system_role}" — only USER<->ANON transitions are allowed here`,
+      );
+    }
+
+    if (current.system_role === nextRole) {
+      throw new InvalidSystemRoleTransitionError(
+        `User ${userId} already has system_role "${nextRole}"`,
+      );
+    }
+
+    const user = await tx.user.update({
+      where: { id: userId },
+      data: {
+        system_role: nextRole,
+        date_modified: dateCreated,
+      },
+    });
+
+    await tx.activity.create({
+      data: {
+        id: uuid(),
+        date_created: dateCreated,
+        date_modified: dateCreated,
+        activity_by_id: activityByUserId,
+        activity_type: ActivityType.ROLE_UPDATED,
+        user_id: userId,
+        status: nextRole,
+        data: {
+          system_role_change: {
+            from: current.system_role,
+            to: nextRole,
+          },
+        },
       },
     });
 

--- a/platform/scms/app/routes/app/platform.users/route.tsx
+++ b/platform/scms/app/routes/app/platform.users/route.tsx
@@ -8,24 +8,36 @@ import {
 } from '@curvenote/scms-core';
 import {
   approveAndNotifyUser,
+  dbChangeUserSystemRoleBetweenUserAndAnon,
   dbCountUsers,
   dbGetUsers,
   dbRejectUser,
   dbToggleUserDisabled,
+  InvalidSystemRoleTransitionError,
   runPlatformUserAnalytics,
 } from './db.server';
 import { handleAssignRole, handleRemoveRole } from './actionHelpers.server';
 import { PlatformUserList } from './PlatformUserList';
+import { data as dataResponse } from 'react-router';
 import { z } from 'zod';
 import { zfd } from 'zod-form-data';
 
 // Zod schema for form validation
 const PlatformUserActionSchema = zfd.formData({
-  intent: z.enum(['toggle-disabled', 'approve-user', 'reject-user', 'assign-role', 'remove-role']),
+  intent: z.enum([
+    'toggle-disabled',
+    'approve-user',
+    'reject-user',
+    'assign-role',
+    'remove-role',
+    'change-system-role',
+  ]),
   userId: zfd.text(z.string()),
   disabled: zfd.text(z.string().transform((val) => val === 'true')).optional(),
   roleId: zfd.text(z.string()).optional(),
   userRoleId: zfd.text(z.string()).optional(),
+  // Client-side narrow: the DB layer does strict server-side validation.
+  systemRole: zfd.text(z.enum(['USER', 'ANON'])).optional(),
 });
 
 export async function loader(args: Route.LoaderArgs) {
@@ -117,6 +129,38 @@ export async function action(args: Route.ActionArgs) {
           });
         }
         return result;
+      }
+      case 'change-system-role': {
+        if (!payload.systemRole) {
+          return dataResponse(
+            {
+              error: {
+                type: 'validation',
+                message: 'systemRole is required for change-system-role intent',
+              },
+            },
+            { status: 400 },
+          );
+        }
+        try {
+          const user = await dbChangeUserSystemRoleBetweenUserAndAnon(
+            payload.userId,
+            payload.systemRole,
+            ctx.user.id,
+          );
+          await runPlatformUserAnalytics(ctx, payload.userId, async () => {
+            await ctx.analytics.flush();
+          });
+          return { success: true, user };
+        } catch (error) {
+          if (error instanceof InvalidSystemRoleTransitionError) {
+            return dataResponse(
+              { error: { type: 'validation', message: error.message } },
+              { status: 400 },
+            );
+          }
+          throw error;
+        }
       }
       default: {
         throw new Error('Invalid intent');


### PR DESCRIPTION
… system role switching for platform admins

This allows for enhanced signup control to be introduced on a per-deployment level

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user provisioning to assign `system_role` based on deploy-time config and adds an admin action to mutate `system_role`, which can immediately affect user access/scopes despite guardrails limiting transitions to USER/ANON.
> 
> **Overview**
> Adds a new `app.signup.defaultUserType` config (schema + types) to control which **restricted** system role (`USER` or `ANON`) is assigned to newly provisioned *pending* users, with server-side validation and a shared `getPendingUserSystemRole()` resolver used across auth providers and editor provisioning.
> 
> Extends the platform admin Users page to include `ANON` filtering and a confirmed toggle action that switches a user’s `system_role` between `USER` and `ANON`, backed by a transactional DB update with strict transition validation and activity logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2631a2ede38307483df0281c2d151f38abec12c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->