### PR TITLE
🦄 add caching on service logos

### DIFF
--- a/.changeset/brown-ties-design.md
+++ b/.changeset/brown-ties-design.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/check-relay': patch
+---
+
+Add aggresive caching on logos

--- a/platform/relay/app/app.ts
+++ b/platform/relay/app/app.ts
@@ -1,23 +1,37 @@
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { serveStatic } from "@hono/node-server/serve-static";
-import { Hono } from "hono";
-import { logger } from "hono/logger";
-import { isHttpAccessLoggingEnabled } from "./http-access-log.js";
-import { httpBodyLogger, isHttpBodyLoggingEnabled } from "./http-body-log.js";
-import { v1 } from "./routes/v1/index.js";
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { serveStatic } from '@hono/node-server/serve-static';
+import { Hono } from 'hono';
+import { logger } from 'hono/logger';
+import { isHttpAccessLoggingEnabled } from './http-access-log.js';
+import { httpBodyLogger, isHttpBodyLoggingEnabled } from './http-body-log.js';
+import { v1 } from './routes/v1/index.js';
 
 const app = new Hono({ strict: false });
 
 const relayAppDir = dirname(fileURLToPath(import.meta.url));
-const assetsRoot = join(relayAppDir, "..", "public", "assets");
+const assetsRoot = join(relayAppDir, '..', 'public', 'assets');
+
+// Plugin assets (e.g. service logos) are mirrored at build time and rarely change,
+// so we instruct browsers and shared caches/CDNs to hold onto them for 7 days.
+const ASSETS_CACHE_MAX_AGE_SECONDS = 60 * 60 * 24 * 7;
+const ASSETS_CACHE_CONTROL = `public, max-age=${ASSETS_CACHE_MAX_AGE_SECONDS}, s-maxage=${ASSETS_CACHE_MAX_AGE_SECONDS}`;
+
+app.use('/api/assets/*', async (c, next) => {
+  await next();
+  // Only attach the cache header to successful asset responses; if the file
+  // isn't found, serveStatic falls through to the 404 handler and we leave
+  // those responses uncached.
+  if (c.res.status === 200 || c.res.status === 206) {
+    c.res.headers.set('Cache-Control', ASSETS_CACHE_CONTROL);
+  }
+});
 
 app.use(
-  "/api/assets/*",
+  '/api/assets/*',
   serveStatic({
     root: assetsRoot,
-    rewriteRequestPath: (path) =>
-      path.replace(/^\/api\/assets\/?/, "").replace(/^\//, "") || ".",
+    rewriteRequestPath: (path) => path.replace(/^\/api\/assets\/?/, '').replace(/^\//, '') || '.',
   }),
 );
 
@@ -28,8 +42,8 @@ if (isHttpBodyLoggingEnabled()) {
   app.use(httpBodyLogger);
 }
 
-app.get("/", (c) => c.redirect("/api/v1", 302));
+app.get('/', (c) => c.redirect('/api/v1', 302));
 
-app.route("/api/v1", v1);
+app.route('/api/v1', v1);
 
 export { app };

--- a/platform/relay/tests/app.test.ts
+++ b/platform/relay/tests/app.test.ts
@@ -38,6 +38,17 @@ describe("relay app", () => {
     expect(text).toContain("<svg");
   });
 
+  it("GET /api/assets/:service/logo.svg sets a long-lived Cache-Control header", async () => {
+    const res = await app.request("/api/assets/echo/logo.svg");
+    expect(res.status).toBe(200);
+    const cacheControl = res.headers.get("cache-control");
+    expect(cacheControl).toBeTruthy();
+    expect(cacheControl).toContain("public");
+    // 7 days = 604800 seconds
+    expect(cacheControl).toMatch(/max-age=604800/);
+    expect(cacheControl).toMatch(/s-maxage=604800/);
+  });
+
   it("GET /assets/:service/logo.svg is not served (use /api/assets for Vercel)", async () => {
     const res = await app.request("/assets/echo/logo.svg");
     expect(res.status).toBe(404);


### PR DESCRIPTION
Service logos rarely change but are served to clients regularly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds `Cache-Control` headers on successful static asset responses, with no changes to auth or data handling; main risk is stale logo updates being cached for up to 7 days.
> 
> **Overview**
> Adds aggressive caching for plugin/service logo assets served from `GET /api/assets/*` by setting `Cache-Control: public, max-age=604800, s-maxage=604800` on 200/206 responses (leaving 404s uncached).
> 
> Updates tests to assert the new caching header behavior, and includes a patch changeset for `@curvenote/check-relay`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a5a564054b7fc5bd47de7d6f38f45c7d505d0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->