### PR TITLE
🔗 relay client-side API changes

### DIFF
--- a/packages/check-plugin-types/package.json
+++ b/packages/check-plugin-types/package.json
@@ -16,6 +16,9 @@
     "build": "rm -rf dist && tsc",
     "lint": "eslint \"src/**/*.ts\" -c ./.eslintrc.cjs"
   },
+  "dependencies": {
+    "@curvenote/check-relay-types": "*"
+  },
   "devDependencies": {
     "typescript": "^5.7.0"
   }

--- a/packages/check-plugin-types/src/plugin.ts
+++ b/packages/check-plugin-types/src/plugin.ts
@@ -4,6 +4,7 @@
  * These are intentionally separated from client-facing API/notify contracts.
  */
 
+import type { RelayCheckStatusResponse } from '@curvenote/check-relay-types';
 import type { PluginUploadPayload, SubmitManuscriptFile } from './relay.js';
 
 // ── JSON ──
@@ -217,12 +218,15 @@ export interface ServicePlugin {
 
   /**
    * Check-scoped methods take **`externalId`** (same value as the URL segment and client `externalId`).
+   *
+   * Returns **`RelayCheckStatusResponse`** — ordered notify envelopes (same JSON relay POSTs to `notify_url`).
+   * Return **`null`** only for legacy adapters; preferred: `{ envelopes: [] }` when there is nothing new.
    */
   getCheckStatus(
     credentials: Record<string, unknown>,
     externalId: string,
     body: Record<string, unknown>,
-  ): Promise<PluginOperationResult | null>;
+  ): Promise<RelayCheckStatusResponse | null>;
 
   getReportViewerUrl(
     credentials: Record<string, unknown>,

--- a/packages/check-relay-plugin-echo/package.json
+++ b/packages/check-relay-plugin-echo/package.json
@@ -17,7 +17,8 @@
     "lint": "eslint \"src/**/*.ts\" -c ./.eslintrc.cjs"
   },
   "dependencies": {
-    "@curvenote/check-plugin-types": "*"
+    "@curvenote/check-plugin-types": "*",
+    "@curvenote/check-relay-types": "*"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/packages/check-relay-plugin-echo/src/index.ts
+++ b/packages/check-relay-plugin-echo/src/index.ts
@@ -10,6 +10,7 @@ import {
   type WebhookVerifyRequest,
   type PluginUploadPayload,
 } from '@curvenote/check-plugin-types';
+import type { RelayCheckStatusResponse } from '@curvenote/check-relay-types';
 
 const ECHO_OPERATIONS = [
   'instanceStatus',
@@ -98,8 +99,8 @@ const echoPlugin: ServicePlugin = {
     _credentials: Record<string, unknown>,
     _externalId: string,
     _body: Record<string, unknown>,
-  ): Promise<PluginOperationResult | null> {
-    return null;
+  ): Promise<RelayCheckStatusResponse | null> {
+    return { envelopes: [] };
   },
 
   async getReportViewerUrl(

--- a/packages/check-relay-types/package.json
+++ b/packages/check-relay-types/package.json
@@ -16,9 +16,7 @@
     "build": "rm -rf dist && tsc",
     "lint": "eslint \"src/**/*.ts\" -c ./.eslintrc.cjs"
   },
-  "dependencies": {
-    "@curvenote/check-plugin-types": "*"
-  },
+  "dependencies": {},
   "devDependencies": {
     "typescript": "^5.7.0"
   }

--- a/packages/check-relay-types/src/api.ts
+++ b/packages/check-relay-types/src/api.ts
@@ -4,7 +4,8 @@
  * These are standard across plugins; plugin-specific options belong under `metadata`.
  */
 
-import type { PluginStatus } from "@curvenote/check-plugin-types";
+/** Mirrors @curvenote/check-plugin-types PluginStatus — kept local to avoid circular package deps */
+export type PluginStatus = 'submitted' | 'processing' | 'completed' | 'failed' | 'error';
 
 /**
  * Standard upload request body sent by clients to checks-relay (wire shape).

--- a/packages/check-relay-types/src/index.ts
+++ b/packages/check-relay-types/src/index.ts
@@ -1,4 +1,5 @@
 export type {
+  PluginStatus,
   RelayUploadRequestBodyWire,
   ServiceListItem,
   ServiceDetailResponse,
@@ -17,8 +18,12 @@ export type {
   ProcessingPhaseFailedPayload,
   ProcessingPhaseName,
   ProcessingPhaseStartedPayload,
+  SimilarityReportWire,
+  SimilarityTopMatchWire,
   UploadAcceptedPayload,
   UploadCompletePayload,
   UploadFailedPayload,
   UploadPendingPayload,
 } from "./notify.js";
+
+export type { RelayCheckStatusResponse } from "./status.js";

--- a/packages/check-relay-types/src/notify.ts
+++ b/packages/check-relay-types/src/notify.ts
@@ -74,17 +74,46 @@ export type UploadFailedPayload = {
 };
 
 /**
- * Processing phases are plugin-dependent and may repeat.
- * Examples: "upload_and_similarity", "queue_similarity", "fetch_report".
+ * Plugin-local names for **`POST …/trigger-stage`** request bodies only (relay routing).
+ * Not used on notify envelopes — distinguish workflow steps via {@link NotifyEventName}.
  */
 export type ProcessingPhaseName = string;
 
+/** Canonical similarity top match (snake_case wire — vendor-neutral). */
+export interface SimilarityTopMatchWire {
+  percentage: number;
+  submission_id?: string;
+  source_type: string;
+  matched_word_count_total: number;
+  submitted_date?: string;
+  institution_name?: string;
+  name: string;
+}
+
+/**
+ * Canonical similarity report snapshot (snake_case wire).
+ * Maps any vendor’s similarity outcome into one SCMS-facing shape.
+ */
+export interface SimilarityReportWire {
+  submission_id: string;
+  overall_match_percentage: number;
+  internet_match_percentage?: number | null;
+  publication_match_percentage?: number | null;
+  submitted_works_match_percentage?: number | null;
+  status: 'PROCESSING' | 'COMPLETE';
+  time_requested: string;
+  time_generated?: string;
+  top_source_largest_matched_word_count?: number;
+  top_matches?: SimilarityTopMatchWire[];
+}
+
 export interface ProcessingPhasePayloadBase {
-  /** Name of the processing phase (plugin-defined, stable string). */
-  phase: ProcessingPhaseName;
   /**
-   * Provider payload or a safely-redacted subset relevant to this phase.
-   * Optional; include when it helps debugging without leaking secrets.
+   * Similarity report when this phase completes with similarity data (preferred over legacy blobs).
+   */
+  similarity_report?: SimilarityReportWire;
+  /**
+   * @deprecated Prefer {@link similarity_report}. Raw vendor JSON must not be required by SCMS.
    */
   provider_payload?: Record<string, unknown>;
   /**

--- a/packages/check-relay-types/src/status.ts
+++ b/packages/check-relay-types/src/status.ts
@@ -1,0 +1,11 @@
+import type { RelayNotifyEnvelope } from './notify.js';
+
+/**
+ * Response body for `POST …/check/:externalId/status`.
+ *
+ * Uses the **same JSON objects** relay would POST to the client `notify_url`, so SCMS can apply
+ * identical handlers as ingest notify — possibly empty when there is nothing new to report.
+ */
+export interface RelayCheckStatusResponse {
+  envelopes: RelayNotifyEnvelope[];
+}

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -106,6 +106,11 @@ export type ExtensionCheckSectionActivityProps = {
   /** POST target for check UI mutations (extension-owned route or legacy work checks path). */
   remoteStatusActionPath?: string;
   /**
+   * ISO timestamp from **check_service_run.date_modified** when displaying an existing run.
+   * Extensions may use this (vs mount timers) to decide when to offer refresh / stale hints.
+   */
+  checkRunDateModified?: string;
+  /**
    * When true, this check run's UI should be expanded/open by default on initial render.
    * Used for one-shot behaviours such as hydrating remote status on work details load.
    * Omitted on routes that do not compute it (treated as false).

--- a/platform/relay/app/routes/v1/services.instances.check.status.ts
+++ b/platform/relay/app/routes/v1/services.instances.check.status.ts
@@ -34,7 +34,10 @@ export async function checkStatusPost(c: Context) {
       externalId,
       rest,
     );
-    return c.json(result ?? { status: "unknown", result: null });
+    if (result == null) {
+      return c.json({ envelopes: [] });
+    }
+    return c.json(result);
   } catch (error) {
     return c.json(
       {

--- a/platform/relay/app/test-plugin.ts
+++ b/platform/relay/app/test-plugin.ts
@@ -45,7 +45,7 @@ export function makeTestPlugin(
       status: "submitted",
       result: { externalId: `ext-${payload.clientId ?? "123"}` },
     }),
-    getCheckStatus: async () => null,
+    getCheckStatus: async () => ({ envelopes: [] }),
     getReportViewerUrl: async () => NI,
     getCheckArtifacts: async () => NI,
     startReportGeneration: async () => ({

--- a/platform/relay/docs/api-reference.md
+++ b/platform/relay/docs/api-reference.md
@@ -321,9 +321,9 @@ The relay sends `POST` requests to the `notifyUrl` you provided in `POST /api/v1
 | `UPLOAD_ACCEPTED`            | `{ "upload_status": "ACCEPTED" }`                                | Provider accepted the manuscript (e.g. submission-complete without error) |
 | `UPLOAD_COMPLETE`            | `{ "upload_status": "COMPLETE" }`                                | Provider signaled completion for this status update (generic fallback)    |
 | `UPLOAD_FAILED`              | `{ "upload_status": "ERROR", "error_code?", "error_message?" }`  | Submission / ingest failed (upload lane, not report phases)               |
-| `PROCESSING_PHASE_STARTED`   | `{ "phase": "<phase>", "started": true }`                        | A named processing phase began                                            |
-| `PROCESSING_PHASE_COMPLETE`  | `{ "phase": "<phase>", "completed": true, "provider_payload?" }` | Phase finished                                                            |
-| `PROCESSING_PHASE_FAILED`    | `{ "phase": "<phase>", "failed": true, "error_message?" }`       | Phase failed                                                              |
+| `PROCESSING_PHASE_STARTED`   | `{ "started": true }`                                              | Processing phase began (semantic detail via event name / extension state) |
+| `PROCESSING_PHASE_COMPLETE`  | `{ "completed": true, "similarity_report?", "provider_payload?" }` | Phase finished                                                            |
+| `PROCESSING_PHASE_FAILED`    | `{ "failed": true, "error_code?", "error_message?" }`             | Phase failed                                                              |
 | `REPORT_GENERATION_STARTED`  | `{ "status": "PROCESSING", "report?" }`                          | Report generation began                                                   |
 | `REPORT_GENERATION_COMPLETE` | `{ "status": "SUCCESS", "report?" }`                             | Report ready                                                              |
 | `REPORT_GENERATION_FAILED`   | `{ "status": "FAILED", "error_message?" }`                       | Report generation failed                                                  |

--- a/platform/relay/docs/plugin-interface.md
+++ b/platform/relay/docs/plugin-interface.md
@@ -149,7 +149,7 @@ All take **`externalId: string`** (same value as the URL segment **`externalId`*
 
 | Method                   | Returns                         | Notes                                                                                             |
 | ------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `getCheckStatus`         | `PluginOperationResult \| null` | Relay JSON-defaults if `null`.                                                                    |
+| `getCheckStatus`         | `RelayCheckStatusResponse \| null` | **`RelayCheckStatusResponse`** = `{ envelopes: RelayNotifyEnvelope[] }` — same JSON relay POSTs to `notify_url`. Relay defaults missing/`null` to `{ envelopes: [] }`. |
 | `getReportViewerUrl`     | `PluginOperationResult`         |                                                                                                   |
 | `getCheckArtifacts`      | `PluginOperationResult`         |                                                                                                   |
 | `triggerProcessingStage` | `PluginOperationResult`         | Relay requires **`phase`** (non-empty string). Use for stages not driven only by ingest webhooks. |

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -287,6 +287,7 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
                       workVersionId={workVersionIdForActivity}
                       checkRunId={latest?.run.id}
                       remoteStatusActionPath={service.checksActionPath ?? `${basePath}/checks`}
+                      checkRunDateModified={latest?.run.date_modified}
                     />
                   </ui.CardContent>
                 </ui.Card>

--- a/platform/scms/app/routes/app/works.$workId.details/timeline/CheckServiceRunTimelineItem.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/timeline/CheckServiceRunTimelineItem.tsx
@@ -69,6 +69,7 @@ export function CheckServiceRunTimelineItem({
           workVersionId={run.work_version_id}
           checkRunId={run.id}
           remoteStatusActionPath={checksActionPath}
+          checkRunDateModified={run.date_modified}
         />
       </div>
     );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the wire/TypeScript contract for `getCheckStatus` and the status endpoint response shape, which can break existing plugins/clients expecting the old `{status,result}` format.
> 
> **Overview**
> **Polling status now returns notify envelopes.** `ServicePlugin.getCheckStatus` is retyped to return `RelayCheckStatusResponse` (`{ envelopes: RelayNotifyEnvelope[] }`), and the relay route defaults `null` to `{ envelopes: [] }` (echo/test plugins updated accordingly).
> 
> **Types are decoupled and extended.** `@curvenote/check-relay-types` removes its dependency on `check-plugin-types` (local `PluginStatus`), adds `RelayCheckStatusResponse`, and extends notify payload typing with canonical `SimilarityReportWire`/`SimilarityTopMatchWire` plus a `similarity_report` field on processing phase payloads.
> 
> **Docs/UI plumbing updates.** API/plugin docs reflect the new status/notify payload shapes, and SCMS extension activity components now receive an optional `checkRunDateModified` timestamp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cee0a0ebf4051d929db959b18ac131edc5d03350. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->