### PR TITLE
🎨 extending design page and extension interfaces

### DIFF
--- a/.changeset/wild-cycles-find.md
+++ b/.changeset/wild-cycles-find.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-core': patch
+'@curvenote/scms': patch
+---
+
+Extended system/design page and provided an interface point for extensions to export design components, sinplifying extension development, testing and review

--- a/package-lock.json
+++ b/package-lock.json
@@ -6274,9 +6274,9 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/canvas": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.99.tgz",
-      "integrity": "sha512-zN4eQlK3eBf7aJBcTHZilpBH3tDekBzPMIWC8r0s94Ecl73XfOyFi4w7yKFMRVUT0lvNQjtOL8YSrwqQj6mZFg==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
       "license": "MIT",
       "optional": true,
       "workspaces": [
@@ -6290,23 +6290,23 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "0.1.99",
-        "@napi-rs/canvas-darwin-arm64": "0.1.99",
-        "@napi-rs/canvas-darwin-x64": "0.1.99",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.99",
-        "@napi-rs/canvas-linux-arm64-gnu": "0.1.99",
-        "@napi-rs/canvas-linux-arm64-musl": "0.1.99",
-        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.99",
-        "@napi-rs/canvas-linux-x64-gnu": "0.1.99",
-        "@napi-rs/canvas-linux-x64-musl": "0.1.99",
-        "@napi-rs/canvas-win32-arm64-msvc": "0.1.99",
-        "@napi-rs/canvas-win32-x64-msvc": "0.1.99"
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
       }
     },
     "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.99.tgz",
-      "integrity": "sha512-9OCRt8VVxA17m32NWZKyNC2qamdaS/SC5CEOIQwFngRq0DIeVm4PDal+6Ljnhqm2whZiC63DNuKZ4xSp2nbj9w==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
       "cpu": [
         "arm64"
       ],
@@ -6324,9 +6324,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.99.tgz",
-      "integrity": "sha512-lupMDMy1+H38dhyCcLirOKKVUyzzlxi7j7rGPLI3vViMHOoPjcXO1b10ivy+ad+q6MiwHfoLjKTCoLke5ySOBg==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
       "cpu": [
         "arm64"
       ],
@@ -6344,9 +6344,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.99.tgz",
-      "integrity": "sha512-fdz02t4w8n6Ii/rYhWig6STb/zcTmCC/6YZTGmjoDeidDwn9Wf0ukQVynhCPEs29vqUc66wHZKsuIgMs9tycCg==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
       "cpu": [
         "x64"
       ],
@@ -6364,9 +6364,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.99.tgz",
-      "integrity": "sha512-w4FwVwlNo00ezeRhfY62IVIyt6G3u8wodkPtiqWc52BUHx+VDBUM2vkS3ogfANaLI7hnf3s6WK4LyZVUjBg1lA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
       "cpu": [
         "arm"
       ],
@@ -6384,9 +6384,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.99.tgz",
-      "integrity": "sha512-8JvHeexKQ8c7g0q7YJ29NVQwnf1ePghP9ys9ZN0R0qzyqJQ9Uw6N9qnDINArlm3IYHexB7LjzArIfhQiqSDGvQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
       "cpu": [
         "arm64"
       ],
@@ -6404,9 +6404,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.99.tgz",
-      "integrity": "sha512-Z+6nyLdJXWzLPVxi4H6g9TJop4DwN3KSgHWto5JCbZV5/uKoVqcSynPs0tGlUHOoWI8S8tEvJspz51GQkvr07w==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
       "cpu": [
         "arm64"
       ],
@@ -6424,9 +6424,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.99.tgz",
-      "integrity": "sha512-jAnfOUv4IO1l8Levk5t85oVtEBOXLa07KnIUgWo1CDlPxiqpxS3uBfiE38Lvj/CQgHaNF6Nxk/SaemwLgsVJgw==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
       "cpu": [
         "riscv64"
       ],
@@ -6444,9 +6444,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.99.tgz",
-      "integrity": "sha512-mIkXw3fGmbYyFjSmfWEvty4jN+rwEOmv0+Dy9bRvvTzLYWCgm3RMgUEQVfAKFw96nIRFnyNZiK83KNQaVVFjng==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
       "cpu": [
         "x64"
       ],
@@ -6464,9 +6464,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.99.tgz",
-      "integrity": "sha512-f3Uz2P0RgrtBHISxZqr6yiYXJlTDyCVBumDacxo+4AmSg7z0HiqYZKGWC/gszq3fbPhyQUya1W2AEteKxT9Y6A==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
       "cpu": [
         "x64"
       ],
@@ -6484,9 +6484,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.99.tgz",
-      "integrity": "sha512-XE6KUkfqRsCNejcoRMiMr3RaUeObxNf6y7dut3hrq2rn7PzfRTZgrjF1F/B2C7FcdgqY/vSHWpQeMuNz1vTNHg==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
       "cpu": [
         "arm64"
       ],
@@ -6504,9 +6504,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.99.tgz",
-      "integrity": "sha512-plMYGVbc/vmmPF9MtmHbwNk1rL1Aj53vQZt+Gnv1oZn6gmd9jEHHJ0n9Nd2nxa5sKH7TS5IjkCDM6289O0d6PQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
       "cpu": [
         "x64"
       ],
@@ -40474,6 +40474,16 @@
         "typescript": "^5.7.0"
       }
     },
+    "platform/relay/node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "platform/relay/node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -40485,6 +40495,13 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "platform/relay/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "platform/scms": {
       "name": "@curvenote/scms",
@@ -40607,6 +40624,16 @@
         "node": ">=18"
       }
     },
+    "platform/scms/node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "platform/scms/node_modules/@types/react": {
       "version": "18.3.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
@@ -40714,9 +40741,9 @@
       }
     },
     "platform/scms/node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -40808,6 +40835,13 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "platform/scms/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/scms-core/src/components/FrameHeader.tsx
+++ b/packages/scms-core/src/components/FrameHeader.tsx
@@ -14,6 +14,7 @@ interface FrameHeaderProps {
   actionIcon?: React.ReactNode;
   onAction?: () => void;
   actionDisabled?: boolean;
+  actionAlign?: 'inline' | 'right';
 }
 
 export function FrameHeader({
@@ -26,6 +27,7 @@ export function FrameHeader({
   actionDisabled,
   actionIcon,
   onAction,
+  actionAlign = 'inline',
 }: FrameHeaderProps) {
   const location = useLocation();
   const deploymentConfig = useDeploymentConfig();
@@ -57,7 +59,7 @@ export function FrameHeader({
           {subtitle && <div className="py-1 text-base">{subtitle}</div>}
         </div>
         {actionLabel && (
-          <div>
+          <div className={cn(actionAlign === 'right' && 'ml-auto')}>
             <StatefulButton onClick={onAction} disabled={actionDisabled}>
               <div className="flex flex-row gap-2 items-center">
                 {actionIcon && <div className="flex flex-shrink-0 items-center">{actionIcon}</div>}

--- a/packages/scms-core/src/components/FrameHeader.tsx
+++ b/packages/scms-core/src/components/FrameHeader.tsx
@@ -50,7 +50,7 @@ export function FrameHeader({
 
   return (
     <div className={cn('flex flex-col gap-2', className)}>
-      <div className="flex flex-row gap-4 justify-between items-center">
+      <div className="flex flex-row gap-4 items-center">
         {iconWithProps && <div className="flex flex-shrink-0 items-center">{iconWithProps}</div>}
         <div className="flex flex-col justify-center">
           <h1 className="text-2xl font-normal tracking-tight">{title}</h1>

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -225,6 +225,13 @@ export interface ClientExtension {
   registerNavigation: NavigationRegistrationFn;
   /** Optional component to render extension admin card content; receives sanitized config. */
   getExtensionAdminCard?: () => React.ComponentType<ExtensionAdminCardProps>;
+  /**
+   * Optional component to render on the system Design page as an extension-owned tab.
+   * The platform shows one tab per extension that returns a component, using the
+   * extension's `name` as the tab label. Extensions can use this surface to showcase
+   * their own UI components and various visual states.
+   */
+  getDesigns?: () => React.ComponentType;
 }
 
 export interface ExtensionAdminActionHandler {

--- a/platform/scms/app/routes/app/system.design/route.tsx
+++ b/platform/scms/app/routes/app/system.design/route.tsx
@@ -3,6 +3,7 @@ import { withAppAdminContext } from '@curvenote/scms-server';
 import { PageFrame, SystemAdminBadge, ui, primitives, FrameHeader } from '@curvenote/scms-core';
 import type { Workflow } from '@curvenote/scms-core';
 import { Palette, ExternalLink } from 'lucide-react';
+import { extensions as clientExtensions } from '../../../extensions/client';
 
 export async function loader(args: Route.LoaderArgs) {
   await withAppAdminContext(args);
@@ -191,933 +192,977 @@ const mockWorkflows: Record<string, Workflow> = {
   },
 };
 
+type ExtensionDesignTab = {
+  id: string;
+  label: string;
+  Component: React.ComponentType;
+};
+
+function getExtensionDesignTabs(): ExtensionDesignTab[] {
+  return clientExtensions
+    .map((extension) => {
+      const Component = extension.getDesigns?.();
+      if (!Component) return null;
+      return {
+        id: extension.id,
+        label: extension.name,
+        Component,
+      } satisfies ExtensionDesignTab;
+    })
+    .filter((tab): tab is ExtensionDesignTab => tab !== null);
+}
+
 export default function SystemDesign() {
+  const extensionTabs = getExtensionDesignTabs();
+
   return (
     <PageFrame
       header={<FrameHeader icon={<Palette />} title="Design" subtitle="Standard UI components" />}
     >
       <SystemAdminBadge />
 
-      <div className="mx-auto space-y-12 max-w-7xl">
-        <TableOfContents />
+      <ui.Tabs defaultValue="core" className="mx-auto w-full max-w-7xl">
+        <ui.TabsList>
+          <ui.TabsTrigger value="core">Core</ui.TabsTrigger>
+          {extensionTabs.map((tab) => (
+            <ui.TabsTrigger key={tab.id} value={tab.id}>
+              {tab.label}
+            </ui.TabsTrigger>
+          ))}
+        </ui.TabsList>
 
-        {/* Toast Section */}
-        <ComponentSection id="toast" title="Toast">
-          <ComponentCard
-            component={
-              <ui.Button
-                onClick={() =>
-                  ui.toastInfo('This is an info message', {
-                    description: 'Additional details about the information',
-                  })
-                }
-                variant="outline"
-              >
-                Show Info Toast
-              </ui.Button>
-            }
-            title="Info"
-            metadata="toastInfo(message, options)"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/toast.tsx"
-          />
-
-          <ComponentCard
-            component={
-              <ui.Button
-                onClick={() =>
-                  ui.toastSuccess('Operation completed successfully!', {
-                    description: 'Your changes have been saved',
-                  })
-                }
-                variant="outline"
-                className="text-green-700 border-green-200 hover:bg-green-50 dark:border-green-800 dark:text-green-400 dark:hover:bg-green-950"
-              >
-                Show Success Toast
-              </ui.Button>
-            }
-            title="Success"
-            metadata="toastSuccess(message, options)"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/toast.tsx"
-          />
-
-          <ComponentCard
-            component={
-              <ui.Button
-                onClick={() =>
-                  ui.toastWarning('Please check your input', {
-                    description: 'Some fields require your attention',
-                  })
-                }
-                variant="outline"
-                className="text-yellow-700 border-yellow-200 hover:bg-yellow-50 dark:border-yellow-800 dark:text-yellow-400 dark:hover:bg-yellow-950"
-              >
-                Show Warning Toast
-              </ui.Button>
-            }
-            title="Warning"
-            metadata="toastWarning(message, options)"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/toast.tsx"
-          />
-
-          <ComponentCard
-            component={
-              <ui.Button
-                onClick={() =>
-                  ui.toastError('Something went wrong', {
-                    description: 'Please try again later or contact support',
-                  })
-                }
-                variant="outline"
-                className="text-red-700 border-red-200 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950"
-              >
-                Show Error Toast
-              </ui.Button>
-            }
-            title="Error"
-            metadata="toastError(message, options)"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/toast.tsx"
-          />
-        </ComponentSection>
-
-        {/* Simple Alerts Section */}
-        <div className="mb-12" id="simple-alerts">
-          <h2 className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
-            Simple Alerts
-          </h2>
-          <div className="grid max-w-2xl grid-cols-1 gap-4">
-            <ComponentCard
-              component={
-                <ui.SimpleAlert
-                  type="info"
-                  size="compact"
-                  message="This is an informational message to provide context about an action."
-                />
-              }
-              title="Info (Compact)"
-              metadata='type="info" size="compact"'
-              sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SimpleAlert.tsx"
-            />
-
-            <ComponentCard
-              component={
-                <ui.SimpleAlert
-                  type="success"
-                  size="compact"
-                  message="Operation completed successfully! Your changes have been saved."
-                />
-              }
-              title="Success (Compact)"
-              metadata='type="success" size="compact"'
-              sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SimpleAlert.tsx"
-            />
-
-            <ComponentCard
-              component={
-                <ui.SimpleAlert
-                  type="warning"
-                  size="compact"
-                  message="Please review your input. Some fields may require attention."
-                />
-              }
-              title="Warning (Compact)"
-              metadata='type="warning" size="compact"'
-              sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SimpleAlert.tsx"
-            />
-
-            <ComponentCard
-              component={
-                <ui.SimpleAlert
-                  type="error"
-                  size="compact"
-                  message="An error occurred while processing your request. Please try again."
-                />
-              }
-              title="Error (Compact)"
-              metadata='type="error" size="compact"'
-              sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SimpleAlert.tsx"
-            />
-
-            <ComponentCard
-              component={
-                <ui.SimpleAlert
-                  type="neutral"
-                  size="normal"
-                  message="This is a neutral message that provides general information."
-                />
-              }
-              title="Neutral (Normal)"
-              metadata='type="neutral" size="normal"'
-              sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SimpleAlert.tsx"
-            />
-          </div>
-        </div>
-
-        {/* Chips Section */}
-        <ComponentSection id="chips" title="Chips">
-          <ComponentCard
-            component={
-              <primitives.Chip className="text-stone-800 dark:text-white dark:bg-stone-500 bg-stone-200">
-                Default Chip
-              </primitives.Chip>
-            }
-            title="Default"
-            metadata="text-stone-800 dark:text-white dark:bg-stone-500 bg-stone-200"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/primitives/Chip.tsx"
-          />
-
-          <ComponentCard
-            component={
-              <primitives.Chip className="text-white bg-green-600">Published</primitives.Chip>
-            }
-            title="Published"
-            metadata="text-white bg-green-600"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/ee/sites/src/components/Chips.tsx#L6-L19"
-          />
-
-          <ComponentCard
-            component={
-              <primitives.Chip className="text-white bg-red-800 dark:bg-red-500">
-                Retracted
-              </primitives.Chip>
-            }
-            title="Retracted"
-            metadata="text-white bg-red-800 dark:bg-red-500"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/ee/sites/src/components/Chips.tsx#L21-L32"
-          />
-
-          <ComponentCard
-            component={
-              <primitives.Chip className="text-white bg-sky-600 border-[1px] border-sky-600 dark:border-sky-600 dark:bg-sky-600">
-                my-article-slug
-              </primitives.Chip>
-            }
-            title="Slug"
-            metadata="text-white bg-sky-600 border-[1px] border-sky-600"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/ee/sites/src/components/Chips.tsx#L34-L44"
-          />
-
-          <ComponentCard
-            component={
-              <primitives.Chip className="text-sky-700 border-[1px] border-sky-700 dark:border-sky-300 dark:text-sky-300">
-                Research Article
-              </primitives.Chip>
-            }
-            title="Submission Kind"
-            metadata="text-sky-700 border-[1px] border-sky-700 dark:border-sky-300 dark:text-sky-300"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/ee/sites/src/components/Chips.tsx#L66-L85"
-          />
-
-          <ComponentCard
-            component={
-              <primitives.Chip className="text-sky-700 border-[1px] border-sky-700 dark:border-sky-300 dark:text-sky-300">
-                Special Issue: AI Research
-              </primitives.Chip>
-            }
-            title="Collection"
-            metadata="text-sky-700 border-[1px] border-sky-700 dark:border-sky-300 dark:text-sky-300"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/ee/sites/src/components/Chips.tsx#L46-L64"
-          />
-
-          <ComponentCard
-            component={
-              <primitives.Chip className="text-black bg-gray-200 dark:bg-gray-600 dark:text-white">
-                3 days ago
-              </primitives.Chip>
-            }
-            title="Age"
-            metadata="text-black bg-gray-200 dark:bg-gray-600 dark:text-white"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/ee/sites/src/components/Chips.tsx#L87-L97"
-          />
-
-          <ComponentCard
-            component={
-              <primitives.Chip className="text-gray-500 border-[1px] border-gray-200 dark:border-gray-500 dark:text-gray-500">
-                2 weeks ago
-              </primitives.Chip>
-            }
-            title="Last Activity"
-            metadata="text-gray-500 border-[1px] border-gray-200 dark:border-gray-500"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/platform/scms/app/routes/app/works._index/WorkListItem.tsx#L137-L142"
-          />
-        </ComponentSection>
-
-        {/* Badge Section */}
-        <ComponentSection id="badge" title="Badge">
-          <ComponentCard
-            component={<ui.Badge>Default Badge</ui.Badge>}
-            title="Default"
-            metadata="variant='default'"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx"
-          />
-
-          <ComponentCard
-            component={<ui.Badge variant="primary">Primary Badge</ui.Badge>}
-            title="Primary"
-            metadata="variant='primary'"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L13"
-          />
-
-          <ComponentCard
-            component={<ui.Badge variant="secondary">Secondary Badge</ui.Badge>}
-            title="Secondary"
-            metadata="variant='secondary'"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L14-L15"
-          />
-
-          <ComponentCard
-            component={<ui.Badge variant="destructive">Destructive Badge</ui.Badge>}
-            title="Destructive"
-            metadata="variant='destructive'"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L16-L17"
-          />
-
-          <ComponentCard
-            component={<ui.Badge variant="outline">Outline Badge</ui.Badge>}
-            title="Outline"
-            metadata="variant='outline'"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L19-L20"
-          />
-
-          <ComponentCard
-            component={<ui.Badge variant="outline-muted">Outline Muted</ui.Badge>}
-            title="Outline Muted"
-            metadata="variant='outline-muted'"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L21-L22"
-          />
-
-          <ComponentCard
-            component={<ui.Badge variant="warning">Warning Badge</ui.Badge>}
-            title="Warning"
-            metadata="variant='warning'"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L23-L24"
-          />
-
-          <ComponentCard
-            component={<ui.Badge variant="success">Success Badge</ui.Badge>}
-            title="Success"
-            metadata="variant='success'"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L25-L26"
-          />
-
-          <ComponentCard
-            component={<ui.Badge variant="mono-dark">Mono Dark</ui.Badge>}
-            title="Mono Dark"
-            metadata="variant='mono-dark'"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L27-L28"
-          />
-
-          <ComponentCard
-            component={<ui.Badge variant="mono-light">Mono Light</ui.Badge>}
-            title="Mono Light"
-            metadata="variant='mono-light'"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L29-L30"
-          />
-        </ComponentSection>
-
-        {/* Submission Version Badge - Default Variant */}
-        <ComponentSection id="submission-badge-default" title="Submission Version Badge - Default">
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'draft',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={false}
-                variant="default"
-              />
-            }
-            title="Draft"
-            metadata="status='draft' variant='default' showLink=false"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'submitted',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={false}
-                variant="default"
-              />
-            }
-            title="Under Review"
-            metadata="status='submitted' variant='default' showLink=false"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'published',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={false}
-                variant="default"
-              />
-            }
-            title="Published"
-            metadata="status='published' variant='default' showLink=false"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'rejected',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={false}
-                variant="default"
-              />
-            }
-            title="Rejected"
-            metadata="status='rejected' variant='default' showLink=false"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'revision-required',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={false}
-                variant="default"
-              />
-            }
-            title="Revision Required"
-            metadata="status='revision-required' variant='default' showLink=false"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx"
-          />
-        </ComponentSection>
-
-        {/* Submission Version Badge - Outline Variant */}
-        <ComponentSection id="submission-badge-outline" title="Submission Version Badge - Outline">
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'draft',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={false}
-                variant="outline"
-              />
-            }
-            title="Draft"
-            metadata="status='draft' variant='outline' showLink=false"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L65-L84"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'submitted',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={false}
-                variant="outline"
-              />
-            }
-            title="Under Review"
-            metadata="status='submitted' variant='outline' showLink=false"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L65-L84"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'published',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={false}
-                variant="outline"
-              />
-            }
-            title="Published"
-            metadata="status='published' variant='outline' showLink=false"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L65-L84"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'rejected',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={false}
-                variant="outline"
-              />
-            }
-            title="Rejected"
-            metadata="status='rejected' variant='outline' showLink=false"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L65-L84"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'revision-required',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={false}
-                variant="outline"
-              />
-            }
-            title="Revision Required"
-            metadata="status='revision-required' variant='outline' showLink=false"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L65-L84"
-          />
-        </ComponentSection>
-
-        {/* Submission Version Badge - With Link (Default) */}
-        <ComponentSection
-          id="submission-badge-with-link-default"
-          title="Submission Version Badge - With Link (Default)"
-          note="These components have hover effects when you interact with them."
-        >
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'draft',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={true}
-                variant="default"
-              />
-            }
-            title="Draft"
-            metadata="status='draft' variant='default' showLink=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'submitted',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={true}
-                variant="default"
-              />
-            }
-            title="Under Review"
-            metadata="status='submitted' variant='default' showLink=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'published',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={true}
-                variant="default"
-              />
-            }
-            title="Published"
-            metadata="status='published' variant='default' showLink=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'rejected',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={true}
-                variant="default"
-              />
-            }
-            title="Rejected"
-            metadata="status='rejected' variant='default' showLink=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'revision-required',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={true}
-                variant="default"
-              />
-            }
-            title="Revision Required"
-            metadata="status='revision-required' variant='default' showLink=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
-          />
-        </ComponentSection>
-
-        {/* Submission Version Badge - With Link (Outline) */}
-        <ComponentSection
-          id="submission-badge-with-link-outline"
-          title="Submission Version Badge - With Link (Outline)"
-          note="These components have hover effects when you interact with them."
-        >
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'draft',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={true}
-                variant="outline"
-              />
-            }
-            title="Draft"
-            metadata="status='draft' variant='outline' showLink=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'submitted',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={true}
-                variant="outline"
-              />
-            }
-            title="Under Review"
-            metadata="status='submitted' variant='outline' showLink=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'published',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={true}
-                variant="outline"
-              />
-            }
-            title="Published"
-            metadata="status='published' variant='outline' showLink=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'rejected',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={true}
-                variant="outline"
-              />
-            }
-            title="Rejected"
-            metadata="status='rejected' variant='outline' showLink=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'revision-required',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showLink={true}
-                variant="outline"
-              />
-            }
-            title="Revision Required"
-            metadata="status='revision-required' variant='outline' showLink=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
-          />
-        </ComponentSection>
-
-        {/* Submission Version Badge - With Site (Default) */}
-        <ComponentSection
-          id="submission-badge-with-site-default"
-          title="Submission Version Badge - With Site (Default)"
-          note="These components have hover effects when you interact with them."
-        >
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'draft',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showSite={true}
-                variant="default"
-              />
-            }
-            title="Draft"
-            metadata="status='draft' variant='default' showSite=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'submitted',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showSite={true}
-                variant="default"
-              />
-            }
-            title="Under Review"
-            metadata="status='submitted' variant='default' showSite=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'published',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showSite={true}
-                variant="default"
-              />
-            }
-            title="Published"
-            metadata="status='published' variant='default' showSite=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'rejected',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showSite={true}
-                variant="default"
-              />
-            }
-            title="Rejected"
-            metadata="status='rejected' variant='default' showSite=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'revision-required',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showSite={true}
-                variant="default"
-              />
-            }
-            title="Revision Required"
-            metadata="status='revision-required' variant='default' showSite=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
-          />
-        </ComponentSection>
-
-        {/* Submission Version Badge - With Site (Outline) */}
-        <ComponentSection
-          id="submission-badge-with-site-outline"
-          title="Submission Version Badge - With Site (Outline)"
-          note="These components have hover effects when you interact with them."
-        >
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'draft',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showSite={true}
-                variant="outline"
-              />
-            }
-            title="Draft"
-            metadata="status='draft' variant='outline' showSite=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'submitted',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showSite={true}
-                variant="outline"
-              />
-            }
-            title="Under Review"
-            metadata="status='submitted' variant='outline' showSite=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'published',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showSite={true}
-                variant="outline"
-              />
-            }
-            title="Published"
-            metadata="status='published' variant='outline' showSite=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'rejected',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showSite={true}
-                variant="outline"
-              />
-            }
-            title="Rejected"
-            metadata="status='rejected' variant='outline' showSite=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
-          />
-
-          <ComponentCard
-            component={
-              <ui.SubmissionVersionBadge
-                submissionVersion={{
-                  ...mockSubmissionVersion,
-                  status: 'revision-required',
-                }}
-                workflows={mockWorkflows}
-                basePath="/app"
-                workVersionId="wv-123"
-                showSite={true}
-                variant="outline"
-              />
-            }
-            title="Revision Required"
-            metadata="status='revision-required' variant='outline' showSite=true"
-            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
-          />
-        </ComponentSection>
-      </div>
+        <ui.TabsContent value="core" className="mt-6">
+          <CoreDesigns />
+        </ui.TabsContent>
+        {extensionTabs.map((tab) => (
+          <ui.TabsContent key={tab.id} value={tab.id} className="mt-6">
+            <tab.Component />
+          </ui.TabsContent>
+        ))}
+      </ui.Tabs>
     </PageFrame>
+  );
+}
+
+function CoreDesigns() {
+  return (
+    <div className="space-y-12">
+      <TableOfContents />
+
+      {/* Toast Section */}
+      <ComponentSection id="toast" title="Toast">
+        <ComponentCard
+          component={
+            <ui.Button
+              onClick={() =>
+                ui.toastInfo('This is an info message', {
+                  description: 'Additional details about the information',
+                })
+              }
+              variant="outline"
+            >
+              Show Info Toast
+            </ui.Button>
+          }
+          title="Info"
+          metadata="toastInfo(message, options)"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/toast.tsx"
+        />
+
+        <ComponentCard
+          component={
+            <ui.Button
+              onClick={() =>
+                ui.toastSuccess('Operation completed successfully!', {
+                  description: 'Your changes have been saved',
+                })
+              }
+              variant="outline"
+              className="text-green-700 border-green-200 hover:bg-green-50 dark:border-green-800 dark:text-green-400 dark:hover:bg-green-950"
+            >
+              Show Success Toast
+            </ui.Button>
+          }
+          title="Success"
+          metadata="toastSuccess(message, options)"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/toast.tsx"
+        />
+
+        <ComponentCard
+          component={
+            <ui.Button
+              onClick={() =>
+                ui.toastWarning('Please check your input', {
+                  description: 'Some fields require your attention',
+                })
+              }
+              variant="outline"
+              className="text-yellow-700 border-yellow-200 hover:bg-yellow-50 dark:border-yellow-800 dark:text-yellow-400 dark:hover:bg-yellow-950"
+            >
+              Show Warning Toast
+            </ui.Button>
+          }
+          title="Warning"
+          metadata="toastWarning(message, options)"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/toast.tsx"
+        />
+
+        <ComponentCard
+          component={
+            <ui.Button
+              onClick={() =>
+                ui.toastError('Something went wrong', {
+                  description: 'Please try again later or contact support',
+                })
+              }
+              variant="outline"
+              className="text-red-700 border-red-200 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950"
+            >
+              Show Error Toast
+            </ui.Button>
+          }
+          title="Error"
+          metadata="toastError(message, options)"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/toast.tsx"
+        />
+      </ComponentSection>
+
+      {/* Simple Alerts Section */}
+      <div className="mb-12" id="simple-alerts">
+        <h2 className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">Simple Alerts</h2>
+        <div className="grid max-w-2xl grid-cols-1 gap-4">
+          <ComponentCard
+            component={
+              <ui.SimpleAlert
+                type="info"
+                size="compact"
+                message="This is an informational message to provide context about an action."
+              />
+            }
+            title="Info (Compact)"
+            metadata='type="info" size="compact"'
+            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SimpleAlert.tsx"
+          />
+
+          <ComponentCard
+            component={
+              <ui.SimpleAlert
+                type="success"
+                size="compact"
+                message="Operation completed successfully! Your changes have been saved."
+              />
+            }
+            title="Success (Compact)"
+            metadata='type="success" size="compact"'
+            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SimpleAlert.tsx"
+          />
+
+          <ComponentCard
+            component={
+              <ui.SimpleAlert
+                type="warning"
+                size="compact"
+                message="Please review your input. Some fields may require attention."
+              />
+            }
+            title="Warning (Compact)"
+            metadata='type="warning" size="compact"'
+            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SimpleAlert.tsx"
+          />
+
+          <ComponentCard
+            component={
+              <ui.SimpleAlert
+                type="error"
+                size="compact"
+                message="An error occurred while processing your request. Please try again."
+              />
+            }
+            title="Error (Compact)"
+            metadata='type="error" size="compact"'
+            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SimpleAlert.tsx"
+          />
+
+          <ComponentCard
+            component={
+              <ui.SimpleAlert
+                type="neutral"
+                size="normal"
+                message="This is a neutral message that provides general information."
+              />
+            }
+            title="Neutral (Normal)"
+            metadata='type="neutral" size="normal"'
+            sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SimpleAlert.tsx"
+          />
+        </div>
+      </div>
+
+      {/* Chips Section */}
+      <ComponentSection id="chips" title="Chips">
+        <ComponentCard
+          component={
+            <primitives.Chip className="text-stone-800 dark:text-white dark:bg-stone-500 bg-stone-200">
+              Default Chip
+            </primitives.Chip>
+          }
+          title="Default"
+          metadata="text-stone-800 dark:text-white dark:bg-stone-500 bg-stone-200"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/primitives/Chip.tsx"
+        />
+
+        <ComponentCard
+          component={
+            <primitives.Chip className="text-white bg-green-600">Published</primitives.Chip>
+          }
+          title="Published"
+          metadata="text-white bg-green-600"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/ee/sites/src/components/Chips.tsx#L6-L19"
+        />
+
+        <ComponentCard
+          component={
+            <primitives.Chip className="text-white bg-red-800 dark:bg-red-500">
+              Retracted
+            </primitives.Chip>
+          }
+          title="Retracted"
+          metadata="text-white bg-red-800 dark:bg-red-500"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/ee/sites/src/components/Chips.tsx#L21-L32"
+        />
+
+        <ComponentCard
+          component={
+            <primitives.Chip className="text-white bg-sky-600 border-[1px] border-sky-600 dark:border-sky-600 dark:bg-sky-600">
+              my-article-slug
+            </primitives.Chip>
+          }
+          title="Slug"
+          metadata="text-white bg-sky-600 border-[1px] border-sky-600"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/ee/sites/src/components/Chips.tsx#L34-L44"
+        />
+
+        <ComponentCard
+          component={
+            <primitives.Chip className="text-sky-700 border-[1px] border-sky-700 dark:border-sky-300 dark:text-sky-300">
+              Research Article
+            </primitives.Chip>
+          }
+          title="Submission Kind"
+          metadata="text-sky-700 border-[1px] border-sky-700 dark:border-sky-300 dark:text-sky-300"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/ee/sites/src/components/Chips.tsx#L66-L85"
+        />
+
+        <ComponentCard
+          component={
+            <primitives.Chip className="text-sky-700 border-[1px] border-sky-700 dark:border-sky-300 dark:text-sky-300">
+              Special Issue: AI Research
+            </primitives.Chip>
+          }
+          title="Collection"
+          metadata="text-sky-700 border-[1px] border-sky-700 dark:border-sky-300 dark:text-sky-300"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/ee/sites/src/components/Chips.tsx#L46-L64"
+        />
+
+        <ComponentCard
+          component={
+            <primitives.Chip className="text-black bg-gray-200 dark:bg-gray-600 dark:text-white">
+              3 days ago
+            </primitives.Chip>
+          }
+          title="Age"
+          metadata="text-black bg-gray-200 dark:bg-gray-600 dark:text-white"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/ee/sites/src/components/Chips.tsx#L87-L97"
+        />
+
+        <ComponentCard
+          component={
+            <primitives.Chip className="text-gray-500 border-[1px] border-gray-200 dark:border-gray-500 dark:text-gray-500">
+              2 weeks ago
+            </primitives.Chip>
+          }
+          title="Last Activity"
+          metadata="text-gray-500 border-[1px] border-gray-200 dark:border-gray-500"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/platform/scms/app/routes/app/works._index/WorkListItem.tsx#L137-L142"
+        />
+      </ComponentSection>
+
+      {/* Badge Section */}
+      <ComponentSection id="badge" title="Badge">
+        <ComponentCard
+          component={<ui.Badge>Default Badge</ui.Badge>}
+          title="Default"
+          metadata="variant='default'"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx"
+        />
+
+        <ComponentCard
+          component={<ui.Badge variant="primary">Primary Badge</ui.Badge>}
+          title="Primary"
+          metadata="variant='primary'"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L13"
+        />
+
+        <ComponentCard
+          component={<ui.Badge variant="secondary">Secondary Badge</ui.Badge>}
+          title="Secondary"
+          metadata="variant='secondary'"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L14-L15"
+        />
+
+        <ComponentCard
+          component={<ui.Badge variant="destructive">Destructive Badge</ui.Badge>}
+          title="Destructive"
+          metadata="variant='destructive'"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L16-L17"
+        />
+
+        <ComponentCard
+          component={<ui.Badge variant="outline">Outline Badge</ui.Badge>}
+          title="Outline"
+          metadata="variant='outline'"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L19-L20"
+        />
+
+        <ComponentCard
+          component={<ui.Badge variant="outline-muted">Outline Muted</ui.Badge>}
+          title="Outline Muted"
+          metadata="variant='outline-muted'"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L21-L22"
+        />
+
+        <ComponentCard
+          component={<ui.Badge variant="warning">Warning Badge</ui.Badge>}
+          title="Warning"
+          metadata="variant='warning'"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L23-L24"
+        />
+
+        <ComponentCard
+          component={<ui.Badge variant="success">Success Badge</ui.Badge>}
+          title="Success"
+          metadata="variant='success'"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L25-L26"
+        />
+
+        <ComponentCard
+          component={<ui.Badge variant="mono-dark">Mono Dark</ui.Badge>}
+          title="Mono Dark"
+          metadata="variant='mono-dark'"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L27-L28"
+        />
+
+        <ComponentCard
+          component={<ui.Badge variant="mono-light">Mono Light</ui.Badge>}
+          title="Mono Light"
+          metadata="variant='mono-light'"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/badge.tsx#L29-L30"
+        />
+      </ComponentSection>
+
+      {/* Submission Version Badge - Default Variant */}
+      <ComponentSection id="submission-badge-default" title="Submission Version Badge - Default">
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'draft',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={false}
+              variant="default"
+            />
+          }
+          title="Draft"
+          metadata="status='draft' variant='default' showLink=false"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'submitted',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={false}
+              variant="default"
+            />
+          }
+          title="Under Review"
+          metadata="status='submitted' variant='default' showLink=false"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'published',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={false}
+              variant="default"
+            />
+          }
+          title="Published"
+          metadata="status='published' variant='default' showLink=false"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'rejected',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={false}
+              variant="default"
+            />
+          }
+          title="Rejected"
+          metadata="status='rejected' variant='default' showLink=false"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'revision-required',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={false}
+              variant="default"
+            />
+          }
+          title="Revision Required"
+          metadata="status='revision-required' variant='default' showLink=false"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx"
+        />
+      </ComponentSection>
+
+      {/* Submission Version Badge - Outline Variant */}
+      <ComponentSection id="submission-badge-outline" title="Submission Version Badge - Outline">
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'draft',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={false}
+              variant="outline"
+            />
+          }
+          title="Draft"
+          metadata="status='draft' variant='outline' showLink=false"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L65-L84"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'submitted',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={false}
+              variant="outline"
+            />
+          }
+          title="Under Review"
+          metadata="status='submitted' variant='outline' showLink=false"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L65-L84"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'published',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={false}
+              variant="outline"
+            />
+          }
+          title="Published"
+          metadata="status='published' variant='outline' showLink=false"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L65-L84"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'rejected',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={false}
+              variant="outline"
+            />
+          }
+          title="Rejected"
+          metadata="status='rejected' variant='outline' showLink=false"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L65-L84"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'revision-required',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={false}
+              variant="outline"
+            />
+          }
+          title="Revision Required"
+          metadata="status='revision-required' variant='outline' showLink=false"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L65-L84"
+        />
+      </ComponentSection>
+
+      {/* Submission Version Badge - With Link (Default) */}
+      <ComponentSection
+        id="submission-badge-with-link-default"
+        title="Submission Version Badge - With Link (Default)"
+        note="These components have hover effects when you interact with them."
+      >
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'draft',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={true}
+              variant="default"
+            />
+          }
+          title="Draft"
+          metadata="status='draft' variant='default' showLink=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'submitted',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={true}
+              variant="default"
+            />
+          }
+          title="Under Review"
+          metadata="status='submitted' variant='default' showLink=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'published',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={true}
+              variant="default"
+            />
+          }
+          title="Published"
+          metadata="status='published' variant='default' showLink=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'rejected',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={true}
+              variant="default"
+            />
+          }
+          title="Rejected"
+          metadata="status='rejected' variant='default' showLink=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'revision-required',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={true}
+              variant="default"
+            />
+          }
+          title="Revision Required"
+          metadata="status='revision-required' variant='default' showLink=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
+        />
+      </ComponentSection>
+
+      {/* Submission Version Badge - With Link (Outline) */}
+      <ComponentSection
+        id="submission-badge-with-link-outline"
+        title="Submission Version Badge - With Link (Outline)"
+        note="These components have hover effects when you interact with them."
+      >
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'draft',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={true}
+              variant="outline"
+            />
+          }
+          title="Draft"
+          metadata="status='draft' variant='outline' showLink=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'submitted',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={true}
+              variant="outline"
+            />
+          }
+          title="Under Review"
+          metadata="status='submitted' variant='outline' showLink=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'published',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={true}
+              variant="outline"
+            />
+          }
+          title="Published"
+          metadata="status='published' variant='outline' showLink=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'rejected',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={true}
+              variant="outline"
+            />
+          }
+          title="Rejected"
+          metadata="status='rejected' variant='outline' showLink=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'revision-required',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showLink={true}
+              variant="outline"
+            />
+          }
+          title="Revision Required"
+          metadata="status='revision-required' variant='outline' showLink=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L115-L127"
+        />
+      </ComponentSection>
+
+      {/* Submission Version Badge - With Site (Default) */}
+      <ComponentSection
+        id="submission-badge-with-site-default"
+        title="Submission Version Badge - With Site (Default)"
+        note="These components have hover effects when you interact with them."
+      >
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'draft',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showSite={true}
+              variant="default"
+            />
+          }
+          title="Draft"
+          metadata="status='draft' variant='default' showSite=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'submitted',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showSite={true}
+              variant="default"
+            />
+          }
+          title="Under Review"
+          metadata="status='submitted' variant='default' showSite=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'published',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showSite={true}
+              variant="default"
+            />
+          }
+          title="Published"
+          metadata="status='published' variant='default' showSite=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'rejected',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showSite={true}
+              variant="default"
+            />
+          }
+          title="Rejected"
+          metadata="status='rejected' variant='default' showSite=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'revision-required',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showSite={true}
+              variant="default"
+            />
+          }
+          title="Revision Required"
+          metadata="status='revision-required' variant='default' showSite=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
+        />
+      </ComponentSection>
+
+      {/* Submission Version Badge - With Site (Outline) */}
+      <ComponentSection
+        id="submission-badge-with-site-outline"
+        title="Submission Version Badge - With Site (Outline)"
+        note="These components have hover effects when you interact with them."
+      >
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'draft',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showSite={true}
+              variant="outline"
+            />
+          }
+          title="Draft"
+          metadata="status='draft' variant='outline' showSite=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'submitted',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showSite={true}
+              variant="outline"
+            />
+          }
+          title="Under Review"
+          metadata="status='submitted' variant='outline' showSite=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'published',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showSite={true}
+              variant="outline"
+            />
+          }
+          title="Published"
+          metadata="status='published' variant='outline' showSite=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'rejected',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showSite={true}
+              variant="outline"
+            />
+          }
+          title="Rejected"
+          metadata="status='rejected' variant='outline' showSite=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
+        />
+
+        <ComponentCard
+          component={
+            <ui.SubmissionVersionBadge
+              submissionVersion={{
+                ...mockSubmissionVersion,
+                status: 'revision-required',
+              }}
+              workflows={mockWorkflows}
+              basePath="/app"
+              workVersionId="wv-123"
+              showSite={true}
+              variant="outline"
+            />
+          }
+          title="Revision Required"
+          metadata="status='revision-required' variant='outline' showSite=true"
+          sourceUrl="https://github.com/curvenote/curvenote/blob/dev/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx#L89-L101"
+        />
+      </ComponentSection>
+    </div>
   );
 }

--- a/platform/scms/app/routes/app/works._index/route.tsx
+++ b/platform/scms/app/routes/app/works._index/route.tsx
@@ -10,7 +10,6 @@ import {
   MainWrapper,
   PageFrame,
   FrameHeader,
-  ui,
   getBrandingFromMetaMatches,
   joinPageTitle,
   getWorkflows,
@@ -223,6 +222,7 @@ export default function MyWorks({ loaderData }: Route.ComponentProps) {
           header={
             <FrameHeader
               className="max-w-4xl"
+              actionAlign="right"
               title="My Works"
               subtitle="Manage your works and submissions"
               actionLabel="Create new work"


### PR DESCRIPTION
Adds extension specific components to the system.design page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily UI/extension-surface changes, but `FrameHeader` layout behavior changes for existing callers unless they opt into `actionAlign="right"`, which could cause visual regressions across pages that use header actions.
> 
> **Overview**
> The system Design page is refactored into a tabbed view: **Core** remains the default, and each enabled extension can now contribute its own Design tab via a new optional `ClientExtension.getDesigns()` component.
> 
> `FrameHeader` gains an `actionAlign` prop to control whether the header action stays inline or is pushed to the right; the My Works page opts into right alignment for its “Create new work” button. The PR also includes the corresponding patch changeset and minor `package-lock.json` dependency updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 576fca85a9e7bd51528b9ae9fdd7fd7034c1bb58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->