### PR TITLE
➰ Removes looping fetch in legacy API code

### DIFF
--- a/.changeset/ninety-swans-read.md
+++ b/.changeset/ninety-swans-read.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/cli': patch
+---
+
+Removed code supporting legacy API, surfacing fatal errors that were previously swallowed

--- a/.changeset/six-donuts-open.md
+++ b/.changeset/six-donuts-open.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms': patch
+---
+
+By default, draft submissions are not listed

--- a/packages/curvenote-cli/src/sites/init.ts
+++ b/packages/curvenote-cli/src/sites/init.ts
@@ -5,7 +5,7 @@ import { checkVenueExists, ensureVenue } from './utils.js';
 import type { SiteWithContentDTO } from '@curvenote/common';
 import { postToJournals } from '../utils/api.js';
 import { tic } from 'myst-cli-utils';
-import { getWorkFromKey, workKeyFromConfig } from '../works/utils.js';
+import { getMyWorkFromKey, workKeyFromConfig } from '../works/utils.js';
 
 export async function patchSiteWithContent(
   session: ISession,
@@ -46,7 +46,7 @@ export async function init(session: ISession, name: string, opts?: SiteInitOpts)
   let content: string | undefined;
   const key = workKeyFromConfig(session);
   if (key) {
-    const work = await getWorkFromKey(session, key);
+    const work = await getMyWorkFromKey(session, key);
     content = work?.id;
   }
   if (!content) {

--- a/packages/curvenote-cli/src/submissions/status.ts
+++ b/packages/curvenote-cli/src/submissions/status.ts
@@ -1,7 +1,7 @@
 import type { ISession } from '../session/types.js';
 import { checkVenueExists, ensureVenue } from '../sites/utils.js';
 import { exitOnInvalidKeyOption, workKeyFromConfig } from '../works/utils.js';
-import { getAllSubmissionsUsingKey, getSubmissionToUpdate } from './submit.utils.js';
+import { getAllSubmissionsThatICanSeeUsingKey, getSubmissionToUpdate } from './submit.utils.js';
 import type { STATUS_ACTIONS } from './types.js';
 import { patchUpdateSubmissionStatus } from './utils.js';
 import { keyFromTransferFile } from './utils.transfer.js';
@@ -45,7 +45,7 @@ async function updateStatus(
   exitOnInvalidKeyOption(session, key);
 
   session.log.info(`📍 Updating submission status using a key: ${key}`);
-  const allExisting = await getAllSubmissionsUsingKey(session, venue, key);
+  const allExisting = await getAllSubmissionsThatICanSeeUsingKey(session, venue, key);
   const existing = allExisting ? await getSubmissionToUpdate(session, allExisting) : undefined;
   if (!existing) {
     session.log.error(`⛔️ No existing submission found to ${action} with key: ${key}`);

--- a/packages/curvenote-cli/src/submissions/submit.ts
+++ b/packages/curvenote-cli/src/submissions/submit.ts
@@ -10,7 +10,7 @@ import {
   checkForSubmissionKeyInUse as checkIfWorkKeyIsInUseOnAnySubmissionOnThisSite,
   determineCollectionAndKind,
   collectionMoniker,
-  getAllSubmissionsUsingKey,
+  getAllSubmissionsThatICanSeeUsingKey,
   getSubmissionToUpdate,
   checkVenueSubmitAccess,
   getVenueCollections,
@@ -90,15 +90,20 @@ export async function submit(session: ISession, venue: string, opts?: SubmitOpts
   if (!opts?.draft && !opts?.new) {
     session.log.info(`📡 Checking submission status...`);
     if (lookupMode === 'id') {
-      const allExisting = await getAllSubmissionsUsingKey(session, venue, key);
-      if (!allExisting?.length) {
+      const allExisting = await getAllSubmissionsThatICanSeeUsingKey(session, venue, key, {
+        includeDrafts: true,
+      });
+
+      const isEmpty = !allExisting || allExisting.length === 0;
+      if (isEmpty) {
+        // check if the work key is in use on any submission on this site just to give a better error message
         const alreadySubmittedToThisSite = await checkIfWorkKeyIsInUseOnAnySubmissionOnThisSite(
           session,
           venue,
           key,
         );
         if (alreadySubmittedToThisSite) {
-          session.log.warn(
+          session.log.error(
             `⛔️ This work has already been submitted to "${venue}", but you don't have permission to access that submission.`,
           );
           session.log.info(
@@ -109,13 +114,11 @@ export async function submit(session: ISession, venue: string, opts?: SubmitOpts
           session.log.info(`🔍 No existing submission found at "${venue}" using the key "${key}"`);
         }
 
+        // Before anyting, am I able to do something with the work?
         const { owned, taken } = await checkMyWorkAccess(session, key);
         if (!owned && taken) {
-          session.log.warn(
-            `⛔️ This work has already been submitted to a Curvenote site, but you don't have permission to access that submission.`,
-          );
-          session.log.info(
-            'If you still want to make a new submission, you may explicitly add flag "--new"',
+          session.log.error(
+            `⛔️ This work exists but you don't have permission submit it to a site.`,
           );
           process.exit(1);
         }

--- a/packages/curvenote-cli/src/submissions/submit.ts
+++ b/packages/curvenote-cli/src/submissions/submit.ts
@@ -7,7 +7,7 @@ import {
   confirmUpdateToExistingSubmission,
   updateExistingSubmission,
   createNewSubmission,
-  checkForSubmissionKeyInUse,
+  checkForSubmissionKeyInUse as checkIfWorkKeyIsInUseOnAnySubmissionOnThisSite,
   determineCollectionAndKind,
   collectionMoniker,
   getAllSubmissionsUsingKey,
@@ -91,7 +91,7 @@ export async function submit(session: ISession, venue: string, opts?: SubmitOpts
     if (lookupMode === 'id') {
       const allExisting = await getAllSubmissionsUsingKey(session, venue, key);
       if (!allExisting?.length) {
-        const exists = await checkForSubmissionKeyInUse(session, venue, key);
+        const exists = await checkIfWorkKeyIsInUseOnAnySubmissionOnThisSite(session, venue, key);
         if (exists) {
           session.log.warn(
             `⛔️ This work has already been submitted to a Curvenote site, but you don't have permission to access that submission.`,

--- a/packages/curvenote-cli/src/submissions/submit.ts
+++ b/packages/curvenote-cli/src/submissions/submit.ts
@@ -22,6 +22,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { prepareChecksForSubmission } from './check.js';
 import {
+  checkMyWorkAccess,
   exitOnInvalidKeyOption,
   performCleanRebuild,
   promptForNewKey,
@@ -91,10 +92,14 @@ export async function submit(session: ISession, venue: string, opts?: SubmitOpts
     if (lookupMode === 'id') {
       const allExisting = await getAllSubmissionsUsingKey(session, venue, key);
       if (!allExisting?.length) {
-        const exists = await checkIfWorkKeyIsInUseOnAnySubmissionOnThisSite(session, venue, key);
-        if (exists) {
+        const alreadySubmittedToThisSite = await checkIfWorkKeyIsInUseOnAnySubmissionOnThisSite(
+          session,
+          venue,
+          key,
+        );
+        if (alreadySubmittedToThisSite) {
           session.log.warn(
-            `⛔️ This work has already been submitted to a Curvenote site, but you don't have permission to access that submission.`,
+            `⛔️ This work has already been submitted to "${venue}", but you don't have permission to access that submission.`,
           );
           session.log.info(
             'If you still want to make a new submission, you may explicitly add flag "--new"',
@@ -102,6 +107,17 @@ export async function submit(session: ISession, venue: string, opts?: SubmitOpts
           process.exit(1);
         } else {
           session.log.info(`🔍 No existing submission found at "${venue}" using the key "${key}"`);
+        }
+
+        const { owned, taken } = await checkMyWorkAccess(session, key);
+        if (!owned && taken) {
+          session.log.warn(
+            `⛔️ This work has already been submitted to a Curvenote site, but you don't have permission to access that submission.`,
+          );
+          session.log.info(
+            'If you still want to make a new submission, you may explicitly add flag "--new"',
+          );
+          process.exit(1);
         }
       } else {
         existing = await getSubmissionToUpdate(session, allExisting);

--- a/packages/curvenote-cli/src/submissions/submit.utils.ts
+++ b/packages/curvenote-cli/src/submissions/submit.utils.ts
@@ -399,27 +399,22 @@ export async function getAllSubmissionsUsingKey(
   session: ISession,
   venue: string,
   key: string,
-  opts?: { includeDrafts?: boolean },
 ): Promise<SubmissionsListItemDTO[] | undefined> {
   session.log.debug(`checking for existing submission using key "${key}"`);
   const submissions: SubmissionsListItemDTO[] = [];
   try {
     const siteSubmissions: SubmissionsListingDTO = await getFromJournals(
       session,
-      `/sites/${venue}/submissions?key=${key}`,
+      `/sites/${venue}/submissions?${new URLSearchParams({ key }).toString()}`,
     );
     submissions.push(...siteSubmissions.items);
   } catch (err) {
     session.log.debug(err);
   }
   try {
-    const searchParams = new URLSearchParams({ key });
-    if (opts?.includeDrafts) {
-      searchParams.set('drafts', 'true');
-    }
     const mySubmissions: SubmissionsListingDTO = await getFromJournals(
       session,
-      `/my/submissions?${searchParams.toString()}`,
+      `/my/submissions?${new URLSearchParams({ key }).toString()}`,
     );
     submissions.push(
       ...mySubmissions.items.filter((submission) => {
@@ -434,9 +429,6 @@ export async function getAllSubmissionsUsingKey(
   }
 
   // TODO we can remove this additional filtering once the `/my/submissions?key=` API endpoint filters out drafts by default
-  if (opts?.includeDrafts) {
-    return submissions;
-  }
   const draftSubmissions = submissions.filter((submission) => submission.status === 'DRAFT');
   if (draftSubmissions.length > 0) {
     session.log.debug(`Ignoring ${plural('%s draft submission(s)', draftSubmissions)}`);

--- a/packages/curvenote-cli/src/submissions/submit.utils.ts
+++ b/packages/curvenote-cli/src/submissions/submit.utils.ts
@@ -399,6 +399,7 @@ export async function getAllSubmissionsUsingKey(
   session: ISession,
   venue: string,
   key: string,
+  opts?: { includeDrafts?: boolean },
 ): Promise<SubmissionsListItemDTO[] | undefined> {
   session.log.debug(`checking for existing submission using key "${key}"`);
   const submissions: SubmissionsListItemDTO[] = [];
@@ -412,58 +413,51 @@ export async function getAllSubmissionsUsingKey(
     session.log.debug(err);
   }
   try {
+    const searchParams = new URLSearchParams({ key });
+    if (opts?.includeDrafts) {
+      searchParams.set('drafts', 'true');
+    }
     const mySubmissions: SubmissionsListingDTO = await getFromJournals(
       session,
-      `/my/submissions?key=${key}`,
-    );
-    // These extra fetches are required for the old version of the API where
-    // the 'key' query parameter is not respected on /my/submissions.
-    // This may be removed (along with the 'correctKey' check below) once
-    // the API is updated.
-    const works = await Promise.all(
-      mySubmissions.items.map((sub) => {
-        return getFromUrl(session, sub.links.work);
-      }),
+      `/my/submissions?${searchParams.toString()}`,
     );
     submissions.push(
-      ...mySubmissions.items.filter((submission, ind) => {
+      ...mySubmissions.items.filter((submission) => {
         const correctVenue = submission.site_name === venue;
-        const correctKey = works[ind].key === key;
         const submissionIsDuplicate = submissions.map(({ id }) => id).includes(submission.id);
-        return correctVenue && correctKey && !submissionIsDuplicate;
+        return correctVenue && !submissionIsDuplicate;
       }),
     );
   } catch (err) {
-    session.log.debug(err);
+    session.log.error(err);
+    throw err;
   }
-  return submissions;
+
+  // TODO we can remove this additional filtering once the `/my/submissions?key=` API endpoint filters out drafts by default
+  if (opts?.includeDrafts) {
+    return submissions;
+  }
+  const draftSubmissions = submissions.filter((submission) => submission.status === 'DRAFT');
+  if (draftSubmissions.length > 0) {
+    session.log.debug(`Ignoring ${plural('%s draft submission(s)', draftSubmissions)}`);
+  }
+  return submissions.filter((submission) => submission.status !== 'DRAFT');
 }
 
 export async function getSubmissionToUpdate(
   session: ISession,
   submissions: SubmissionsListItemDTO[],
 ) {
-  const draftSubmissions = submissions.filter((submission) => {
-    return submission.status === 'DRAFT';
-  });
-  const nonDraftSubmissions = submissions.filter((submission) => {
-    return submission.status !== 'DRAFT';
-  });
-  if (draftSubmissions.length > 0) {
-    session.log.debug(`Ignoring ${plural('%s draft submission(s)', draftSubmissions)}`);
-  }
-  if (nonDraftSubmissions.length === 0) {
+  if (submissions.length === 0) {
     session.log.debug('existing submission not found');
     return;
   }
-  if (nonDraftSubmissions.length === 1) {
+  if (submissions.length === 1) {
     session.log.debug(`${chalk.bold(`🔍 Found one existing submission`)}`);
-    return nonDraftSubmissions[0];
+    return submissions[0];
   }
-  session.log.info(
-    `🔍 Found ${plural('%s existing submission(s)', nonDraftSubmissions)} for this work`,
-  );
-  const submission = await chooseSubmission(session, nonDraftSubmissions);
+  session.log.info(`🔍 Found ${plural('%s existing submission(s)', submissions)} for this work`);
+  const submission = await chooseSubmission(session, submissions);
   return submission;
 }
 

--- a/packages/curvenote-cli/src/submissions/submit.utils.ts
+++ b/packages/curvenote-cli/src/submissions/submit.utils.ts
@@ -13,7 +13,7 @@ import type {
 import { plural } from 'myst-common';
 import type { ISession } from '../session/types.js';
 import { confirmOrExit } from '../utils/utils.js';
-import { getWorkFromKey } from '../works/utils.js';
+import { getMyWorkFromKey } from '../works/utils.js';
 import type { SubmitLog, SubmitOpts } from './types.js';
 import { getFromJournals, getFromUrl } from '../utils/api.js';
 import { postNewWork, postNewWorkVersion } from '../works/push.js';
@@ -395,14 +395,16 @@ export async function chooseSubmission(
   throw new Error('Using non-latest submission not yet supported...');
 }
 
-export async function getAllSubmissionsUsingKey(
+export async function getAllSubmissionsThatICanSeeUsingKey(
   session: ISession,
   venue: string,
   key: string,
+  opts?: { includeDrafts?: boolean },
 ): Promise<SubmissionsListItemDTO[] | undefined> {
   session.log.debug(`checking for existing submission using key "${key}"`);
   const submissions: SubmissionsListItemDTO[] = [];
   try {
+    // will only contain submissions is the user has scopes on the site
     const siteSubmissions: SubmissionsListingDTO = await getFromJournals(
       session,
       `/sites/${venue}/submissions?${new URLSearchParams({ key }).toString()}`,
@@ -424,8 +426,11 @@ export async function getAllSubmissionsUsingKey(
       }),
     );
   } catch (err) {
-    session.log.error(err);
-    throw err;
+    session.log.debug(err);
+  }
+
+  if (opts?.includeDrafts) {
+    return submissions;
   }
 
   // TODO we can remove this additional filtering once the `/my/submissions?key=` API endpoint filters out drafts by default
@@ -502,7 +507,7 @@ export async function confirmUpdateToExistingSubmission(
       process.exit(1);
     }
 
-    const work = await getWorkFromKey(session, key);
+    const work = await getMyWorkFromKey(session, key);
     if (!work) {
       session.log.info(
         `${chalk.yellow(
@@ -561,7 +566,7 @@ export async function createNewSubmission(
   opts?: SubmitOpts,
   existingWork?: WorkDTO,
 ) {
-  const workResp = existingWork ?? (await getWorkFromKey(session, key));
+  const workResp = existingWork ?? (await getMyWorkFromKey(session, key));
   let work: WorkDTO;
   if (workResp) {
     session.log.debug(`posting new work version...`);

--- a/packages/curvenote-cli/src/utils/api.ts
+++ b/packages/curvenote-cli/src/utils/api.ts
@@ -24,7 +24,7 @@ export async function getFromUrl(session: ISession, url: string) {
     const json = (await response.json()) as any;
     return json;
   } else {
-    session.log.debug('GET FAILED', url, response.status, response.statusText);
+    session.log.error('GET FAILED', url, response.status, response.statusText);
     throw new Error(
       `GET FAILED ${url}: ${response.status}\n\n${response.statusText}
       Please contact support@curvenote.com`,

--- a/packages/curvenote-cli/src/utils/api.ts
+++ b/packages/curvenote-cli/src/utils/api.ts
@@ -24,7 +24,7 @@ export async function getFromUrl(session: ISession, url: string) {
     const json = (await response.json()) as any;
     return json;
   } else {
-    session.log.error('GET FAILED', url, response.status, response.statusText);
+    session.log.debug('GET FAILED', url, response.status, response.statusText);
     throw new Error(
       `GET FAILED ${url}: ${response.status}\n\n${response.statusText}
       Please contact support@curvenote.com`,

--- a/packages/curvenote-cli/src/works/push.ts
+++ b/packages/curvenote-cli/src/works/push.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import {
   exitOnInvalidKeyOption,
-  getWorkFromKey,
+  getMyWorkFromKey,
   performCleanRebuild,
   promptForNewKey,
   uploadAndGetCdnKey,
@@ -164,7 +164,7 @@ export async function push(session: ISession, opts?: PushOpts) {
     const cdn = opts?.public ? session.config.publicCdnUrl : session.config.privateCdnUrl;
     const cdnKey = await uploadAndGetCdnKey(session, cdn, opts);
 
-    const workResp = await getWorkFromKey(session, key);
+    const workResp = await getMyWorkFromKey(session, key);
     let work: WorkDTO;
     if (workResp) {
       session.log.debug(`posting new work version...`);

--- a/packages/curvenote-cli/src/works/resolveExistingWork.spec.ts
+++ b/packages/curvenote-cli/src/works/resolveExistingWork.spec.ts
@@ -10,8 +10,8 @@ vi.mock('inquirer', () => ({
 }));
 
 vi.mock('./utils.js', () => ({
-  getWorkFromKey: vi.fn(),
-  getWorksFromDoi: vi.fn(),
+  getMyWorkFromKey: vi.fn(),
+  getMyWorksFromDoi: vi.fn(),
   workKeyExists: vi.fn(),
 }));
 
@@ -22,7 +22,7 @@ describe('resolveExistingWork', () => {
 
   it('returns work by id lookup mode', async () => {
     const expected = { id: 'w1' } as any;
-    vi.mocked(workUtils.getWorkFromKey).mockResolvedValueOnce(expected);
+    vi.mocked(workUtils.getMyWorkFromKey).mockResolvedValueOnce(expected);
     const result = await resolveExistingWork({} as any, {
       mode: 'id',
       key: 'project-id',
@@ -48,7 +48,7 @@ describe('resolveExistingWork', () => {
   });
 
   it('returns undefined for doi mode with no matches', async () => {
-    vi.mocked(workUtils.getWorksFromDoi).mockResolvedValueOnce([]);
+    vi.mocked(workUtils.getMyWorksFromDoi).mockResolvedValueOnce([]);
     const result = await resolveExistingWork({} as any, {
       mode: 'doi',
       doi: '10.1000/test',
@@ -59,7 +59,7 @@ describe('resolveExistingWork', () => {
 
   it('auto-selects latest match when yes=true', async () => {
     const expected = { id: 'w1' } as any;
-    vi.mocked(workUtils.getWorksFromDoi).mockResolvedValueOnce([expected, { id: 'w2' } as any]);
+    vi.mocked(workUtils.getMyWorksFromDoi).mockResolvedValueOnce([expected, { id: 'w2' } as any]);
     const result = await resolveExistingWork({} as any, {
       mode: 'doi',
       doi: '10.1000/test',
@@ -71,7 +71,7 @@ describe('resolveExistingWork', () => {
 
   it('prompts for specific work when multiple DOI matches', async () => {
     const works = [{ id: 'w1' }, { id: 'w2' }] as any[];
-    vi.mocked(workUtils.getWorksFromDoi).mockResolvedValueOnce(works as any);
+    vi.mocked(workUtils.getMyWorksFromDoi).mockResolvedValueOnce(works as any);
     vi.mocked(inquirer.prompt as any).mockResolvedValueOnce({ workId: 'w2' });
     const result = await resolveExistingWork({} as any, {
       mode: 'doi',
@@ -82,7 +82,7 @@ describe('resolveExistingWork', () => {
   });
 
   it('returns undefined when single DOI match is rejected', async () => {
-    vi.mocked(workUtils.getWorksFromDoi).mockResolvedValueOnce([{ id: 'w1' } as any]);
+    vi.mocked(workUtils.getMyWorksFromDoi).mockResolvedValueOnce([{ id: 'w1' } as any]);
     vi.mocked(inquirer.prompt as any).mockResolvedValueOnce({ confirm: false });
     const result = await resolveExistingWork({} as any, {
       mode: 'doi',
@@ -93,8 +93,8 @@ describe('resolveExistingWork', () => {
   });
 
   it('throws on DOI mode when fallback key collides', async () => {
-    vi.mocked(workUtils.getWorksFromDoi).mockResolvedValueOnce([]);
-    vi.mocked(workUtils.getWorkFromKey).mockResolvedValueOnce(undefined);
+    vi.mocked(workUtils.getMyWorksFromDoi).mockResolvedValueOnce([]);
+    vi.mocked(workUtils.getMyWorkFromKey).mockResolvedValueOnce(undefined);
     vi.mocked(workUtils.workKeyExists as any).mockResolvedValueOnce(true);
     await expect(
       resolveExistingWork({} as any, {

--- a/packages/curvenote-cli/src/works/resolveExistingWork.ts
+++ b/packages/curvenote-cli/src/works/resolveExistingWork.ts
@@ -1,7 +1,7 @@
 import inquirer from 'inquirer';
 import type { WorkDTO } from '@curvenote/common';
 import type { ISession } from '../session/types.js';
-import { getWorkFromKey, getWorksFromDoi, workKeyExists } from './utils.js';
+import { getMyWorkFromKey, getMyWorksFromDoi, workKeyExists } from './utils.js';
 
 export type LookupKeyMode = 'id' | 'doi';
 
@@ -22,7 +22,7 @@ export async function resolveExistingWork(
   if (opts.mode === 'id') {
     if (opts.forceNew) return undefined;
     if (!opts.key) return undefined;
-    return getWorkFromKey(session, opts.key);
+    return getMyWorkFromKey(session, opts.key);
   }
 
   const doi =
@@ -35,13 +35,13 @@ export async function resolveExistingWork(
 
   let works: WorkDTO[] = [];
   if (!opts.forceNew) {
-    works = await getWorksFromDoi(session, doi);
+    works = await getMyWorksFromDoi(session, doi);
   }
   if (works.length === 0) {
     // In DOI mode, creating a new work can still fail if the project.id/work key
     // is already taken by an inaccessible work. Preflight this consistently.
     if (opts.fallbackCreateKey) {
-      const owned = await getWorkFromKey(session, opts.fallbackCreateKey);
+      const owned = await getMyWorkFromKey(session, opts.fallbackCreateKey);
       if (!owned) {
         const taken = await workKeyExists(session, opts.fallbackCreateKey);
         if (taken) {

--- a/packages/curvenote-cli/src/works/utils.ts
+++ b/packages/curvenote-cli/src/works/utils.ts
@@ -203,6 +203,15 @@ export async function workKeyExists(session: ISession, key: string): Promise<boo
   }
 }
 
+export async function checkMyWorkAccess(
+  session: ISession,
+  key: string,
+): Promise<{ owned: WorkDTO | undefined; taken: boolean }> {
+  const owned = await getWorkFromKey(session, key);
+  const taken = await workKeyExists(session, key);
+  return { owned, taken };
+}
+
 /**
  * Prompt user for a new work key
  *

--- a/packages/curvenote-cli/src/works/utils.ts
+++ b/packages/curvenote-cli/src/works/utils.ts
@@ -174,7 +174,10 @@ export function workDoiFromConfig(session: ISession) {
  * Returns undefined if work for the given venue is not defined or
  * if the API request for the work fails.
  */
-export async function getWorkFromKey(session: ISession, key: string): Promise<WorkDTO | undefined> {
+export async function getMyWorkFromKey(
+  session: ISession,
+  key: string,
+): Promise<WorkDTO | undefined> {
   try {
     session.log.debug(`GET from journals API /my/works?key=${key}`);
     const resp = await getFromJournals(session, `/my/works?key=${key}`);
@@ -184,7 +187,7 @@ export async function getWorkFromKey(session: ISession, key: string): Promise<Wo
   }
 }
 
-export async function getWorksFromDoi(session: ISession, doi: string): Promise<WorkDTO[]> {
+export async function getMyWorksFromDoi(session: ISession, doi: string): Promise<WorkDTO[]> {
   try {
     session.log.debug(`GET from journals API /my/works?doi=${doi}`);
     const resp = await getFromJournals(session, `/my/works?doi=${encodeURIComponent(doi)}`);
@@ -207,7 +210,7 @@ export async function checkMyWorkAccess(
   session: ISession,
   key: string,
 ): Promise<{ owned: WorkDTO | undefined; taken: boolean }> {
-  const owned = await getWorkFromKey(session, key);
+  const owned = await getMyWorkFromKey(session, key);
   const taken = await workKeyExists(session, key);
   return { owned, taken };
 }

--- a/packages/scms-server/src/backend/loaders/my/submissions/list.server.ts
+++ b/packages/scms-server/src/backend/loaders/my/submissions/list.server.ts
@@ -1,4 +1,3 @@
-import type { Prisma } from '@curvenote/scms-db';
 import type { Context } from '../../../context.server.js';
 import { SiteContext } from '../../../context.site.server.js';
 import type { ClientExtension } from '@curvenote/scms-core';
@@ -8,20 +7,25 @@ import { userHasWorkScope } from '../../../scopes.helpers.server.js';
 
 export async function dbListUserSubmissions(
   userId: string,
-  opts: { key?: string; workId?: string; siteName?: string } = {},
+  opts: { key?: string; workId?: string; siteName?: string; includeDrafts?: boolean } = {},
 ) {
-  return dbListSubmissions({
-    ...(opts.siteName ? { site: { name: opts.siteName } } : {}),
-    work: {
-      ...(opts.key ? { key: opts.key } : {}),
-      ...(opts.workId ? { id: opts.workId } : {}),
-      work_users: {
-        some: {
-          user_id: userId,
+  return dbListSubmissions(
+    {
+      ...(opts.siteName ? { site: { name: opts.siteName } } : {}),
+      work: {
+        ...(opts.key ? { key: opts.key } : {}),
+        ...(opts.workId ? { id: opts.workId } : {}),
+        work_users: {
+          some: {
+            user_id: userId,
+          },
         },
       },
     },
-  });
+    undefined,
+    undefined,
+    { includeDraftOnlySubmissions: opts.includeDrafts },
+  );
 }
 
 type DBO = Exclude<Awaited<ReturnType<typeof dbListUserSubmissions>>, null>;
@@ -60,13 +64,18 @@ export async function formatMySubmissionListDTO(
 export default async function (
   ctx: Context,
   extensions: ClientExtension[],
-  opts?: string | { key?: string; workId?: string; siteName?: string },
+  opts?: string | { key?: string; workId?: string; siteName?: string; includeDrafts?: boolean },
 ) {
   if (!ctx.user) throw error401();
   const normalized =
     typeof opts === 'string'
       ? { key: opts }
-      : { key: opts?.key, workId: opts?.workId, siteName: opts?.siteName };
+      : {
+          key: opts?.key,
+          workId: opts?.workId,
+          siteName: opts?.siteName,
+          includeDrafts: opts?.includeDrafts,
+        };
   const dbo = await dbListUserSubmissions(ctx.user.id, normalized);
   if (!dbo) throw error404();
   const siteCtxCache: Record<string, SiteContext> = {};

--- a/packages/scms-server/src/backend/loaders/sites/submissions/list.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/list.server.ts
@@ -13,15 +13,44 @@ function withHasVersions(where: Prisma.SubmissionWhereInput): Prisma.SubmissionW
     AND: [where, { versions: { some: {} } }],
   };
 }
+/** Submissions whose every version is DRAFT — excluded from list queries unless opted out. */
+const submissionWhereDraftOnlyExclusion: Prisma.SubmissionWhereInput = {
+  NOT: {
+    versions: {
+      every: {
+        status: 'DRAFT',
+      },
+    },
+  },
+};
+
+export type DbListSubmissionsOpts = {
+  /**
+   * When true (e.g. /my/submissions?drafts=true), include submissions whose versions are all DRAFT.
+   * @default false
+   */
+  includeDraftOnlySubmissions?: boolean;
+};
 
 export async function dbListSubmissions(
   where: Prisma.SubmissionWhereInput,
   skip?: number,
   take?: number,
+  opts?: DbListSubmissionsOpts,
 ) {
+  const applyDraftOnlyExclusion = opts?.includeDraftOnlySubmissions !== true;
+  const mergedWhere: Prisma.SubmissionWhereInput = applyDraftOnlyExclusion
+    ? {
+        AND: [
+          ...(where != null && Object.keys(where).length > 0 ? [where] : []),
+          submissionWhereDraftOnlyExclusion,
+        ],
+      }
+    : where;
+
   const prisma = await getPrismaClient();
   return prisma.submission.findMany({
-    where,
+    where: mergedWhere,
     skip,
     take,
     include: {

--- a/packages/scms-server/src/backend/loaders/sites/submissions/list.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/list.server.ts
@@ -8,11 +8,14 @@ import { formatSubmissionLinksDTO } from './get.server.js';
 import { formatSubmissionKindSummaryDTO } from '../kinds/get.server.js';
 import type { ClientExtension, WorkflowTransition } from '@curvenote/scms-core';
 
-function withHasVersions(where: Prisma.SubmissionWhereInput): Prisma.SubmissionWhereInput {
-  return {
-    AND: [where, { versions: { some: {} } }],
-  };
-}
+export type DbListSubmissionsOpts = {
+  /**
+   * When true (e.g. /my/submissions?drafts=true), include submissions whose versions are all DRAFT.
+   * @default false
+   */
+  includeDraftOnlySubmissions?: boolean;
+};
+
 /** Submissions whose every version is DRAFT — excluded from list queries unless opted out. */
 const submissionWhereDraftOnlyExclusion: Prisma.SubmissionWhereInput = {
   NOT: {
@@ -24,13 +27,17 @@ const submissionWhereDraftOnlyExclusion: Prisma.SubmissionWhereInput = {
   },
 };
 
-export type DbListSubmissionsOpts = {
-  /**
-   * When true (e.g. /my/submissions?drafts=true), include submissions whose versions are all DRAFT.
-   * @default false
-   */
-  includeDraftOnlySubmissions?: boolean;
-};
+function withHasVersions(
+  where: Prisma.SubmissionWhereInput,
+  opts?: Pick<DbListSubmissionsOpts, 'includeDraftOnlySubmissions'>,
+): Prisma.SubmissionWhereInput {
+  const applyDraftOnlyExclusion = opts?.includeDraftOnlySubmissions !== true;
+  const andClauses: Prisma.SubmissionWhereInput[] = [where, { versions: { some: {} } }];
+  if (applyDraftOnlyExclusion) {
+    andClauses.push(submissionWhereDraftOnlyExclusion);
+  }
+  return { AND: andClauses };
+}
 
 export async function dbListSubmissions(
   where: Prisma.SubmissionWhereInput,
@@ -38,19 +45,9 @@ export async function dbListSubmissions(
   take?: number,
   opts?: DbListSubmissionsOpts,
 ) {
-  const applyDraftOnlyExclusion = opts?.includeDraftOnlySubmissions !== true;
-  const mergedWhere: Prisma.SubmissionWhereInput = applyDraftOnlyExclusion
-    ? {
-        AND: [
-          ...(where != null && Object.keys(where).length > 0 ? [where] : []),
-          submissionWhereDraftOnlyExclusion,
-        ],
-      }
-    : where;
-
   const prisma = await getPrismaClient();
   return prisma.submission.findMany({
-    where: mergedWhere,
+    where: withHasVersions(where, opts),
     skip,
     take,
     include: {
@@ -106,10 +103,11 @@ export async function dbListSubmissions(
 async function dbCountSubmissions(
   where: Prisma.SubmissionWhereInput,
   tx?: Prisma.TransactionClient,
+  opts?: Pick<DbListSubmissionsOpts, 'includeDraftOnlySubmissions'>,
 ) {
   const prisma = await getPrismaClient();
   return (tx ?? prisma).submission.count({
-    where: withHasVersions(where),
+    where: withHasVersions(where, opts),
   });
 }
 
@@ -259,7 +257,7 @@ export default async function (
   const prisma = await getPrismaClient();
   const result = await prisma.$transaction(async (tx) => {
     const [items, total] = await Promise.all([
-      dbListSubmissions(withHasVersions(normalizedWhere), skip, take),
+      dbListSubmissions(normalizedWhere, skip, take),
       dbCountSubmissions(normalizedWhere, tx),
     ]);
     return { items, total };

--- a/platform/scms/app/routes/api/v1.my.submissions.tsx
+++ b/platform/scms/app/routes/api/v1.my.submissions.tsx
@@ -8,10 +8,12 @@ export async function loader(args: Route.LoaderArgs) {
   const key = url.searchParams.get('key');
   const workId = url.searchParams.get('work_id');
   const site = url.searchParams.get('site') ?? url.searchParams.get('site_name');
+  const includeDrafts = url.searchParams.get('drafts') ? true : false;
   const dto = await my.submissions.list(ctx, extensions, {
     key: key ?? undefined,
     workId: workId ?? undefined,
     siteName: site ?? undefined,
+    includeDrafts,
   });
   return Response.json(dto);
 }

--- a/platform/scms/app/routes/api/v1.my.submissions.tsx
+++ b/platform/scms/app/routes/api/v1.my.submissions.tsx
@@ -8,7 +8,7 @@ export async function loader(args: Route.LoaderArgs) {
   const key = url.searchParams.get('key');
   const workId = url.searchParams.get('work_id');
   const site = url.searchParams.get('site') ?? url.searchParams.get('site_name');
-  const includeDrafts = url.searchParams.get('drafts') ? true : false;
+  const includeDrafts = url.searchParams.get('drafts') === 'true' ? true : false;
   const dto = await my.submissions.list(ctx, extensions, {
     key: key ?? undefined,
     workId: workId ?? undefined,

--- a/platform/scms/app/routes/api/v1.my.submissions.tsx
+++ b/platform/scms/app/routes/api/v1.my.submissions.tsx
@@ -8,7 +8,7 @@ export async function loader(args: Route.LoaderArgs) {
   const key = url.searchParams.get('key');
   const workId = url.searchParams.get('work_id');
   const site = url.searchParams.get('site') ?? url.searchParams.get('site_name');
-  const includeDrafts = url.searchParams.get('drafts') === 'true' ? true : false;
+  const includeDrafts = url.searchParams.get('drafts') === 'true';
   const dto = await my.submissions.list(ctx, extensions, {
     key: key ?? undefined,
     workId: workId ?? undefined,

--- a/platform/scms/app/routes/api/v1.sites.$siteName.submissions.key.$keyName.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.submissions.key.$keyName.tsx
@@ -12,6 +12,9 @@ export async function loader(args: Route.LoaderArgs) {
       versions: {
         some: {
           work_version: { is: { work: { is: { key: keyName } } } },
+          NOT: {
+            status: 'DRAFT',
+          },
         },
       },
     },


### PR DESCRIPTION
This changes the CLI behavior such that it does not make a large number of requests to the work endpoint, which we're getting rate limited. We've removed legacy code as well, or code that was supporting the legacy API. 

On the API side, this makes changes to the submission listing responses, now the submission listings will only ever return submissions that have at least one non-draft version. The My Submissions endpoint now also has a flag allowing you to get all of the submissions, including drafts, on request. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes submission/work discovery and listing semantics across both CLI and API, which may affect who can see/update submissions and could alter automation that depended on drafts being returned.
> 
> **Overview**
> The CLI now uses only `my/*` work/submission endpoints (`getMyWorkFromKey`, `getMyWorksFromDoi`, `getAllSubmissionsThatICanSeeUsingKey`) and removes legacy fallback logic that performed extra per-submission work fetches and could swallow errors.
> 
> Submission flows (`submit`, `status`, `site init`, `work push`) add clearer permission failures: if a key is already used on a site or belongs to an inaccessible work, the CLI exits with explicit fatal messaging rather than continuing.
> 
> On the server, submissions list queries now **exclude submissions whose versions are all `DRAFT` by default**; `/my/submissions` accepts a `drafts=true` (wired through as `includeDrafts`) opt-in to include them, and the site key-existence check ignores `DRAFT` versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 066e57aabb077242372614907effcfdf74de8eaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->