### PR TITLE
🧍🏼‍♀️ Adding MEMBER site role, remapped SUBMITTER, removed REVIEWER and AUTHOR

### DIFF
--- a/.changeset/easy-apes-grow.md
+++ b/.changeset/easy-apes-grow.md
@@ -1,0 +1,7 @@
+---
+'@curvenote/scms-server': minor
+'@curvenote/scms': minor
+'@curvenote/scms-sites-ext': minor
+---
+
+Removed redundant REVIEWER and AUTHOR site roles

--- a/.changeset/tricky-eggs-join.md
+++ b/.changeset/tricky-eggs-join.md
@@ -1,0 +1,7 @@
+---
+'@curvenote/scms-server': minor
+'@curvenote/scms': minor
+'@curvenote/scms-sites-ext': minor
+---
+
+Adding MEMBER site role and moving SUBMITTER to a more restricted scope set only allowing new submissions and submission updates

--- a/ee/sites/src/routes/$siteName.users/SiteRolesForm.tsx
+++ b/ee/sites/src/routes/$siteName.users/SiteRolesForm.tsx
@@ -2,10 +2,23 @@ import { useFetcher } from 'react-router';
 import { ui, type GeneralError } from '@curvenote/scms-core';
 import { useRef, useState, useCallback, useEffect } from 'react';
 
+type GrantSiteRole = 'ADMIN' | 'MEMBER' | 'SUBMITTER';
+
+const ROLE_DESCRIPTIONS: Record<GrantSiteRole, string> = {
+  ADMIN: 'Full access: manage site settings, users, submissions and publishing.',
+  MEMBER:
+    'Site/Lab Member: Can browse the site, kinds, collections, and submissions, and create new and update existig submissions. Members cannot publish submissions.',
+  SUBMITTER:
+    'Submit only: Can start new and update existing submissions on sites with restricted submissions. People with this role cannot list or view submissions or other site settings.',
+};
+
 export function SiteRolesForm({ canGrantAdminRole }: { canGrantAdminRole: boolean }) {
   const form = useRef<HTMLFormElement>(null);
   const fetcher = useFetcher<{ error?: GeneralError; message?: string; info?: string }>();
   const [selectedUser, setSelectedUser] = useState<string>('');
+  const [selectedRole, setSelectedRole] = useState<GrantSiteRole>(() =>
+    canGrantAdminRole ? 'ADMIN' : 'MEMBER',
+  );
 
   // Handle toast notifications
   useEffect(() => {
@@ -20,10 +33,11 @@ export function SiteRolesForm({ canGrantAdminRole }: { canGrantAdminRole: boolea
         ui.toastSuccess(fetcher.data.info);
         // Reset form on success
         setSelectedUser('');
+        setSelectedRole(canGrantAdminRole ? 'ADMIN' : 'MEMBER');
         form.current?.reset();
       }
     }
-  }, [fetcher.state, fetcher.data]);
+  }, [fetcher.state, fetcher.data, canGrantAdminRole]);
 
   // Search function for AsyncComboBox using plain fetch
   const searchUsers = useCallback(async (query: string): Promise<ui.ComboBoxOption[]> => {
@@ -98,8 +112,30 @@ export function SiteRolesForm({ canGrantAdminRole }: { canGrantAdminRole: boolea
         <h3 className="font-medium text-md">Add a New User or Grant a Role</h3>
       </div>
 
-      {/* Single row layout on md+ breakpoints */}
+      {/* Role first (left), user search, then Grant */}
       <div className="flex flex-col gap-4 md:flex-row md:items-end">
+        <div className="flex-none md:min-w-[220px]">
+          <label
+            htmlFor="invite.role"
+            className="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            Role
+          </label>
+          <select
+            className="px-3 py-2 w-full text-sm bg-white rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
+            id="invite.role"
+            name="role"
+            required
+            disabled={fetcher.state === 'submitting'}
+            value={selectedRole}
+            onChange={(e) => setSelectedRole(e.target.value as GrantSiteRole)}
+          >
+            {canGrantAdminRole && <option value="ADMIN">Admin</option>}
+            <option value="MEMBER">Member</option>
+            <option value="SUBMITTER">Submitter</option>
+          </select>
+        </div>
+
         <div className="flex-1">
           <label className="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">
             Search User
@@ -118,25 +154,6 @@ export function SiteRolesForm({ canGrantAdminRole }: { canGrantAdminRole: boolea
           />
         </div>
 
-        <div className="flex-none md:min-w-[200px]">
-          <label
-            htmlFor="invite.role"
-            className="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-300"
-          >
-            Role
-          </label>
-          <select
-            className="px-3 py-2 w-full text-sm bg-white rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
-            id="invite.role"
-            name="role"
-            required
-            disabled={fetcher.state === 'submitting'}
-          >
-            {canGrantAdminRole && <option value="ADMIN">Admin</option>}
-            <option value="SUBMITTER">Submitter</option>
-          </select>
-        </div>
-
         <div className="flex-none pb-[1px]">
           <ui.StatefulButton
             type="submit"
@@ -148,6 +165,8 @@ export function SiteRolesForm({ canGrantAdminRole }: { canGrantAdminRole: boolea
           </ui.StatefulButton>
         </div>
       </div>
+
+      <div className="text-xs text-muted-foreground">{ROLE_DESCRIPTIONS[selectedRole] ?? ''}</div>
     </form>
   );
 }

--- a/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.users/actionHelpers.server.ts
@@ -25,7 +25,7 @@ export const ActionFormDataSchema = zfd
     // Accept either email or userId for backward compatibility and new search functionality
     email: zfd.text(z.email({ message: 'invalid email address' }).optional().or(z.literal(''))),
     userId: zfd.text(z.string().min(1).optional().or(z.literal(''))),
-    role: zfd.text(z.union([z.literal('ADMIN'), z.literal('SUBMITTER')])),
+    role: zfd.text(z.union([z.literal('ADMIN'), z.literal('SUBMITTER'), z.literal('MEMBER')])),
   })
   .refine(
     (item) => {
@@ -50,7 +50,7 @@ export const ActionFormDataSchema = zfd
 export type ParsedFormData = {
   email?: string;
   userId?: string;
-  role: 'ADMIN' | 'SUBMITTER';
+  role: 'ADMIN' | 'SUBMITTER' | 'MEMBER';
 };
 
 function isErrorResponse<T>(value: T | ReturnType<typeof data>): value is ReturnType<typeof data> {

--- a/packages/scms-server/src/backend/roles.server.ts
+++ b/packages/scms-server/src/backend/roles.server.ts
@@ -101,7 +101,8 @@ const SITE_ROLES: Record<SiteRole, Set<string>> = {
     site.users.delete,
     site.users.admin,
   ]),
-  [SiteRole.SUBMITTER]: new Set([
+  [SiteRole.SUBMITTER]: new Set([site.submissions.create, site.submissions.versions.create]),
+  [SiteRole.MEMBER]: new Set([
     site.list,
     site.read,
     site.details,
@@ -114,8 +115,6 @@ const SITE_ROLES: Record<SiteRole, Set<string>> = {
     site.submissions.create,
     site.submissions.versions.create,
   ]),
-  [SiteRole.REVIEWER]: new Set([site.read]),
-  [SiteRole.AUTHOR]: new Set([site.read]),
   [SiteRole.PUBLIC]: new Set([site.read]),
   [SiteRole.UNRESTRICTED]: new Set([
     site.read,

--- a/packages/scms-server/src/backend/scopes.helpers.server.spec.ts
+++ b/packages/scms-server/src/backend/scopes.helpers.server.spec.ts
@@ -65,15 +65,15 @@ describe('userHasScope', () => {
 
   test('returns true for site: scope (inferred) when matching site role has raw scope', () => {
     const user = createUser({
-      site_roles: [siteRole('mysite', SiteRole.SUBMITTER)],
+      site_roles: [siteRole('mysite', SiteRole.MEMBER)],
     });
     expect(userHasScope(user, `${site.read}:mysite`)).toBe(true);
   });
 
   test('returns false for site: scope (inferred) when matching site role lacks raw scope', () => {
     const user = createUser({
-      // REVIEWER only has site.read, so choose a scope they don't have, e.g., site.update
-      site_roles: [siteRole('mysite', SiteRole.REVIEWER)],
+      // PUBLIC only has site.read, so choose a scope they don't have, e.g., site.update
+      site_roles: [siteRole('mysite', SiteRole.PUBLIC)],
     });
     expect(userHasScope(user, `${site.update}:mysite`)).toBe(false);
   });
@@ -87,7 +87,7 @@ describe('userHasScope', () => {
 
   test('returns true for site override branch when siteName is provided and raw scope matches', () => {
     const user = createUser({
-      site_roles: [siteRole('mysite', SiteRole.SUBMITTER)],
+      site_roles: [siteRole('mysite', SiteRole.PUBLIC)],
     });
     // siteName override provided; scope is treated as raw
     expect(userHasScope(user, site.read, 'mysite')).toBe(true);
@@ -95,7 +95,7 @@ describe('userHasScope', () => {
 
   test('returns false for site override branch when raw scope does not match', () => {
     const user = createUser({
-      site_roles: [siteRole('mysite', SiteRole.REVIEWER)],
+      site_roles: [siteRole('mysite', SiteRole.PUBLIC)],
     });
     expect(userHasScope(user, site.update, 'mysite')).toBe(false);
   });
@@ -113,7 +113,7 @@ describe('userHasScopes', () => {
   test('returns true when all requested scopes are satisfied', () => {
     const user = createUser({
       roles: [roleWithScopes(['x', 'y'])],
-      site_roles: [siteRole('mysite', SiteRole.SUBMITTER)],
+      site_roles: [siteRole('mysite', SiteRole.PUBLIC)],
     });
     expect(userHasScopes(user, ['x', `${site.read}:mysite`])).toBe(true);
   });

--- a/platform/scms/docs/navigation-scopes.md
+++ b/platform/scms/docs/navigation-scopes.md
@@ -129,9 +129,8 @@ The system automatically maps site roles to scopes:
 | Site Role | Gets These Scopes |
 |-----------|-------------------|
 | `ADMIN` | All site scopes (full access) |
-| `SUBMITTER` | Read, create submissions and versions |
-| `REVIEWER` | Read-only access |
-| `AUTHOR` | Read-only access |
+| `SUBMITTER` | Create submissions and submission versions only |
+| `MEMBER` | List/read site, kinds, collections, submissions; create submissions and versions |
 | `PUBLIC` | Read-only access |
 | `UNRESTRICTED` | Read, browse, create submissions |
 

--- a/prisma/schema/migrations/20260506160000_remove_reviewer_author_site_roles/migration.sql
+++ b/prisma/schema/migrations/20260506160000_remove_reviewer_author_site_roles/migration.sql
@@ -1,0 +1,23 @@
+-- Remap removed site roles to SUBMITTER before replacing the enum.
+UPDATE "SiteUser"
+SET "role" = 'SUBMITTER'::"SiteRole"
+WHERE "role"::text IN ('REVIEWER', 'AUTHOR');
+
+CREATE TYPE "SiteRole_new" AS ENUM (
+  'ADMIN',
+  'SUBMITTER',
+  'PUBLIC',
+  'UNRESTRICTED'
+);
+
+ALTER TABLE "SiteUser" ALTER COLUMN "role" DROP DEFAULT;
+
+ALTER TABLE "SiteUser"
+ALTER COLUMN "role" TYPE "SiteRole_new"
+USING ("role"::text::"SiteRole_new");
+
+ALTER TYPE "SiteRole" RENAME TO "SiteRole_old";
+ALTER TYPE "SiteRole_new" RENAME TO "SiteRole";
+DROP TYPE "SiteRole_old";
+
+ALTER TABLE "SiteUser" ALTER COLUMN "role" SET DEFAULT 'SUBMITTER'::"SiteRole";

--- a/prisma/schema/migrations/20260506163000_add_member_site_role/migration.sql
+++ b/prisma/schema/migrations/20260506163000_add_member_site_role/migration.sql
@@ -1,0 +1,2 @@
+-- Add MEMBER site role (scopes are enforced in application code via SITE_ROLES).
+ALTER TYPE "SiteRole" ADD VALUE 'MEMBER';

--- a/prisma/schema/site.prisma
+++ b/prisma/schema/site.prisma
@@ -1,8 +1,7 @@
 enum SiteRole {
   ADMIN
   SUBMITTER
-  REVIEWER
-  AUTHOR
+  MEMBER
   PUBLIC // Role granted to all users for public sites
   UNRESTRICTED // Role granted to all users for sites without restricted submissions
 }
@@ -11,7 +10,7 @@ model SiteUser {
   id            String   @id
   date_created  String
   date_modified String
-  role          SiteRole @default(AUTHOR)
+  role          SiteRole @default(SUBMITTER)
   site          Site     @relation(fields: [site_id], references: [id])
   site_id       String
   user          User     @relation(fields: [user_id], references: [id])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it changes authorization semantics (site role→scope mapping) and performs Prisma enum migrations that remap existing user roles, which can unintentionally broaden/restrict access if misapplied.
> 
> **Overview**
> Updates site authorization by **adding a new `MEMBER` site role** (browse/read site content and list/read submissions, plus create submissions/versions) while **tightening `SUBMITTER`** to creation-only (no listing/reading).
> 
> Removes redundant `REVIEWER`/`AUTHOR` roles across the stack: Prisma enum and default role change (`SiteUser.role` now defaults to `SUBMITTER`), a migration remaps existing `REVIEWER`/`AUTHOR` rows to `SUBMITTER`, backend scope mapping and unit tests are updated accordingly, and the site user admin UI now supports selecting `MEMBER` with inline role descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b2dc6bd4a4d1573af560f6cb5d6620fa57bfd9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->