### PR TITLE
🔩 minimise DB return package size

### DIFF
--- a/.changeset/wet-geckos-jog.md
+++ b/.changeset/wet-geckos-jog.md
@@ -1,0 +1,7 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms': patch
+'@curvenote/scms-sites-ext': patch
+---
+
+Minimise db returns bu explicit minimal selects

--- a/ee/sites/src/routes/$siteName.advanced/actionHelper.server.ts
+++ b/ee/sites/src/routes/$siteName.advanced/actionHelper.server.ts
@@ -43,6 +43,7 @@ export async function actionUpdateSiteByJson(ctx: SiteContext, formData: FormDat
         metadata: filteredMetadata,
         date_modified: new Date().toISOString(),
       },
+      select: { id: true },
     });
 
     return { info: 'Site metadata updated successfully' };
@@ -107,6 +108,7 @@ export async function actionUpdateSiteSettings(ctx: SiteContext, formData: FormD
           data: updatedData,
           date_modified: new Date().toISOString(),
         },
+        select: { id: true },
       });
 
       return { info: 'Site settings updated successfully' };

--- a/ee/sites/src/routes/$siteName.advanced/serviceAccount.server.ts
+++ b/ee/sites/src/routes/$siteName.advanced/serviceAccount.server.ts
@@ -53,6 +53,7 @@ export async function dbCreateSiteServiceAccount(site: {
         user_id: userId,
         role: SiteRole.ADMIN,
       },
+      select: { id: true },
     });
 
     return user;

--- a/ee/sites/src/routes/$siteName.collections-classic/delete.server.ts
+++ b/ee/sites/src/routes/$siteName.collections-classic/delete.server.ts
@@ -65,6 +65,7 @@ export async function $actionCollectionDelete(ctx: SiteContext, formData: FormDa
             default: true,
             date_modified: new Date().toISOString(),
           },
+          select: { id: true },
         });
       }
     }

--- a/ee/sites/src/routes/$siteName.collections-classic/update.server.ts
+++ b/ee/sites/src/routes/$siteName.collections-classic/update.server.ts
@@ -65,6 +65,7 @@ async function dbEditCollection(
             }
           : undefined,
       },
+      select: { id: true },
     });
 
     const existingKICs = await tx.kindsInCollections.findMany({

--- a/ee/sites/src/routes/$siteName.collections.$collectionName/db.server.ts
+++ b/ee/sites/src/routes/$siteName.collections.$collectionName/db.server.ts
@@ -61,6 +61,7 @@ export async function safeCollectionContentUpdate(
               },
             },
           },
+          select: { id: true },
         });
         return collection;
       });
@@ -113,6 +114,7 @@ export async function dbUpdateCollectionName(name: string, collectionId: string,
           },
         },
       },
+      select: { id: true },
     });
     return collection;
   });
@@ -153,6 +155,7 @@ export async function dbUpdateCollectionDefault(
           },
         },
       },
+      select: { id: true },
     });
     if (value) {
       const otherCollections = await tx.collection.findMany({
@@ -176,6 +179,7 @@ export async function dbUpdateCollectionDefault(
               default: false,
               date_modified: timestamp,
             },
+            select: { id: true },
           });
           await tx.activity.create({
             data: {
@@ -194,6 +198,7 @@ export async function dbUpdateCollectionDefault(
                 },
               },
             },
+            select: { id: true },
           });
         }),
       );
@@ -239,6 +244,7 @@ export async function dbCreateCollectionKind(kindId: string, collectionId: strin
           },
         },
       },
+      select: { id: true },
     });
 
     return kindInCollection;
@@ -279,6 +285,7 @@ export async function dbDeleteCollectionKind(kindId: string, collectionId: strin
           },
         },
       },
+      select: { id: true },
     });
 
     return deleted;
@@ -316,6 +323,7 @@ export async function dbUpdateCollectionOpen(value: boolean, collectionId: strin
           },
         },
       },
+      select: { id: true },
     });
 
     return collection;
@@ -343,6 +351,7 @@ export async function dbDeleteCollection(collectionId: string, userId: string) {
           },
         },
       },
+      select: { id: true },
     });
     await tx.kindsInCollections.deleteMany({
       where: {
@@ -393,6 +402,7 @@ export async function dbUpdateCollectionParent(
           },
         },
       },
+      select: { id: true },
     });
     return collection;
   });

--- a/ee/sites/src/routes/$siteName.collections.$collectionName/db.server.ts
+++ b/ee/sites/src/routes/$siteName.collections.$collectionName/db.server.ts
@@ -44,7 +44,7 @@ export async function safeCollectionContentUpdate(
             date_modified: timestamp,
           },
         });
-        tx.activity.create({
+        await tx.activity.create({
           data: {
             id: uuid(),
             date_created: timestamp,

--- a/ee/sites/src/routes/$siteName.domains/db.server.ts
+++ b/ee/sites/src/routes/$siteName.domains/db.server.ts
@@ -58,6 +58,7 @@ export async function dbDeleteDomain(domainId: string): Promise<void> {
 
   await prisma.domain.delete({
     where: { id: domainId },
+    select: { id: true },
   });
 }
 

--- a/ee/sites/src/routes/$siteName.domains/db.server.ts
+++ b/ee/sites/src/routes/$siteName.domains/db.server.ts
@@ -39,6 +39,7 @@ export async function dbCreateDomain(
         date_created: timestamp,
         date_modified: timestamp,
       },
+      select: { id: true },
     });
   });
 }
@@ -88,6 +89,7 @@ export async function dbSetDefaultDomain(domainId: string): Promise<void> {
     await tx.domain.update({
       where: { id: domainId },
       data: { default: true, date_modified: new Date().toISOString() },
+      select: { id: true },
     });
   });
 }

--- a/ee/sites/src/routes/$siteName.forms.$formName/db.server.ts
+++ b/ee/sites/src/routes/$siteName.forms.$formName/db.server.ts
@@ -98,6 +98,7 @@ export async function safeFormDataUpdate(
               },
             },
           },
+          select: { id: true },
         });
         return form;
       });
@@ -149,6 +150,7 @@ export async function dbUpdateFormName(name: string, formId: string, userId: str
           },
         },
       },
+      select: { id: true },
     });
     return form;
   });
@@ -251,6 +253,7 @@ export async function dbUpdateFormKind(kindId: string, formId: string, userId: s
           },
         },
       },
+      select: { id: true },
     });
     return form;
   });
@@ -300,6 +303,7 @@ export async function dbCreateFormCollection(collectionId: string, formId: strin
           },
         },
       },
+      select: { id: true },
     });
 
     return collectionInForm;
@@ -335,6 +339,7 @@ export async function dbDeleteFormCollection(collectionId: string, formId: strin
           },
         },
       },
+      select: { id: true },
     });
 
     return deleted;
@@ -362,6 +367,7 @@ export async function dbDeleteForm(formId: string, userId: string) {
           },
         },
       },
+      select: { id: true },
     });
     // Clean up CollectionsInForms
     await tx.collectionsInForms.deleteMany({

--- a/ee/sites/src/routes/$siteName.forms/db.server.ts
+++ b/ee/sites/src/routes/$siteName.forms/db.server.ts
@@ -108,6 +108,7 @@ export async function dbCreateForm(
           },
         },
       },
+      select: { id: true },
     });
 
     return form;

--- a/ee/sites/src/routes/$siteName.kinds-classic/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.kinds-classic/actionHelpers.server.ts
@@ -116,6 +116,7 @@ export async function $actionKindEdit(ctx: SiteContext, formData: FormData) {
         name: payload.name,
         date_modified: new Date().toISOString(),
       },
+      select: { id: true },
     });
 
     if (payload.default) {
@@ -189,6 +190,7 @@ export async function $actionKindDelete(ctx: SiteContext, formData: FormData) {
             default: true,
             date_modified: new Date().toISOString(),
           },
+          select: { id: true },
         });
       }
     }

--- a/ee/sites/src/routes/$siteName.kinds.$kindName/db.server.ts
+++ b/ee/sites/src/routes/$siteName.kinds.$kindName/db.server.ts
@@ -45,7 +45,7 @@ export async function safeKindContentUpdate(
             date_modified: timestamp,
           },
         });
-        tx.activity.create({
+        await tx.activity.create({
           data: {
             id: uuid(),
             date_created: timestamp,
@@ -252,7 +252,7 @@ export async function safeKindChecksUpdate(
             date_modified: timestamp,
           },
         });
-        tx.activity.create({
+        await tx.activity.create({
           data: {
             id: uuid(),
             date_created: timestamp,

--- a/ee/sites/src/routes/$siteName.kinds.$kindName/db.server.ts
+++ b/ee/sites/src/routes/$siteName.kinds.$kindName/db.server.ts
@@ -62,6 +62,7 @@ export async function safeKindContentUpdate(
               },
             },
           },
+          select: { id: true },
         });
         return kind;
       });
@@ -114,6 +115,7 @@ export async function dbUpdateKindName(name: string, kindId: string, userId: str
           },
         },
       },
+      select: { id: true },
     });
     return kind;
   });
@@ -155,6 +157,7 @@ export async function dbUpdateKindDefault(
           },
         },
       },
+      select: { id: true },
     });
     if (value) {
       const otherKinds = await tx.submissionKind.findMany({
@@ -178,6 +181,7 @@ export async function dbUpdateKindDefault(
               default: false,
               date_modified: timestamp,
             },
+            select: { id: true },
           });
           await tx.activity.create({
             data: {
@@ -196,6 +200,7 @@ export async function dbUpdateKindDefault(
                 },
               },
             },
+            select: { id: true },
           });
         }),
       );
@@ -264,6 +269,7 @@ export async function safeKindChecksUpdate(
               },
             },
           },
+          select: { id: true },
         });
         return kind;
       });

--- a/ee/sites/src/routes/$siteName.kinds/db.server.ts
+++ b/ee/sites/src/routes/$siteName.kinds/db.server.ts
@@ -122,7 +122,7 @@ export async function dbCreateKind(
         date_modified: timestamp,
       },
     });
-    tx.activity.create({
+    await tx.activity.create({
       data: {
         id: uuid(),
         date_created: timestamp,

--- a/ee/sites/src/routes/$siteName.kinds/db.server.ts
+++ b/ee/sites/src/routes/$siteName.kinds/db.server.ts
@@ -24,6 +24,7 @@ export async function dbDeleteKind(kindId: string, siteId: string, userId: strin
           },
         },
       },
+      select: { id: true },
     });
     const deleted = await tx.submissionKind.delete({
       where: {
@@ -47,6 +48,7 @@ export async function dbDeleteKind(kindId: string, siteId: string, userId: strin
             default: true,
             date_modified: timestamp,
           },
+          select: { id: true },
         });
         await tx.activity.create({
           data: {
@@ -65,6 +67,7 @@ export async function dbDeleteKind(kindId: string, siteId: string, userId: strin
               },
             },
           },
+          select: { id: true },
         });
       }
     }
@@ -136,6 +139,7 @@ export async function dbCreateKind(
           },
         },
       },
+      select: { id: true },
     });
     return kind;
   });

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/actionHelpers.server.ts
@@ -32,6 +32,7 @@ export async function actionSetPrimarySlug(
           primary: true,
           date_modified: timestamp,
         },
+        select: { id: true },
       });
 
       await tx.slug.updateMany({
@@ -99,6 +100,7 @@ export async function actionDeleteSlug(
           await tx.slug.update({
             where: { id: mostRecent?.id },
             data: { primary: true, date_modified: new Date().toISOString() },
+            select: { id: true },
           });
         } // else there are no more slugs
       }
@@ -215,6 +217,7 @@ export async function actionAddSlug(
         },
         primary: true,
       },
+      select: { id: true },
     });
 
     await tx.slug.updateMany({
@@ -412,10 +415,7 @@ export async function actionUpdateDatePublished(
         activity_type: ActivityType.SUBMISSION_DATE_CHANGE,
         date_published,
       },
-      include: {
-        activity_by: true,
-        kind: true,
-      },
+      select: { id: true },
     });
 
     return sub;

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/actionHelpers.server.ts
@@ -91,6 +91,7 @@ export async function actionDeleteSlug(
     await prisma.$transaction(async (tx) => {
       await tx.slug.delete({
         where: { id: slug_id },
+        select: { id: true },
       });
 
       if (dbo.primary) {

--- a/ee/sites/src/routes/$siteName.website-classic/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.website-classic/actionHelpers.server.ts
@@ -48,6 +48,7 @@ export async function $actionEditNavLinks(ctx: SiteContext, formData: FormData) 
   await prisma.site.update({
     where: { id: ctx.site.id },
     data: { metadata, date_modified: new Date().toISOString() },
+    select: { id: true },
   });
 
   return { metadata };
@@ -120,6 +121,7 @@ export async function $actionEditCTAs(ctx: SiteContext, formData: FormData) {
   await prisma.site.update({
     where: { id: ctx.site.id },
     data: { metadata: updated, date_modified: new Date().toISOString() },
+    select: { id: true },
   });
 
   return null;

--- a/ee/sites/src/routes/$siteName.website/actionHelpers.server.ts
+++ b/ee/sites/src/routes/$siteName.website/actionHelpers.server.ts
@@ -49,7 +49,7 @@ export async function $actionUpdateSiteDesign(ctx: SiteContext, formData: FormDa
     if (description) data.description = description;
     data.date_modified = new Date().toISOString();
     const prisma = await getPrismaClient();
-    await prisma.site.update({ where: { id: ctx.site.id }, data });
+    await prisma.site.update({ where: { id: ctx.site.id }, data, select: { id: true } });
   }
 
   await ctx.trackEvent(TrackEvent.SITE_DESIGN_UPDATED, {

--- a/ee/sites/src/routes/forms.$siteName.$formName.$pageName/db.server.ts
+++ b/ee/sites/src/routes/forms.$siteName.$formName.$pageName/db.server.ts
@@ -28,6 +28,7 @@ export async function createDraftObject(
       occ: 0,
       ...(createdById && { created_by: { connect: { id: createdById } } }),
     },
+    select: { id: true },
   });
   return id;
 }
@@ -190,6 +191,7 @@ export async function dbCreateWorkAndSubmission(
           },
         },
       },
+      select: { id: true },
     });
 
     const sv = await tx.submissionVersion.create({
@@ -279,6 +281,7 @@ export async function dbCreateWorkAndSubmission(
           },
         },
       },
+      select: { id: true },
     });
 
     await tx.activity.create({
@@ -318,6 +321,7 @@ export async function dbCreateWorkAndSubmission(
           },
         },
       },
+      select: { id: true },
     });
 
     if (draftObjectId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5048,6 +5048,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+      "integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
@@ -5188,6 +5205,23 @@
       "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
       "cpu": [
         "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+      "integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+      "cpu": [
+        "loong64"
       ],
       "dev": true,
       "license": "MIT",
@@ -6620,6 +6654,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jest/schemas": {
@@ -10154,6 +10200,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@rgrove/parse-xml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@rgrove/parse-xml/-/parse-xml-4.2.0.tgz",
+      "integrity": "sha512-UuBOt7BOsKVOkFXRe4Ypd/lADuNIfqJXv8GvHqtXaTYXPPKkj2nS2zPllVsrtRjcomDhIJVBnZwfmlI222WH8g==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@rjsf/utils": {
       "version": "5.24.13",
       "license": "Apache-2.0",
@@ -12814,6 +12869,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2-sftp-client": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-sftp-client/-/ssh2-sftp-client-9.0.6.tgz",
+      "integrity": "sha512-4+KvXO/V77y9VjI2op2T8+RCGI/GXQAwR0q5Qkj/EJ5YSeyKszqZP6F8i3H3txYoBqjc7sgorqyvBP3+w1EHyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ssh2": "^1.0.0"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/supports-color": {
       "version": "8.1.3",
       "license": "MIT"
@@ -12863,6 +12955,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/xast": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/xast/-/xast-2.0.4.tgz",
+      "integrity": "sha512-6Q6HWhHXR5EEKcxgF5YBW5XPAAtCi/GgyCWHx6wR7dZTXF5rv2B2fm0hgpSscJqaVDVm6n1DAVbsM8RSM5PlMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -14529,7 +14630,6 @@
     },
     "node_modules/asn1": {
       "version": "0.2.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
@@ -14810,7 +14910,6 @@
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
@@ -15122,6 +15221,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/builtins": {
@@ -16412,6 +16520,21 @@
       "version": "0.0.1",
       "license": "MIT"
     },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/concurrently": {
       "version": "9.2.1",
       "dev": true,
@@ -16607,6 +16730,20 @@
       "license": "MIT",
       "dependencies": {
         "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/cpx": {
@@ -17129,6 +17266,22 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/css-selector-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
+      "integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -18810,6 +18963,346 @@
         "@esbuild/win32-arm64": "0.28.0",
         "@esbuild/win32-ia32": "0.28.0",
         "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/esbuild-android-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+      "integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+      "integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+      "integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+      "integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+      "integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+      "integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+      "integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+      "integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+      "integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+      "integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+      "integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+      "integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+      "integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+      "integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+      "integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+      "integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+      "integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+      "integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+      "integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+      "integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
@@ -27603,7 +28096,6 @@
     },
     "node_modules/nan": {
       "version": "2.25.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -30180,6 +30672,279 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pmc-node-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pmc-node-utils/-/pmc-node-utils-0.3.1.tgz",
+      "integrity": "sha512-ofCqphRccMNw32sugWWU3BMNnj7Yis3XkNRntq2+SfpQy60pji28tlhwrnxW/cZuWVpVGuHg6k241X0Lv60SQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/xast": "^2.0.4",
+        "adm-zip": "^0.5.10",
+        "chalk": "^5.3.0",
+        "commander": "^11.1.0",
+        "css-selector-parser": "^3.0.5",
+        "doi-utils": "^2.0.3",
+        "inquirer": "^9.2.23",
+        "js-yaml": "^4.1.0",
+        "myst-cli": "^1.3.1",
+        "myst-cli-utils": "^2.0.10",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
+        "myst-to-jats": "^1.0.27",
+        "nanoid": "^5.0.9",
+        "pmc-utils": "0.3.1",
+        "tar": "^7.4.3",
+        "unist-builder": "^4.0.0",
+        "unist-util-select": "^5.1.0",
+        "unist-util-visit": "^5.0.0",
+        "uuid": "^10.0.0",
+        "vfile": "^5.0.0",
+        "which": "^4.0.0",
+        "xast-util-to-xml": "^4.0.0",
+        "zod": "^3.23.8"
+      },
+      "bin": {
+        "pmc": "dist/pmc.cjs"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-builder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-4.0.0.tgz",
+      "integrity": "sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-util-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-5.1.0.tgz",
+      "integrity": "sha512-4A5mfokSHG/rNQ4g7gSbdEs+H586xyd24sdJqF1IWamqrLHvYb+DH48fzxowyOhOfK7YSqX+XlCojAyuuyyT2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.1.0",
+        "nth-check": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/pmc-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pmc-utils/-/pmc-utils-0.3.1.tgz",
+      "integrity": "sha512-ri9DmmEf4375ES9+xjLqdfX4Y++QzBVfXkSgsrepBmYVnoF4j8CJy/Cqt/0gcLWjWaB2Ilih7v83yJP3+Vdj3w==",
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "^0.5.10",
+        "css-selector-parser": "^3.0.5",
+        "doi-utils": "^2.0.3",
+        "js-yaml": "^4.1.0",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
+        "myst-to-jats": "^1.0.27",
+        "nanoid": "^5.0.9",
+        "unist-builder": "^4.0.0",
+        "unist-util-select": "^5.1.0",
+        "unist-util-visit": "^5.0.0",
+        "uuid": "^10.0.0",
+        "xast-util-from-xml": "^4.0.0",
+        "xast-util-to-xml": "^4.0.0",
+        "xml-formatter": "^3.6.3",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-builder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-4.0.0.tgz",
+      "integrity": "sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-util-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-5.1.0.tgz",
+      "integrity": "sha512-4A5mfokSHG/rNQ4g7gSbdEs+H586xyd24sdJqF1IWamqrLHvYb+DH48fzxowyOhOfK7YSqX+XlCojAyuuyyT2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.1.0",
+        "nth-check": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/points-on-curve": {
@@ -33254,6 +34019,40 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
+    "node_modules/ssh2-sftp-client": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-12.1.1.tgz",
+      "integrity": "sha512-wYVDgwkpcKG2iPGQQ+QR33xkWqLFIaVrYvA+uON4pmxTPaPuB81f1aooUEPN75e/9DCK6rrKYXb6zR6zP3+EtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "concat-stream": "^2.0.0",
+        "ssh2": "^1.16.0"
+      },
+      "engines": {
+        "node": ">=18.20.4"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://square.link/u/4g7sPflL"
+      }
+    },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "dev": true,
@@ -34156,6 +34955,52 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/teeny-request": {
@@ -35897,7 +36742,6 @@
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
-      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/type-check": {
@@ -38784,6 +39628,64 @@
         }
       }
     },
+    "node_modules/xast-util-from-xml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xast-util-from-xml/-/xast-util-from-xml-4.0.0.tgz",
+      "integrity": "sha512-Pwj6Bw5XARduMeTWpeEfmfgT8/Ma3oiMI4bBIRzCd7GH26A/dn3x7jDc2BHBCQxxdQniTh0MjVUYbjaj4Ljb+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@rgrove/parse-xml": "^4.1.0",
+        "@types/xast": "^2.0.0",
+        "vfile-location": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/xast-util-from-xml/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/xast-util-from-xml/node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/xast-util-to-xml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xast-util-to-xml/-/xast-util-to-xml-4.0.0.tgz",
+      "integrity": "sha512-r1euIWS5yZJUNpfN+ReE4m7Vld2iytaOPJtuXVuRQacRZwqRN1MAb+dv0aGLrdXOZrpGLyvUFf1Upyrb3R5qBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/xast": "^2.0.0",
+        "ccount": "^2.0.0",
+        "stringify-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
       "license": "MIT",
@@ -38794,6 +39696,18 @@
     "node_modules/xml": {
       "version": "1.0.1",
       "license": "MIT"
+    },
+    "node_modules/xml-formatter": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/xml-formatter/-/xml-formatter-3.7.0.tgz",
+      "integrity": "sha512-+8qTc3zv2UcJ1v9IsSIce37Dl4MQG14Cp7tWrwmy202UaI1wqRukw5QMX1JHsV+DX64yw77EgGsj2s5wGvuMbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-parser-xo": "^4.1.5"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/xml-js": {
       "version": "1.6.11",
@@ -38810,6 +39724,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xml-parser-xo": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/xml-parser-xo/-/xml-parser-xo-4.1.6.tgz",
+      "integrity": "sha512-mXbSNSM+rIwndoxSwmFa83bOdeP8G/cOGr7XvxA67X7ebCzoAuVez9JYDCDub3zRDNBZxIbfjuXLSsamr7NfwQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/xmlchars": {
@@ -41409,16 +42332,6 @@
         "typescript": "^5.7.0"
       }
     },
-    "platform/relay/node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "platform/relay/node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -41430,13 +42343,6 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
-    },
-    "platform/relay/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "platform/scms": {
       "name": "@curvenote/scms",
@@ -41557,16 +42463,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "platform/scms/node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "platform/scms/node_modules/@types/react": {
@@ -41770,13 +42666,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "platform/scms/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/scms-server/src/backend/access.server.ts
+++ b/packages/scms-server/src/backend/access.server.ts
@@ -53,6 +53,7 @@ export async function createAccess(params: CreateAccessParams): Promise<Access> 
         access_id: access.id,
         user_id: params.receiverId,
       },
+      select: { id: true },
     });
 
     return access;
@@ -182,6 +183,7 @@ export async function revokeAccess(accessId: string, performedByUserId?: string)
         access_id: accessId,
         user_id: access.receiver_id, // The user who had access revoked
       },
+      select: { id: true },
     });
 
     return updatedAccess;

--- a/packages/scms-server/src/backend/db.server.ts
+++ b/packages/scms-server/src/backend/db.server.ts
@@ -255,6 +255,7 @@ export async function $updateSubmissionVersion(
         data: {
           date_published: data.date_published,
         },
+        select: { id: true },
       });
     }
 
@@ -282,12 +283,7 @@ export async function $updateSubmissionVersion(
         status: data.status,
         activity_type: ActivityType.SUBMISSION_VERSION_STATUS_CHANGE,
       },
-      include: {
-        kind: true,
-        activity_by: true,
-        work_version: { include: { work: true } },
-        submission_version: true,
-      },
+      select: { id: true },
     });
 
     return updated;
@@ -371,10 +367,7 @@ export async function updateSubmissionKind(
           },
         },
       },
-      include: {
-        activity_by: true,
-        kind: true,
-      },
+      select: { id: true },
     });
 
     return updated;
@@ -474,6 +467,7 @@ export async function dbCreateDraftWork(
           },
         },
       },
+      select: { id: true },
     });
 
     return newWork;
@@ -575,6 +569,7 @@ export async function dbCreateDraftWorkVersion(
           connect: { id: workVersionId },
         },
       },
+      select: { id: true },
     });
 
     return { workId, workVersionId, work };
@@ -608,6 +603,7 @@ export async function createWorkActivity(params: {
       ...(params.transition != null ? { transition: params.transition as object } : {}),
       ...(params.data != null ? { data: params.data as object } : {}),
     },
+    select: { id: true },
   });
 }
 
@@ -722,6 +718,7 @@ export async function dbCreateDraftSubmission(
           },
         },
       },
+      select: { id: true },
     });
 
     return submission;

--- a/packages/scms-server/src/backend/db.server.ts
+++ b/packages/scms-server/src/backend/db.server.ts
@@ -230,7 +230,15 @@ export async function $updateSubmissionVersion(
         job_id: data.jobId,
       },
       include: {
-        work_version: true,
+        work_version: {
+          select: {
+            id: true,
+            work_id: true,
+            title: true,
+            doi: true,
+            author_details: true,
+          },
+        },
         submission: {
           include: {
             slugs: true,
@@ -332,8 +340,9 @@ export async function updateSubmissionKind(
         submitted_by: true,
         site: true,
         versions: {
-          include: {
-            work_version: true,
+          select: {
+            id: true,
+            work_version: { select: { id: true } },
           },
         },
       },
@@ -880,7 +889,9 @@ export async function dangerouslyHardDeleteDraftSubmissionVersions(
         include: {
           versions: {
             include: {
-              work_version: true, // only include work versions related to this submission version
+              work_version: {
+                select: { id: true, draft: true, cdn: true, cdn_key: true },
+              },
             },
           },
         },

--- a/packages/scms-server/src/backend/db.server.ts
+++ b/packages/scms-server/src/backend/db.server.ts
@@ -912,6 +912,7 @@ export async function dangerouslyHardDeleteDraftSubmissionVersions(
     for (const submissionVersion of draftSubmissionVersions) {
       await tx.submissionVersion.delete({
         where: { id: submissionVersion.id },
+        select: { id: true },
       });
     }
 
@@ -952,6 +953,7 @@ export async function dangerouslyHardDeleteDraftSubmissionVersions(
         // Then delete the work
         await tx.work.delete({
           where: { id: workId },
+          select: { id: true },
         });
       }
     }

--- a/packages/scms-server/src/backend/index.ts
+++ b/packages/scms-server/src/backend/index.ts
@@ -13,6 +13,7 @@ export * from './middleware.server.js';
 export * from './minimumClient.server.js';
 export * from './occ.server.js';
 export * from './prisma.server.js';
+export * from './prisma.selects.server.js';
 export * from './jwt.context.server.js';
 export * from './jobs/processing/index.js';
 export * from './roles.server.js';

--- a/packages/scms-server/src/backend/jobs/handlers/converter-task.server.ts
+++ b/packages/scms-server/src/backend/jobs/handlers/converter-task.server.ts
@@ -156,6 +156,7 @@ export async function converterTaskHandler(ctx: Context, data: CreateJob) {
       job_id: job.id,
       work_version_id: payload.work_version_id,
     },
+    select: { id: true },
   });
 
   const workVersionPayload = workVersionToPayload(workVersionRow);

--- a/packages/scms-server/src/backend/jobs/handlers/publish.server.ts
+++ b/packages/scms-server/src/backend/jobs/handlers/publish.server.ts
@@ -165,7 +165,7 @@ export async function publishHandler(
 
   // Only send email if this is the only published version for the submission
   const prisma = await getPrismaClient();
-  const allPublishedVersions = await prisma.submissionVersion.findMany({
+  const publishedVersionCount = await prisma.submissionVersion.count({
     where: {
       submission: {
         id: updated.submission_id,
@@ -173,7 +173,7 @@ export async function publishHandler(
       status: 'PUBLISHED',
     },
   });
-  if (allPublishedVersions.length === 1) {
+  if (publishedVersionCount === 1) {
     const emails: TemplatedResendEmail<
       typeof KnownResendEvents.SUBMISSION_PUBLISHED,
       SubmissionPublishedEmailProps

--- a/packages/scms-server/src/backend/jobs/handlers/unpublish.server.ts
+++ b/packages/scms-server/src/backend/jobs/handlers/unpublish.server.ts
@@ -140,7 +140,16 @@ export async function unpublishHandler(
   const prisma = await getPrismaClient();
   const sv = await prisma.submissionVersion.findFirst({
     where: { id: submission_version_id },
-    include: { submission: { include: { site: { select: { name: true } } } } },
+    select: {
+      id: true,
+      submission_id: true,
+      submission: {
+        select: {
+          id: true,
+          site: { select: { name: true } },
+        },
+      },
+    },
   });
   const siteName = sv?.submission?.site?.name;
 

--- a/packages/scms-server/src/backend/jobs/handlers/utils.server.ts
+++ b/packages/scms-server/src/backend/jobs/handlers/utils.server.ts
@@ -27,6 +27,7 @@ export async function updateCdnOnWorkVersion(
           },
         },
       },
+      select: { id: true },
     });
     if (!wv) throw Error('Work Version not updated');
     results = { ...results, work_version_updated: true, cdn: newCdn };
@@ -59,7 +60,14 @@ export async function validateSitePublishingScopes(ctx: Context, submission_vers
   const prisma = await getPrismaClient();
   const sv = await prisma.submissionVersion.findFirst({
     where: { id: submission_version_id },
-    include: { submission: { include: { site: { select: { name: true } } } } },
+    select: {
+      id: true,
+      submission: {
+        select: {
+          site: { select: { name: true } },
+        },
+      },
+    },
   });
   if (!sv) throw httpError(404, 'Submission version not found');
   if (

--- a/packages/scms-server/src/backend/loaders/activity.server.ts
+++ b/packages/scms-server/src/backend/loaders/activity.server.ts
@@ -50,6 +50,7 @@ export async function logActivity(data: LogActivityData): Promise<void> {
       transition: data.transition,
       date_published: data.datePublished,
     },
+    select: { id: true },
   });
 }
 

--- a/packages/scms-server/src/backend/loaders/my/works/list.server.ts
+++ b/packages/scms-server/src/backend/loaders/my/works/list.server.ts
@@ -5,6 +5,12 @@ import { getPrismaClient } from '../../../prisma.server.js';
 import type { UserDBO } from '../../../db.types.js';
 import { error401, error404 } from '@curvenote/scms-core';
 import { formatWorkDTO, getCanonicalOrLatestVersion } from '../../works/get.server.js';
+import { siteWorkWorkVersionSelect } from '../../../prisma.selects.server.js';
+
+const myWorksVersionSelect = {
+  ...siteWorkWorkVersionSelect,
+  date_modified: true,
+} satisfies Prisma.WorkVersionSelect;
 
 async function dbListWorksForUser(user: UserDBO, where: Prisma.WorkWhereInput = {}) {
   const prisma = await getPrismaClient();
@@ -22,6 +28,7 @@ async function dbListWorksForUser(user: UserDBO, where: Prisma.WorkWhereInput = 
         orderBy: {
           date_created: 'desc',
         },
+        select: myWorksVersionSelect,
       },
     },
     orderBy: {

--- a/packages/scms-server/src/backend/loaders/previews/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/previews/get.server.ts
@@ -1,4 +1,5 @@
 import { getPrismaClient } from '../../prisma.server.js';
+import { siteWorkWorkVersionSelect } from '../../prisma.selects.server.js';
 import type { SubmissionVersionDTO } from '@curvenote/common';
 import type { Context } from '../../context.server.js';
 import { error401, error404, scopes } from '@curvenote/scms-core';
@@ -30,7 +31,7 @@ export async function dbGetSubmissionVersion(id: string) {
           work: true,
         },
       },
-      work_version: true,
+      work_version: { select: siteWorkWorkVersionSelect },
     },
   });
 }

--- a/packages/scms-server/src/backend/loaders/roles.server.ts
+++ b/packages/scms-server/src/backend/loaders/roles.server.ts
@@ -232,6 +232,7 @@ export async function deleteRole(
 
       await tx.role.delete({
         where: { id },
+        select: { id: true },
       });
 
       return { success: true };

--- a/packages/scms-server/src/backend/loaders/roles.server.ts
+++ b/packages/scms-server/src/backend/loaders/roles.server.ts
@@ -134,6 +134,7 @@ export async function createRole(data: CreateRoleData): Promise<RoleWithCreator>
         activity_type: 'ROLE_CREATED',
         role_id: role.id,
       },
+      select: { id: true },
     });
 
     // Process scopes to ensure clean string array
@@ -186,6 +187,7 @@ export async function updateRole(
         activity_type: 'ROLE_UPDATED',
         role_id: role.id,
       },
+      select: { id: true },
     });
 
     // Process scopes to ensure clean string array
@@ -225,6 +227,7 @@ export async function deleteRole(
           activity_type: 'ROLE_DELETED',
           role_id: id,
         },
+        select: { id: true },
       });
 
       await tx.role.delete({

--- a/packages/scms-server/src/backend/loaders/sites/create.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/create.server.ts
@@ -305,6 +305,7 @@ export async function dbCreateSite(ctx: Context, siteData: CreateSiteData) {
               })),
             },
           },
+          select: { id: true },
         });
       }
       return created;

--- a/packages/scms-server/src/backend/loaders/sites/doi.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/doi.server.ts
@@ -3,6 +3,7 @@ import { getPrismaClient } from '../../prisma.server.js';
 import { error404 } from '@curvenote/scms-core';
 import { formatSiteWorkDTO } from './submissions/published/get.server.js';
 import type { SiteContext } from '../../context.site.server.js';
+import { siteWorkWorkVersionSelect } from '../../prisma.selects.server.js';
 
 export type SiteDoiResolveOptions = {
   /** If set, pick the latest *published* submission version for this DOI whose `tags` contains this string */
@@ -24,8 +25,9 @@ async function dbGetLatestPublishedWorkByDoi(doiNormalized: string) {
       date_created: 'desc',
     },
     take: 1,
-    include: {
-      work: true,
+    select: {
+      ...siteWorkWorkVersionSelect,
+      work: { select: { id: true, doi: true, key: true } },
       submissionVersions: {
         where: {
           status: 'PUBLISHED',
@@ -79,7 +81,7 @@ async function dbGetPublishedSubmissionVersionByDoiAndTag(
           work: true,
         },
       },
-      work_version: true,
+      work_version: { select: siteWorkWorkVersionSelect },
     },
   });
 }

--- a/packages/scms-server/src/backend/loaders/sites/submissions/create.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/create.server.ts
@@ -1,6 +1,11 @@
 import type { ClientExtension } from '@curvenote/scms-core';
 import { error401, TrackEvent, asSiteSubmissionUrl } from '@curvenote/scms-core';
 import { getPrismaClient } from '../../../prisma.server.js';
+import {
+  activitySubmissionVersionRefSelect,
+  activityWorkVersionRefSelect,
+  siteWorkWorkVersionWithWorkSelect,
+} from '../../../prisma.selects.server.js';
 import { formatSubmissionDTO } from './get.server.js';
 import { formatDate, normalizeExplicitTags } from '@curvenote/common';
 import type { UserDBO } from '../../../db.types.js';
@@ -37,6 +42,7 @@ export async function dbCreateNewSubmission(
     where: {
       id: workVersionId,
     },
+    select: { work_id: true },
   });
   const submissionTags = normalizeExplicitTags(tags);
   return prisma.$transaction(async (tx) => {
@@ -117,9 +123,7 @@ export async function dbCreateNewSubmission(
               include: {
                 submitted_by: true,
                 work_version: {
-                  include: {
-                    work: true,
-                  },
+                  select: siteWorkWorkVersionWithWorkSelect,
                 },
               },
               orderBy: {
@@ -167,8 +171,8 @@ export async function dbCreateNewSubmission(
       include: {
         kind: true,
         activity_by: true,
-        submission_version: true,
-        work_version: { include: { work: true } },
+        submission_version: { select: activitySubmissionVersionRefSelect },
+        work_version: { select: activityWorkVersionRefSelect },
       },
     });
 

--- a/packages/scms-server/src/backend/loaders/sites/submissions/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/get.server.ts
@@ -3,6 +3,11 @@ import type { SubmissionActivityDTO, SubmissionDTO, SubmissionLinksDTO } from '@
 import type { Prisma } from '@curvenote/scms-db';
 import type { SiteContext } from '../../../context.site.server.js';
 import { getPrismaClient } from '../../../prisma.server.js';
+import {
+  activitySubmissionVersionRefSelect,
+  activityWorkVersionRefSelect,
+  siteWorkWorkVersionWithWorkSelect,
+} from '../../../prisma.selects.server.js';
 import { signPrivateUrls } from '../../../sign.private.server.js';
 import type { ClientExtension } from '@curvenote/scms-core';
 import {
@@ -36,9 +41,7 @@ export async function dbGetSubmission(where: Prisma.SubmissionFindUniqueArgs['wh
         include: {
           submitted_by: true,
           work_version: {
-            include: {
-              work: true,
-            },
+            select: siteWorkWorkVersionWithWorkSelect,
           },
         },
         orderBy: {
@@ -49,8 +52,8 @@ export async function dbGetSubmission(where: Prisma.SubmissionFindUniqueArgs['wh
         include: {
           activity_by: true,
           kind: true,
-          submission_version: true,
-          work_version: true,
+          submission_version: { select: activitySubmissionVersionRefSelect },
+          work_version: { select: activityWorkVersionRefSelect },
         },
         orderBy: {
           date_created: 'desc',

--- a/packages/scms-server/src/backend/loaders/sites/submissions/list.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/list.server.ts
@@ -1,5 +1,9 @@
 import type { SiteContext } from '../../../context.site.server.js';
 import { getPrismaClient } from '../../../prisma.server.js';
+import {
+  activitySubmissionVersionRefSelect,
+  activityWorkVersionRefSelect,
+} from '../../../prisma.selects.server.js';
 import { coerceToObject, makePaginationLinks } from '@curvenote/scms-core';
 import type { Prisma } from '@curvenote/scms-db';
 import { formatAuthorDTO } from '../../../format.server.js';
@@ -67,8 +71,16 @@ export async function dbListSubmissions(
         include: {
           submitted_by: true,
           work_version: {
-            include: {
-              work: true,
+            select: {
+              id: true,
+              work_id: true,
+              metadata: true,
+              title: true,
+              description: true,
+              authors: true,
+              date: true,
+              doi: true,
+              work: { select: { id: true, doi: true } },
             },
           },
         },
@@ -80,8 +92,8 @@ export async function dbListSubmissions(
         include: {
           activity_by: true,
           kind: true,
-          submission_version: true,
-          work_version: true,
+          submission_version: { select: activitySubmissionVersionRefSelect },
+          work_version: { select: activityWorkVersionRefSelect },
         },
         orderBy: {
           date_created: 'desc',

--- a/packages/scms-server/src/backend/loaders/sites/submissions/published/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/published/get.server.ts
@@ -2,6 +2,7 @@ import type { SiteContext } from '../../../../context.site.server.js';
 import type { HostSpec, SiteWorkDTO } from '@curvenote/common';
 import { formatDate, concatSiteWorkTags } from '@curvenote/common';
 import { getPrismaClient } from '../../../../prisma.server.js';
+import { siteWorkWorkVersionSelect } from '../../../../prisma.selects.server.js';
 import { signPrivateUrls } from '../../../../sign.private.server.js';
 import { formatCollectionSummaryDTO } from '../../get.server.js';
 import { formatSubmissionKindSummaryDTO } from '../../kinds/get.server.js';
@@ -50,7 +51,7 @@ export async function dbGetLatestPublishedSubmissionVersion(
           work: true,
         },
       },
-      work_version: true,
+      work_version: { select: siteWorkWorkVersionSelect },
     },
   });
 }

--- a/packages/scms-server/src/backend/loaders/sites/submissions/published/list.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/published/list.server.ts
@@ -1,4 +1,5 @@
 import { getPrismaClient } from '../../../../prisma.server.js';
+import { siteWorkWorkVersionSelect } from '../../../../prisma.selects.server.js';
 import type { SiteContext } from '../../../../context.site.server.js';
 import type { SiteWorkListingDTO } from '@curvenote/common';
 import type { ClientExtension } from '@curvenote/scms-core';
@@ -83,7 +84,7 @@ async function dbQuerySubmissions(
         },
       },
       submitted_by: true,
-      work_version: true,
+      work_version: { select: siteWorkWorkVersionSelect },
     },
     orderBy: [
       {

--- a/packages/scms-server/src/backend/loaders/sites/submissions/versions/create.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/versions/create.server.ts
@@ -109,12 +109,7 @@ export async function dbCreateNewSubmissionVersionOnExistingSubmission(
           },
         },
       },
-      include: {
-        activity_by: true,
-        kind: true,
-        submission_version: true,
-        work_version: { include: { work: true } },
-      },
+      select: { id: true },
     });
 
     return sv;

--- a/packages/scms-server/src/backend/loaders/sites/submissions/versions/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/versions/get.server.ts
@@ -4,6 +4,7 @@ import type { Prisma } from '@curvenote/scms-db';
 import { signPrivateUrls } from '../../../../sign.private.server.js';
 import type { SiteContext } from '../../../../context.site.server.js';
 import { getPrismaClient } from '../../../../prisma.server.js';
+import { siteWorkWorkVersionWithWorkSelect } from '../../../../prisma.selects.server.js';
 import { coerceToObject, error404 } from '@curvenote/scms-core';
 import type { ModifiedSiteWorkDTO } from '../published/get.server.js';
 import { formatSiteWorkDTO } from '../published/get.server.js';
@@ -19,9 +20,7 @@ export async function dbGetSubmissionVersion(
     include: {
       submitted_by: true,
       work_version: {
-        include: {
-          work: true,
-        },
+        select: siteWorkWorkVersionWithWorkSelect,
       },
       submission: {
         include: {

--- a/packages/scms-server/src/backend/loaders/sites/submissions/versions/list.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/versions/list.server.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from '@curvenote/scms-db';
 import type { SubmissionVersionListingDTO } from '@curvenote/common';
 import { getPrismaClient } from '../../../../prisma.server.js';
+import { siteWorkWorkVersionWithWorkSelect } from '../../../../prisma.selects.server.js';
 import type { SiteContext } from '../../../../context.site.server.js';
 import { error404, makePaginationLinks } from '@curvenote/scms-core';
 import { formatSubmissionVersionDTO } from './get.server.js';
@@ -54,9 +55,7 @@ async function dbQuerySubmissionVersions(
       },
       submitted_by: true,
       work_version: {
-        include: {
-          work: true,
-        },
+        select: siteWorkWorkVersionWithWorkSelect,
       },
     },
     orderBy: [

--- a/packages/scms-server/src/backend/loaders/sites/submissions/versions/transition.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/versions/transition.server.ts
@@ -10,6 +10,11 @@ import {
   asSiteSubmissionUrl,
 } from '@curvenote/scms-core';
 import { getPrismaClient } from '../../../../prisma.server.js';
+import {
+  activitySubmissionVersionRefSelect,
+  activityWorkVersionRefSelect,
+  siteWorkWorkVersionWithWorkSelect,
+} from '../../../../prisma.selects.server.js';
 import { userHasScopes } from '../../../../scopes.helpers.server.js';
 import * as slugs from '../slugs.server.js';
 import type { SiteContext } from '../../../../context.site.server.js';
@@ -52,9 +57,7 @@ export async function dbGetLatestSubmissionVersionFromSubmission(
         },
       },
       work_version: {
-        include: {
-          work: true,
-        },
+        select: siteWorkWorkVersionWithWorkSelect,
       },
     },
   });
@@ -75,8 +78,8 @@ const include = {
       activity: {
         include: {
           activity_by: true,
-          submission_version: true,
-          work_version: true,
+          submission_version: { select: activitySubmissionVersionRefSelect },
+          work_version: { select: activityWorkVersionRefSelect },
           kind: true,
         },
       },
@@ -84,9 +87,7 @@ const include = {
       versions: {
         include: {
           work_version: {
-            include: {
-              work: true,
-            },
+            select: siteWorkWorkVersionWithWorkSelect,
           },
           submitted_by: true,
         },
@@ -96,9 +97,7 @@ const include = {
     },
   },
   work_version: {
-    include: {
-      work: true,
-    },
+    select: siteWorkWorkVersionWithWorkSelect,
   },
   submitted_by: true,
 };

--- a/packages/scms-server/src/backend/loaders/sites/submissions/versions/transition.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/versions/transition.server.ts
@@ -142,6 +142,7 @@ async function startJobBasedTransition(
         submission_version_id: existing.id,
         transition,
       },
+      select: { id: true },
     });
 
     // Handle job creation based on transition properties
@@ -227,6 +228,7 @@ async function performSimpleTransition(
         status: targetStateName,
         transition,
       },
+      select: { id: true },
     });
 
     return updated;

--- a/packages/scms-server/src/backend/loaders/sites/update.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/update.server.ts
@@ -54,6 +54,7 @@ export async function dbUpdateSiteContent(userId: string, name: string, content:
         },
         activity_type: ActivityType.SITE_CONTENT_UPDATED,
       },
+      select: { id: true },
     });
     return updated.content?.versions[0];
   });

--- a/packages/scms-server/src/backend/loaders/sites/works/thumbnail.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/works/thumbnail.server.ts
@@ -5,6 +5,7 @@ import {
 } from '../submissions/published/get.server.js';
 import { error401, error404 } from '@curvenote/scms-core';
 import { getPrismaClient } from '../../../prisma.server.js';
+import { cdnWorkVersionSelect } from '../../../prisma.selects.server.js';
 import * as cdnlib from '@curvenote/cdn';
 
 async function dbGetLatestSubmissionVersion(siteName: string, workIdOrSlug: string) {
@@ -37,7 +38,7 @@ async function dbGetLatestSubmissionVersion(siteName: string, workIdOrSlug: stri
       date_created: 'desc',
     },
     include: {
-      work_version: true,
+      work_version: { select: cdnWorkVersionSelect },
     },
   });
 }

--- a/packages/scms-server/src/backend/loaders/sites/works/versions/thumbnail.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/works/versions/thumbnail.server.ts
@@ -1,6 +1,7 @@
 import type { SiteContext } from '../../../../context.site.server.js';
 import { error401, error404 } from '@curvenote/scms-core';
 import { getPrismaClient } from '../../../../prisma.server.js';
+import { cdnWorkVersionSelect } from '../../../../prisma.selects.server.js';
 import * as cdnlib from '@curvenote/cdn';
 
 async function dbGetWorkVersion(siteName: string, versionId: string) {
@@ -9,6 +10,7 @@ async function dbGetWorkVersion(siteName: string, versionId: string) {
     where: {
       id: versionId,
     },
+    select: cdnWorkVersionSelect,
   });
 }
 

--- a/packages/scms-server/src/backend/loaders/unsubscribe.ts
+++ b/packages/scms-server/src/backend/loaders/unsubscribe.ts
@@ -33,6 +33,7 @@ export async function dbToggleUnsubscribe(email: string, unsubscribe: boolean) {
         email,
         date_created: new Date().toISOString(),
       },
+      select: { id: true },
     });
   } else {
     // Remove from unsubscribe list

--- a/packages/scms-server/src/backend/loaders/userRoles.server.ts
+++ b/packages/scms-server/src/backend/loaders/userRoles.server.ts
@@ -178,6 +178,7 @@ export async function assignRoleToUser(data: AssignRoleData): Promise<UserRoleWi
         user_id: data.userId,
         role_id: data.roleId,
       },
+      select: { id: true },
     });
 
     return userRole;
@@ -221,6 +222,7 @@ export async function removeRoleFromUser(
           user_id: userRole.user_id,
           role_id: userRole.role_id,
         },
+        select: { id: true },
       });
 
       // Delete the user role after logging the activity

--- a/packages/scms-server/src/backend/loaders/userRoles.server.ts
+++ b/packages/scms-server/src/backend/loaders/userRoles.server.ts
@@ -228,6 +228,7 @@ export async function removeRoleFromUser(
       // Delete the user role after logging the activity
       await tx.userRole.delete({
         where: { id: userRoleId },
+        select: { id: true },
       });
 
       return { success: true };

--- a/packages/scms-server/src/backend/loaders/works/create.server.ts
+++ b/packages/scms-server/src/backend/loaders/works/create.server.ts
@@ -171,6 +171,7 @@ export async function dbCreateWorkAndVersion(
           },
         },
       },
+      select: { id: true },
     });
 
     return work;

--- a/packages/scms-server/src/backend/loaders/works/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/works/get.server.ts
@@ -9,6 +9,7 @@ import { dbGetSubmission } from '../sites/submissions/get.server.js';
 import { signPrivateUrls } from '../../sign.private.server.js';
 import type { WorkRole } from '@curvenote/scms-db';
 import { userHasSiteScope } from '../../scopes.helpers.server.js';
+import { siteWorkWorkVersionSelect } from '../../prisma.selects.server.js';
 
 export type WorkAndVersionsDBO = WorkDBO & { versions?: WorkVersionDBO[] };
 export type WorkUserDBO = { work_id: string; user_id: string; role: WorkRole };
@@ -98,6 +99,7 @@ export async function dbGetWorkForUser(
     },
     include: {
       versions: {
+        select: siteWorkWorkVersionSelect,
         orderBy: {
           date_created: 'desc',
         },
@@ -116,6 +118,7 @@ export async function dbGetWork(workId: string): Promise<WorkAndVersionsDBO | nu
     },
     include: {
       versions: {
+        select: siteWorkWorkVersionSelect,
         orderBy: {
           date_created: 'desc',
         },

--- a/packages/scms-server/src/backend/loaders/works/versions/create.server.ts
+++ b/packages/scms-server/src/backend/loaders/works/versions/create.server.ts
@@ -86,6 +86,7 @@ export async function dbCreateWorkVersionAndUpdateWork(
           },
         },
       },
+      select: { id: true },
     });
     return work;
   });

--- a/packages/scms-server/src/backend/loaders/works/versions/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/works/versions/get.server.ts
@@ -7,6 +7,7 @@ export async function dbGetWorkVersion(workId: string, workVersionId: string) {
       id: workVersionId,
       work_id: workId,
     },
+    select: { id: true },
   });
   return workVersion;
 }

--- a/packages/scms-server/src/backend/prisma.selects.server.ts
+++ b/packages/scms-server/src/backend/prisma.selects.server.ts
@@ -1,0 +1,44 @@
+import type { Prisma } from '@curvenote/scms-db';
+
+/** WorkVersion scalars used by formatSiteWorkDTO and formatWorkDTO (excludes metadata). */
+export const siteWorkWorkVersionSelect = {
+  id: true,
+  work_id: true,
+  cdn: true,
+  cdn_key: true,
+  title: true,
+  description: true,
+  authors: true,
+  tags: true,
+  doi: true,
+  canonical: true,
+  date_created: true,
+  date: true,
+  draft: true,
+  occ: true,
+} satisfies Prisma.WorkVersionSelect;
+
+/** WorkVersion + work for site-work DTOs that fall back to work.doi/key. */
+export const siteWorkWorkVersionWithWorkSelect = {
+  ...siteWorkWorkVersionSelect,
+  work: { select: { id: true, doi: true, key: true } },
+} satisfies Prisma.WorkVersionSelect;
+
+/** CDN / storage admin paths (excludes metadata). */
+export const cdnWorkVersionSelect = {
+  id: true,
+  work_id: true,
+  cdn: true,
+  cdn_key: true,
+} satisfies Prisma.WorkVersionSelect;
+
+/** Activity feed refs — avoid full version payloads. */
+export const activitySubmissionVersionRefSelect = {
+  id: true,
+  date_created: true,
+} satisfies Prisma.SubmissionVersionSelect;
+
+export const activityWorkVersionRefSelect = {
+  id: true,
+  date_created: true,
+} satisfies Prisma.WorkVersionSelect;

--- a/packages/scms-server/src/backend/prisma.selects.server.ts
+++ b/packages/scms-server/src/backend/prisma.selects.server.ts
@@ -18,6 +18,13 @@ export const siteWorkWorkVersionSelect = {
   occ: true,
 } satisfies Prisma.WorkVersionSelect;
 
+/** Work details route: version scalars + submission graph (excludes metadata JSON). */
+export const workDetailsWorkVersionSelect = {
+  ...siteWorkWorkVersionSelect,
+  date_modified: true,
+  author_details: true,
+} satisfies Prisma.WorkVersionSelect;
+
 /** WorkVersion + work for site-work DTOs that fall back to work.doi/key. */
 export const siteWorkWorkVersionWithWorkSelect = {
   ...siteWorkWorkVersionSelect,

--- a/packages/scms-server/src/backend/prisma.selects.server.ts
+++ b/packages/scms-server/src/backend/prisma.selects.server.ts
@@ -1,6 +1,6 @@
 import type { Prisma } from '@curvenote/scms-db';
 
-/** WorkVersion scalars used by formatSiteWorkDTO and formatWorkDTO (excludes metadata). */
+/** WorkVersion scalars used by formatSiteWorkDTO, formatWorkDTO, and WorkContext (excludes metadata). */
 export const siteWorkWorkVersionSelect = {
   id: true,
   work_id: true,

--- a/packages/scms-server/src/backend/services/emails/resend.server.ts
+++ b/packages/scms-server/src/backend/services/emails/resend.server.ts
@@ -98,6 +98,7 @@ async function logEmailToMessages(
         payload,
         results,
       },
+      select: { id: true },
     });
   } catch (error) {
     // Don't fail email send if logging fails

--- a/packages/scms-server/src/backend/services/magic-links.server.ts
+++ b/packages/scms-server/src/backend/services/magic-links.server.ts
@@ -215,6 +215,7 @@ export async function deleteMagicLink(linkId: string): Promise<void> {
   // Access logs are preserved for audit history (FK constraint removed to allow this)
   await prisma.magicLink.delete({
     where: { id: linkId },
+    select: { id: true },
   });
 }
 

--- a/packages/scms-server/src/backend/services/messages.server.ts
+++ b/packages/scms-server/src/backend/services/messages.server.ts
@@ -93,5 +93,9 @@ export async function updateMessageStatus(
       ...(results as any),
     };
   }
-  await prisma.message.update({ where: { id: messageId }, data });
+  await prisma.message.update({
+    where: { id: messageId },
+    data,
+    select: { id: true },
+  });
 }

--- a/packages/scms-server/src/backend/signup/index.server.ts
+++ b/packages/scms-server/src/backend/signup/index.server.ts
@@ -343,6 +343,7 @@ export async function updateSignupStep(
         },
       },
     },
+    select: { id: true },
   });
 }
 
@@ -383,6 +384,7 @@ export async function completeSignupStep(
         },
       },
     },
+    select: { id: true },
   });
 }
 

--- a/packages/scms-server/src/backend/uploads/remove.server.ts
+++ b/packages/scms-server/src/backend/uploads/remove.server.ts
@@ -10,6 +10,7 @@ import { StorageBackend } from '../storage/backend.server.js';
 import { File } from '../storage/file.server.js';
 import { KnownBuckets } from '../storage/constants.server.js';
 import type { WorkContext } from '../context.work.server.js';
+import { getPrismaClient } from '../prisma.server.js';
 
 export async function workVersionUploadRemove(
   ctx: WorkContext,
@@ -58,8 +59,13 @@ export async function workVersionUploadRemove(
   // Check if we're operating on the latest work version (versions are already sorted by date_created desc)
   const isLatestVersion = ctx.work.versions[0].id === workVersionId;
 
-  // Get the file metadata from the current work version
-  const workVersionMetadata = currentWorkVersion.metadata as FileMetadataSection | null;
+  // Metadata is not loaded on WorkContext; fetch only what we need for storage deletion checks.
+  const prisma = await getPrismaClient();
+  const versionWithMetadata = await prisma.workVersion.findUnique({
+    where: { id: workVersionId },
+    select: { metadata: true },
+  });
+  const workVersionMetadata = versionWithMetadata?.metadata as FileMetadataSection | null;
   const fileMetadata = workVersionMetadata?.files?.[path];
   if (!fileMetadata) {
     console.warn(`File ${path} not found in metadata, skipping storage deletion`);

--- a/packages/scms-server/src/modules/auth/bluesky/oauth-authorization-state.server.ts
+++ b/packages/scms-server/src/modules/auth/bluesky/oauth-authorization-state.server.ts
@@ -67,6 +67,7 @@ export const oauthAuthorizationStateStore = {
         payload,
         expires_at: expiresAt,
       },
+      select: { state: true },
     });
   },
 

--- a/packages/scms-server/src/modules/auth/bluesky/oauth-session-store.server.ts
+++ b/packages/scms-server/src/modules/auth/bluesky/oauth-session-store.server.ts
@@ -39,6 +39,7 @@ export const blueskyOAuthSessionStore = {
           date_created: now,
           date_modified: now,
         },
+        select: { id: true },
       });
     });
   },

--- a/packages/scms-server/src/modules/auth/bluesky/session-db.server.ts
+++ b/packages/scms-server/src/modules/auth/bluesky/session-db.server.ts
@@ -52,6 +52,7 @@ export async function persistBlueskySessionForLinkedAccount(
             : {}),
           date_modified: now,
         },
+        select: { id: true },
       });
     } else {
       await sessionTx.userLinkedAccountSession.create({
@@ -69,6 +70,7 @@ export async function persistBlueskySessionForLinkedAccount(
           date_created: now,
           date_modified: now,
         },
+        select: { id: true },
       });
     }
   });

--- a/packages/scms-server/src/modules/auth/common.server.ts
+++ b/packages/scms-server/src/modules/auth/common.server.ts
@@ -99,6 +99,7 @@ export async function dbDeletePendingUser(userId: string): Promise<void> {
     // Delete the pending user
     await tx.user.delete({
       where: { id: userId },
+      select: { id: true },
     });
   });
 }

--- a/platform/scms/README.md
+++ b/platform/scms/README.md
@@ -62,6 +62,16 @@ Make two copies of the `.env.sample` file, called `.env.development` and `.env.t
 
 Add your firebase config and secrets to both.
 
+#### Prisma query logging (optional)
+
+To log every Prisma SQL query to the dev server console (useful when tuning loaders or checking N+1 queries), uncomment or add this to your local env file (e.g. `.env.development`):
+
+```
+PRISMA_DEBUG_QUERIES=true
+```
+
+Accepted values are `true`, `1`, or `yes`. Each query is printed with duration, SQL, and parameters. This flag is **ignored in production** (`NODE_ENV=production`), so it is safe to leave in a local env file.
+
 ### Seed
 
 To reset and seed the database for **initial** development work. This needs to be run from the top level.

--- a/platform/scms/app/routes/api/v1.works.tsx
+++ b/platform/scms/app/routes/api/v1.works.tsx
@@ -151,6 +151,7 @@ async function dbCreateManualWorkAndVersion(
         work: { connect: { id: workId } },
         work_version: { connect: { id: workVersionId } },
       },
+      select: { id: true },
     });
     return { work, version };
   });

--- a/platform/scms/app/routes/app/platform.users/db.server.ts
+++ b/platform/scms/app/routes/app/platform.users/db.server.ts
@@ -170,6 +170,7 @@ export async function dbToggleUserDisabled(
         user_id: id,
         status: disabled ? 'DISABLED' : 'ENABLED',
       },
+      select: { id: true },
     });
 
     return user;
@@ -200,6 +201,7 @@ export async function dbApproveUser(userId: string, activityByUserId: string) {
         user_id: userId,
         status: 'APPROVED',
       },
+      select: { id: true },
     });
 
     return user;
@@ -231,6 +233,7 @@ export async function dbRejectUser(userId: string, activityByUserId: string) {
         user_id: userId,
         status: 'REJECTED',
       },
+      select: { id: true },
     });
 
     return user;

--- a/platform/scms/app/routes/app/resources.csp-report.tsx
+++ b/platform/scms/app/routes/app/resources.csp-report.tsx
@@ -181,6 +181,7 @@ async function persistReport(extracted: ExtractedReport) {
       user_agent_sample: extracted.userAgentSample,
       latest_payload: extracted.latestPayload as object,
     },
+    select: { id: true },
   });
 }
 

--- a/platform/scms/app/routes/app/route.system.storage.tsx
+++ b/platform/scms/app/routes/app/route.system.storage.tsx
@@ -8,6 +8,7 @@ import {
   getPrismaClient,
   StorageBackend,
   sites as sitesLoader,
+  cdnWorkVersionSelect,
 } from '@curvenote/scms-server';
 import {
   KnownBuckets,
@@ -44,7 +45,7 @@ async function dbListAllSubmissions(siteName: string) {
       site: { include: { submissionKinds: true } },
       versions: {
         include: {
-          work_version: true,
+          work_version: { select: cdnWorkVersionSelect },
         },
         orderBy: {
           date_created: 'desc',

--- a/platform/scms/app/routes/app/route.system.storage.tsx
+++ b/platform/scms/app/routes/app/route.system.storage.tsx
@@ -281,6 +281,7 @@ async function actionUpdateCdnReference(ctx: Context, formData: FormData) {
       cdn: new_cdn,
       date_modified: new Date().toISOString(),
     },
+    select: { id: true },
   });
 
   return { cdn: new_cdn, warning };

--- a/platform/scms/app/routes/app/system.migrate/db.server.ts
+++ b/platform/scms/app/routes/app/system.migrate/db.server.ts
@@ -202,6 +202,7 @@ export async function dbSetDefaultDomain(domainId: string): Promise<void> {
     await tx.domain.update({
       where: { id: domainId },
       data: { default: true },
+      select: { id: true },
     });
   });
 }

--- a/platform/scms/app/routes/app/system.migrate/db.server.ts
+++ b/platform/scms/app/routes/app/system.migrate/db.server.ts
@@ -134,7 +134,7 @@ export async function dbAddWorkToSubmission(id: string) {
     include: {
       versions: {
         include: {
-          work_version: true,
+          work_version: { select: { work_id: true } },
         },
         orderBy: {
           date_created: 'desc',

--- a/platform/scms/app/routes/app/system.roles/systemRoleScopes.server.ts
+++ b/platform/scms/app/routes/app/system.roles/systemRoleScopes.server.ts
@@ -75,7 +75,7 @@ export async function updateSystemRoleScopes(
         date_modified: now,
         scopes,
       },
-      select: { id: true },
+      select: { role: true },
     });
 
     await tx.activity.create({

--- a/platform/scms/app/routes/app/system.roles/systemRoleScopes.server.ts
+++ b/platform/scms/app/routes/app/system.roles/systemRoleScopes.server.ts
@@ -75,6 +75,7 @@ export async function updateSystemRoleScopes(
         date_modified: now,
         scopes,
       },
+      select: { id: true },
     });
 
     await tx.activity.create({
@@ -90,6 +91,7 @@ export async function updateSystemRoleScopes(
           system_role: true,
         },
       },
+      select: { id: true },
     });
   });
 
@@ -128,6 +130,7 @@ export async function deleteSystemRoleScopes(
           deleted: true,
         },
       },
+      select: { id: true },
     });
   });
 

--- a/platform/scms/app/routes/app/system.submissions/db.server.ts
+++ b/platform/scms/app/routes/app/system.submissions/db.server.ts
@@ -18,12 +18,36 @@ export async function dbGetSiteSubmission(siteName: string) {
         },
         include: {
           work_version: {
-            include: {
+            select: {
+              id: true,
+              work_id: true,
+              date_created: true,
+              date: true,
+              title: true,
+              description: true,
+              authors: true,
+              doi: true,
+              cdn: true,
+              cdn_key: true,
+              draft: true,
+              canonical: true,
+              tags: true,
               work: {
-                include: {
+                select: {
+                  id: true,
+                  doi: true,
+                  key: true,
                   work_users: {
-                    include: {
-                      user: true,
+                    select: {
+                      id: true,
+                      role: true,
+                      user: {
+                        select: {
+                          id: true,
+                          display_name: true,
+                          email: true,
+                        },
+                      },
                     },
                   },
                 },

--- a/platform/scms/app/routes/app/works.$workId.checks/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.checks/db.server.ts
@@ -23,6 +23,15 @@ export async function dbGetLatestWorkVersion(workId: string) {
   return latestVersion;
 }
 
+/** Latest finalized version including metadata (checks page only — not loaded on WorkContext). */
+export async function dbGetLatestNonDraftWorkVersion(workId: string) {
+  const prisma = await getPrismaClient();
+  return prisma.workVersion.findFirst({
+    where: { work_id: workId, draft: false },
+    orderBy: { date_created: 'desc' },
+  });
+}
+
 /**
  * Format a work version as a DTO
  */

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -18,7 +18,7 @@ import {
   useDeploymentConfig,
   ui,
 } from '@curvenote/scms-core';
-import { formatWorkVersionDTO } from './db.server';
+import { dbGetLatestNonDraftWorkVersion, formatWorkVersionDTO } from './db.server';
 import {
   dbGetCheckServiceRunsByWorkVersionIds,
   type CheckServiceRunRow,
@@ -56,7 +56,11 @@ export async function loader(args: Route.LoaderArgs) {
     throw httpError(404, 'No finalized work version found');
   }
 
-  const latestVersion = nonDraftVersions[0];
+  const latestVersion = await dbGetLatestNonDraftWorkVersion(ctx.work.id);
+  if (!latestVersion) {
+    throw httpError(404, 'No finalized work version found');
+  }
+
   const metadata = (latestVersion.metadata ??
     makeDefaultWorkVersionMetadata()) as WorkVersionMetadata &
     FileMetadataSection &

--- a/platform/scms/app/routes/app/works.$workId.details/WorkDetailsContentCard.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkDetailsContentCard.tsx
@@ -1,18 +1,10 @@
 import { ExternalLink } from 'lucide-react';
 import { primitives, summarizeAuthors, ui } from '@curvenote/scms-core';
+import type { WorkVersionContentCardData } from '../works.$workId/types';
 
 type AuthorLike = { name?: string; family?: string; given?: string };
 
-type WorkVersionForCard = {
-  title: string;
-  authors: string[];
-  author_details?: unknown[];
-  doi?: string | null;
-  /** Accepts Prisma JsonValue (string | number | boolean | object | array | null) and other shapes */
-  metadata?: unknown;
-};
-
-function getAuthorsForDisplay(version: WorkVersionForCard): AuthorLike[] {
+function getAuthorsForDisplay(version: WorkVersionContentCardData): AuthorLike[] {
   const details = version.author_details;
   if (Array.isArray(details) && details.length > 0) {
     return details.map((d) => {
@@ -29,24 +21,7 @@ function getAuthorsForDisplay(version: WorkVersionForCard): AuthorLike[] {
   return (version.authors ?? []).map((name) => ({ name }));
 }
 
-function getLicenseDisplay(version: WorkVersionForCard): { text: string; tooltip?: string } {
-  const meta = version.metadata;
-  if (meta && typeof meta === 'object' && !Array.isArray(meta)) {
-    const record = meta as Record<string, unknown>;
-    const license = record.license;
-    if (license != null && license !== '') {
-      if (typeof license === 'string') return { text: license };
-      if (typeof license === 'object' && license !== null && 'content' in license) {
-        const content = (license as { content?: { id?: string; name?: string } }).content;
-        const id = content?.id ?? content?.name;
-        if (id) return { text: String(id) };
-      }
-    }
-  }
-  return { text: 'unknown', tooltip: 'No license has been set.' };
-}
-
-export function WorkDetailsContentCard({ version }: { version: WorkVersionForCard | null }) {
+export function WorkDetailsContentCard({ version }: { version: WorkVersionContentCardData | null }) {
   if (!version) {
     return (
       <primitives.Card className="p-6">
@@ -57,7 +32,7 @@ export function WorkDetailsContentCard({ version }: { version: WorkVersionForCar
 
   const authorsForDisplay = getAuthorsForDisplay(version);
   const authorSummary = summarizeAuthors(authorsForDisplay, { maxDisplay: 5 }) || 'Unknown authors';
-  const licenseDisplay = getLicenseDisplay(version);
+  const licenseDisplay = version.license;
   const hasDoi = version.doi != null && String(version.doi).trim() !== '';
   const doiValue = hasDoi ? String(version.doi).trim() : 'none';
   const doiHref = hasDoi ? `https://doi.org/${encodeURIComponent(doiValue)}` : null;

--- a/platform/scms/app/routes/app/works.$workId.details/WorkDetailsContentCard.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkDetailsContentCard.tsx
@@ -21,7 +21,11 @@ function getAuthorsForDisplay(version: WorkVersionContentCardData): AuthorLike[]
   return (version.authors ?? []).map((name) => ({ name }));
 }
 
-export function WorkDetailsContentCard({ version }: { version: WorkVersionContentCardData | null }) {
+export function WorkDetailsContentCard({
+  version,
+}: {
+  version: WorkVersionContentCardData | null;
+}) {
   if (!version) {
     return (
       <primitives.Card className="p-6">

--- a/platform/scms/app/routes/app/works.$workId.details/WorkDetailsTopBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkDetailsTopBar.tsx
@@ -10,12 +10,12 @@ type WorkUser = {
   work_roles: string[];
 };
 
-/** Minimal shape for latest version used for resume-draft vs upload-new. */
 export type WorkDetailsUploadProps = {
   canUpload: boolean;
   workBasePath: string;
-  /** Latest work version (versions[0]); used to decide resume vs create and for resume target. */
-  latestVersion: { id: string; draft?: boolean; metadata?: unknown } | null | undefined;
+  /** Computed on the server from latest draft metadata.checks. */
+  canResumeDraft: boolean;
+  resumeDraftVersionId?: string;
 };
 
 function getInitials(displayName: string | null): string {
@@ -29,20 +29,6 @@ function getInitials(displayName: string | null): string {
   return displayName.slice(0, 2).toUpperCase();
 }
 
-/** True when the latest version is a draft with checks metadata (resumable). */
-export function canResumeDraft(
-  canUpload: boolean,
-  latestVersion: WorkDetailsUploadProps['latestVersion'],
-): boolean {
-  return (
-    canUpload === true &&
-    latestVersion?.draft === true &&
-    latestVersion.metadata != null &&
-    typeof latestVersion.metadata === 'object' &&
-    'checks' in latestVersion.metadata
-  );
-}
-
 export function WorkDetailsTopBar({
   workId,
   users,
@@ -53,7 +39,7 @@ export function WorkDetailsTopBar({
   /** When provided, the top bar owns the upload button and resume vs create-new-version logic. */
   uploadProps: WorkDetailsUploadProps;
 }) {
-  const { canUpload, workBasePath, latestVersion } = uploadProps;
+  const { canUpload, workBasePath, canResumeDraft, resumeDraftVersionId } = uploadProps;
   const navigate = useNavigate();
   const fetcher = useFetcher<{
     intent?: string;
@@ -62,13 +48,12 @@ export function WorkDetailsTopBar({
     workVersionId?: string;
   }>();
 
-  const resumeDraft = canResumeDraft(canUpload, latestVersion);
-  const uploadButtonLabel = resumeDraft ? 'Resume Draft Version' : 'Create new version';
+  const uploadButtonLabel = canResumeDraft ? 'Resume Draft Version' : 'Create new version';
 
   const handleUploadAction = () => {
     if (!canUpload) return;
-    if (resumeDraft && latestVersion) {
-      navigate(`${workBasePath}/upload/${latestVersion.id}?from=details`);
+    if (canResumeDraft && resumeDraftVersionId) {
+      navigate(`${workBasePath}/upload/${resumeDraftVersionId}?from=details`);
       return;
     }
     const formData = new FormData();

--- a/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
@@ -1,6 +1,6 @@
 import { useSearchParams } from 'react-router';
 import { formatDate, scopes, ui } from '@curvenote/scms-core';
-import type { WorkVersionWithSubmissionVersions } from '../works.$workId/types';
+import type { WorkVersionForDetailsClient } from '../works.$workId/types';
 import type { WorkActivityRow, CheckServiceRunRow } from '../works.$workId/db.server';
 import type { Workflow, ClientExtensionCheckService } from '@curvenote/scms-core';
 import type { LinkedJobsByWorkVersionId } from './types';
@@ -16,7 +16,7 @@ import {
   useTimelineActivitiesVisibility,
 } from './timeline/TimelineActivitiesVisibility';
 
-type SubmissionVersionRow = WorkVersionWithSubmissionVersions['submissionVersions'][number];
+type SubmissionVersionRow = WorkVersionForDetailsClient['submissionVersions'][number];
 
 /** Unified timeline entry for chronological sorting. Date is ISO-like for sort order (newest first). */
 type TimelineEntry =
@@ -24,7 +24,7 @@ type TimelineEntry =
       kind: 'work-version';
       date: string;
       key: string;
-      version: WorkVersionWithSubmissionVersions;
+      version: WorkVersionForDetailsClient;
     }
   | {
       kind: 'submission';
@@ -43,7 +43,7 @@ type TimelineEntry =
       date: string;
       key: string;
       run: CheckServiceRunRow;
-      version: WorkVersionWithSubmissionVersions;
+      version: WorkVersionForDetailsClient;
     };
 
 /** Latest run id for each check `kind` across all versions (by `date_created`). */
@@ -83,7 +83,7 @@ function toMinuteKey(dateStr: string): number {
 
 /** Build section entries and sort by date descending (most recent first). */
 function getSortedSectionEntries(
-  version: WorkVersionWithSubmissionVersions,
+  version: WorkVersionForDetailsClient,
   submissionVersionsToShow: SubmissionVersionRow[],
   activitiesForVersion: WorkActivityRow[],
   checkRunsForVersion: CheckServiceRunRow[],
@@ -138,7 +138,7 @@ function getSortedSectionEntries(
 }
 
 type WorkVersionTimelineProps = {
-  versions: WorkVersionWithSubmissionVersions[];
+  versions: WorkVersionForDetailsClient[];
   workflows: Record<string, Workflow>;
   /** Work owner display name; used for "Work version created by" */
   workOwnerName?: string | null;

--- a/platform/scms/app/routes/app/works.$workId.details/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/route.tsx
@@ -14,7 +14,8 @@ import { WorkDetailsContentCard } from './WorkDetailsContentCard';
 import { SubmittedToBar } from './SubmittedToBar';
 import type {
   SubmissionWithVersionsAndSite,
-  WorkVersionWithSubmissionVersions,
+  WorkVersionContentCardData,
+  WorkVersionForDetailsClient,
 } from '../works.$workId/types';
 import type { WorkActivityRow, CheckServiceRunRow } from '../works.$workId/db.server';
 import type { LinkedJobsByWorkVersionId } from './types';
@@ -31,13 +32,16 @@ type LoaderData = {
   userScopes: string[];
   workflows: Record<string, Workflow>;
   work: WorkDTO;
-  versions: WorkVersionWithSubmissionVersions[];
+  versions: WorkVersionForDetailsClient[];
   submissions: SubmissionWithVersionsAndSite[];
   linkedJobsByWorkVersionId: Promise<LinkedJobsByWorkVersionId>;
   workOwnerName: string | null;
   activities: WorkActivityRow[];
   checkServiceRunsByWorkVersionId: Record<string, CheckServiceRunRow[]>;
   canUpload: boolean;
+  canResumeDraft: boolean;
+  resumeDraftVersionId?: string;
+  latestNonDraftContentCard: WorkVersionContentCardData | null;
   users: WorkUser[];
 };
 
@@ -58,6 +62,9 @@ export default function WorkDetailRoute() {
     activities,
     checkServiceRunsByWorkVersionId,
     canUpload,
+    canResumeDraft,
+    resumeDraftVersionId,
+    latestNonDraftContentCard,
     users,
   } = useRouteLoaderData('routes/app/works.$workId/route') as LoaderData;
 
@@ -78,14 +85,6 @@ export default function WorkDetailRoute() {
   );
 
   const workBasePath = `/app/works/${work.id}`;
-  // Versions are ordered by date_modified desc; latest is first.
-  const latestVersion = versions[0];
-
-  // Prefer the latest non-draft work version for user-facing "Last updated" copy.
-  const latestNonDraftWorkVersion = versions.find((v) => !v.draft);
-  const lastUpdatedDate =
-    latestNonDraftWorkVersion?.date_modified ?? versions[0]?.date_modified ?? undefined;
-
   const basePath = `/app/works/${work.id}`;
 
   return (
@@ -97,10 +96,15 @@ export default function WorkDetailRoute() {
         <WorkDetailsTopBar
           workId={work.id}
           users={users}
-          uploadProps={{ canUpload, workBasePath, latestVersion }}
+          uploadProps={{
+            canUpload,
+            workBasePath,
+            canResumeDraft,
+            resumeDraftVersionId,
+          }}
         />
         <div className="space-y-1">
-          <WorkDetailsContentCard version={latestNonDraftWorkVersion ?? null} />
+          <WorkDetailsContentCard version={latestNonDraftContentCard} />
           <SubmittedToBar submissions={submissions} workflows={workflows} basePath={basePath} />
         </div>
         <div>

--- a/platform/scms/app/routes/app/works.$workId.site.$siteName.submission.$submissionVersionId/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.site.$siteName.submission.$submissionVersionId/db.server.ts
@@ -1,4 +1,8 @@
-import { getPrismaClient } from '@curvenote/scms-server';
+import {
+  getPrismaClient,
+  siteWorkWorkVersionWithWorkSelect,
+  cdnWorkVersionSelect,
+} from '@curvenote/scms-server';
 
 export async function getSubmissionVersionsForWorkAndSite(workId: string, siteName: string) {
   const prisma = await getPrismaClient();
@@ -18,7 +22,7 @@ export async function getSubmissionVersionsForWorkAndSite(workId: string, siteNa
       },
     },
     include: {
-      work_version: true,
+      work_version: { select: cdnWorkVersionSelect },
       submission: {
         include: {
           site: true,
@@ -68,9 +72,7 @@ export async function getSubmissionVersion(submissionVersionId: string) {
     },
     include: {
       work_version: {
-        include: {
-          work: true,
-        },
+        select: siteWorkWorkVersionWithWorkSelect,
       },
       submission: {
         include: {

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/db.server.ts
@@ -120,10 +120,12 @@ export async function dbUpdateWorkAndVersionTimestamps(workId: string, versionId
     prisma.work.update({
       where: { id: workId },
       data: { date_modified: now },
+      select: { id: true },
     }),
     prisma.workVersion.update({
       where: { id: versionId },
       data: { date_modified: now },
+      select: { id: true },
     }),
   ]);
 }

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/fetchPreviews.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/fetchPreviews.server.ts
@@ -211,6 +211,7 @@ export async function fetchDocxPreviews(
                 occ: 0,
                 ...(ctx.user?.id ? { created_by_id: ctx.user.id } : {}),
               },
+              select: { id: true },
             });
           } catch (createErr: unknown) {
             const code = (createErr as { code?: string })?.code;

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/updateMetadata.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/updateMetadata.server.ts
@@ -14,6 +14,7 @@ export async function updateWorkVersionTitle(workVersionId: string, title: strin
         title,
         date_modified: new Date().toISOString(),
       },
+      select: { id: true },
     });
 
     return { success: true };
@@ -49,6 +50,7 @@ export async function updateWorkVersionAuthors(workVersionId: string, authorsTex
         authors,
         date_modified: new Date().toISOString(),
       },
+      select: { id: true },
     });
 
     return { success: true };

--- a/platform/scms/app/routes/app/works.$workId/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/db.server.ts
@@ -215,7 +215,7 @@ export async function dbDeleteDraftVersionOnWork(
         : 'No versions found',
     };
   }
-  await prisma.workVersion.delete({ where: { id: latest.id } });
+  await prisma.workVersion.delete({ where: { id: latest.id }, select: { id: true } });
   await deleteWorkVersionStorage(ctx, latest);
   return { deleted: true };
 }

--- a/platform/scms/app/routes/app/works.$workId/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/db.server.ts
@@ -1,6 +1,11 @@
-import { getPrismaClient, StorageBackend, KnownBuckets, Folder } from '@curvenote/scms-server';
+import {
+  getPrismaClient,
+  StorageBackend,
+  KnownBuckets,
+  Folder,
+} from '@curvenote/scms-server';
 import type { SecureContext } from '@curvenote/scms-server';
-import type { WorkVersion } from '@curvenote/scms-db';
+import type { Prisma, WorkVersion } from '@curvenote/scms-db';
 
 export type LinkedJobWithStatus = { id: string; status: string };
 
@@ -79,33 +84,112 @@ export async function dbGetWorkOwnerName(workId: string): Promise<string | null>
   return work?.created_by?.display_name ?? null;
 }
 
-export async function dbGetWorkVersionsWithSubmissionVersions(workId: string) {
+/** Batch-fetch metadata JSON for work versions (separate from the submission graph query). */
+export async function dbAttachMetadataToWorkVersions<T extends { id: string }>(
+  versions: T[],
+): Promise<(T & { metadata: Prisma.JsonValue | null })[]> {
+  if (versions.length === 0) return [];
+  const prisma = await getPrismaClient();
+  const rows = await prisma.workVersion.findMany({
+    where: { id: { in: versions.map((v) => v.id) } },
+    select: { id: true, metadata: true },
+  });
+  const metadataById = new Map(rows.map((row) => [row.id, row.metadata]));
+  return versions.map((version) => ({
+    ...version,
+    metadata: metadataById.get(version.id) ?? null,
+  }));
+}
+
+/** Latest work version row — used by actions that only need the head version (+ metadata). */
+export async function dbGetLatestWorkVersionForWork(workId: string) {
+  const prisma = await getPrismaClient();
+  return prisma.workVersion.findFirst({
+    where: { work_id: workId },
+    orderBy: { date_created: 'desc' },
+    select: {
+      id: true,
+      draft: true,
+      title: true,
+      date_created: true,
+      date_modified: true,
+      metadata: true,
+    },
+  });
+}
+
+const workDetailsSubmissionVersionSelect = {
+  id: true,
+  submission_id: true,
+  date_created: true,
+  date_modified: true,
+  date_published: true,
+  status: true,
+  transition: true,
+  job_id: true,
+  tags: true,
+  submitted_by: { select: { id: true, display_name: true } },
+  submission: {
+    include: {
+      collection: true,
+      site: true,
+    },
+  },
+} satisfies Prisma.SubmissionVersionSelect;
+
+/** Slim work version row returned by dbGetWorkVersionsWithSubmissionVersions. */
+export type WorkVersionWithSubmissionVersions = Prisma.WorkVersionGetPayload<{
+  select: {
+    id: true;
+    work_id: true;
+    cdn: true;
+    cdn_key: true;
+    title: true;
+    description: true;
+    authors: true;
+    tags: true;
+    doi: true;
+    canonical: true;
+    date_created: true;
+    date: true;
+    draft: true;
+    occ: true;
+    date_modified: true;
+    author_details: true;
+    submissionVersions: {
+      select: typeof workDetailsSubmissionVersionSelect;
+    };
+  };
+}>;
+
+export async function dbGetWorkVersionsWithSubmissionVersions(
+  workId: string,
+): Promise<WorkVersionWithSubmissionVersions[]> {
   const prisma = await getPrismaClient();
   const workVersions = await prisma.workVersion.findMany({
     where: { work_id: workId },
     orderBy: {
       date_created: 'desc',
     },
-    include: {
+    select: {
+      id: true,
+      work_id: true,
+      cdn: true,
+      cdn_key: true,
+      title: true,
+      description: true,
+      authors: true,
+      tags: true,
+      doi: true,
+      canonical: true,
+      date_created: true,
+      date: true,
+      draft: true,
+      occ: true,
+      date_modified: true,
+      author_details: true,
       submissionVersions: {
-        select: {
-          id: true,
-          submission_id: true,
-          date_created: true,
-          date_modified: true,
-          date_published: true,
-          status: true,
-          transition: true,
-          job_id: true,
-          tags: true,
-          submitted_by: { select: { id: true, display_name: true } },
-          submission: {
-            include: {
-              collection: true,
-              site: true,
-            },
-          },
-        },
+        select: workDetailsSubmissionVersionSelect,
         orderBy: {
           date_created: 'desc',
         },

--- a/platform/scms/app/routes/app/works.$workId/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/db.server.ts
@@ -88,7 +88,16 @@ export async function dbGetWorkVersionsWithSubmissionVersions(workId: string) {
     },
     include: {
       submissionVersions: {
-        include: {
+        select: {
+          id: true,
+          submission_id: true,
+          date_created: true,
+          date_modified: true,
+          date_published: true,
+          status: true,
+          transition: true,
+          job_id: true,
+          tags: true,
           submitted_by: { select: { id: true, display_name: true } },
           submission: {
             include: {
@@ -180,7 +189,10 @@ export async function dbGetWorkActivities(workId: string): Promise<WorkActivityR
 /**
  * Delete storage files for a single work version (used when deleting a draft version).
  */
-async function deleteWorkVersionStorage(ctx: SecureContext, version: WorkVersion) {
+async function deleteWorkVersionStorage(
+  ctx: SecureContext,
+  version: Pick<WorkVersion, 'id' | 'cdn' | 'cdn_key'>,
+) {
   if (!version.cdn || !version.cdn_key) return;
   const backend = new StorageBackend(ctx, [KnownBuckets.prv, KnownBuckets.pub, KnownBuckets.tmp]);
   const bucket = backend.knownBucketFromCDN(version.cdn);
@@ -201,7 +213,13 @@ export async function dbDeleteDraftVersionOnWork(
   const versions = await prisma.workVersion.findMany({
     where: { work_id: workId },
     orderBy: { date_created: 'desc' },
-    include: { submissionVersions: { take: 1 } },
+    select: {
+      id: true,
+      draft: true,
+      cdn: true,
+      cdn_key: true,
+      submissionVersions: { select: { id: true }, take: 1 },
+    },
     take: 1,
   });
   const latest = versions[0];

--- a/platform/scms/app/routes/app/works.$workId/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/db.server.ts
@@ -1,9 +1,4 @@
-import {
-  getPrismaClient,
-  StorageBackend,
-  KnownBuckets,
-  Folder,
-} from '@curvenote/scms-server';
+import { getPrismaClient, StorageBackend, KnownBuckets, Folder } from '@curvenote/scms-server';
 import type { SecureContext } from '@curvenote/scms-server';
 import type { Prisma, WorkVersion } from '@curvenote/scms-db';
 

--- a/platform/scms/app/routes/app/works.$workId/metadata.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/metadata.server.ts
@@ -44,9 +44,7 @@ export async function signVersionFilesForClient(
   ctx: Context,
 ): Promise<{ files: Record<string, unknown> } | undefined> {
   const meta =
-    metadata != null && typeof metadata === 'object'
-      ? (metadata as Record<string, unknown>)
-      : null;
+    metadata != null && typeof metadata === 'object' ? (metadata as Record<string, unknown>) : null;
   if (!meta?.files || typeof meta.files !== 'object') return undefined;
   const signed = await signFilesInMetadata(
     meta as Parameters<typeof signFilesInMetadata>[0],

--- a/platform/scms/app/routes/app/works.$workId/metadata.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/metadata.server.ts
@@ -1,0 +1,58 @@
+import { signFilesInMetadata, type Context } from '@curvenote/scms-server';
+
+export type LicenseDisplay = { text: string; tooltip?: string };
+
+/** Draft version is valid for resume if it has the checks field in metadata (same as My Works). */
+export function isDraftVersionValidForReuse(metadata: unknown): boolean {
+  const meta = metadata as Record<string, unknown> | null;
+  return Boolean(meta && 'checks' in meta);
+}
+
+export function getLicenseDisplayFromMetadata(metadata: unknown): LicenseDisplay {
+  const meta = metadata;
+  if (meta && typeof meta === 'object' && !Array.isArray(meta)) {
+    const record = meta as Record<string, unknown>;
+    const license = record.license;
+    if (license != null && license !== '') {
+      if (typeof license === 'string') return { text: license };
+      if (typeof license === 'object' && license !== null && 'content' in license) {
+        const content = (license as { content?: { id?: string; name?: string } }).content;
+        const id = content?.id ?? content?.name;
+        if (id) return { text: String(id) };
+      }
+    }
+  }
+  return { text: 'unknown', tooltip: 'No license has been set.' };
+}
+
+export function computeCanResumeDraftUpload(
+  canUpload: boolean,
+  latestVersion: { draft: boolean } | undefined,
+  latestMetadata: unknown,
+): boolean {
+  return (
+    canUpload === true &&
+    latestVersion?.draft === true &&
+    isDraftVersionValidForReuse(latestMetadata)
+  );
+}
+
+/** Signed file entries only — omit myst/checks/license from the client payload. */
+export async function signVersionFilesForClient(
+  version: { cdn: string | null },
+  metadata: unknown,
+  ctx: Context,
+): Promise<{ files: Record<string, unknown> } | undefined> {
+  const meta =
+    metadata != null && typeof metadata === 'object'
+      ? (metadata as Record<string, unknown>)
+      : null;
+  if (!meta?.files || typeof meta.files !== 'object') return undefined;
+  const signed = await signFilesInMetadata(
+    meta as Parameters<typeof signFilesInMetadata>[0],
+    version.cdn ?? '',
+    ctx,
+  );
+  if (!signed.files || typeof signed.files !== 'object') return undefined;
+  return { files: signed.files as Record<string, unknown> };
+}

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -9,7 +9,6 @@ import {
 import { Outlet } from 'react-router';
 import {
   withSecureWorkContext,
-  signFilesInMetadata,
   dbCreateDraftWorkVersion,
   metadataForNewDraftFileWorkVersion,
   userHasScope,
@@ -27,8 +26,10 @@ import {
 } from '@curvenote/scms-core';
 import { buildMenu } from './menu';
 import {
+  dbAttachMetadataToWorkVersions,
   dbGetCheckServiceRunsByWorkVersionIds,
   dbGetLinkedJobsByWorkVersionIds,
+  dbGetLatestWorkVersionForWork,
   dbGetWorkActivities,
   dbGetWorkOwnerName,
   dbGetWorkVersionsWithSubmissionVersions,
@@ -37,6 +38,13 @@ import {
 import { dbGetWorkUsers, dtoWorkUsers } from '../works.$workId.users/db.server';
 import { WorkDetailsCard } from './WorkDetailsCard';
 import { getUniqueSubmissions } from './utils.server';
+import {
+  computeCanResumeDraftUpload,
+  getLicenseDisplayFromMetadata,
+  isDraftVersionValidForReuse,
+  signVersionFilesForClient,
+} from './metadata.server';
+import type { WorkVersionContentCardData, WorkVersionForDetailsClient } from './types';
 import { extensions } from '../../../extensions/client';
 import { extensions as serverExtensions } from '../../../extensions/server';
 import { exportToPdfAction } from './actionHelpers.server';
@@ -49,12 +57,6 @@ const WorkActionIntentSchema = zfd.formData({
   ),
   workId: zfd.text(z.string().optional()),
 });
-
-/** Draft version is valid for resume if it has the checks field in metadata (same as My Works). */
-function isDraftVersionValidForReuse(version: { metadata: unknown }): boolean {
-  const meta = version.metadata as Record<string, unknown> | null;
-  return Boolean(meta && 'checks' in meta);
-}
 
 export async function action(args: ActionFunctionArgs) {
   const formData = await args.request.formData();
@@ -70,10 +72,9 @@ export async function action(args: ActionFunctionArgs) {
   const ctx = await withSecureWorkContext(args, [scopes.work.id.read]);
 
   if (intent === 'get-drafts-for-work') {
-    const workVersions = await dbGetWorkVersionsWithSubmissionVersions(ctx.work.id);
-    const latest = workVersions[0];
+    const latest = await dbGetLatestWorkVersionForWork(ctx.work.id);
     const drafts =
-      latest?.draft && isDraftVersionValidForReuse(latest)
+      latest?.draft && isDraftVersionValidForReuse(latest.metadata)
         ? [
             {
               workId: ctx.work.id,
@@ -81,7 +82,6 @@ export async function action(args: ActionFunctionArgs) {
               workTitle: latest.title || 'Untitled Work',
               dateModified: latest.date_modified,
               dateCreated: latest.date_created,
-              metadata: latest.metadata,
             },
           ]
         : [];
@@ -93,8 +93,7 @@ export async function action(args: ActionFunctionArgs) {
       return data({ success: false, intent, error: 'Upload scope required' }, { status: 403 });
     }
     try {
-      const workVersionsForTitle = await dbGetWorkVersionsWithSubmissionVersions(ctx.work.id);
-      const latestNonDraft = workVersionsForTitle?.find((v) => !v.draft);
+      const latestNonDraft = ctx.work.versions?.find((v) => !v.draft);
       const workTitle = latestNonDraft?.title ?? ctx.workDTO?.title ?? '';
       const result = await dbCreateDraftWorkVersion(
         ctx,
@@ -164,7 +163,10 @@ export const loader = async (args: LoaderFunctionArgs) => {
   const workVersions = await dbGetWorkVersionsWithSubmissionVersions(ctx.work.id);
   if (!workVersions) throw redirect('/app/works');
 
-  const isDraftOnlyWork = workVersions.length > 0 && workVersions.every((v) => v.draft);
+  const workVersionsWithMetadata = await dbAttachMetadataToWorkVersions(workVersions);
+
+  const isDraftOnlyWork =
+    workVersionsWithMetadata.length > 0 && workVersionsWithMetadata.every((v) => v.draft);
 
   const url = new URL(args.request.url);
   const pathname = url.pathname;
@@ -182,7 +184,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
       pathname.startsWith(`/app/works/${workId}/site/`);
 
     if (!isOnUploadRoute && isDetailsLikePath) {
-      throw redirect(`/app/works/${workId}/upload/${workVersions[0].id}`);
+      throw redirect(`/app/works/${workId}/upload/${workVersionsWithMetadata[0].id}`);
     }
   }
 
@@ -191,7 +193,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
     throw redirect(`/app/works/${workId}/details${url.search}`);
   }
 
-  const submissions = getUniqueSubmissions(workVersions, {
+  const submissions = getUniqueSubmissions(workVersionsWithMetadata, {
     includeDrafts: includeDraftSubmissions,
   });
   const workflowNames = submissions.map((s) => s.collection.workflow);
@@ -206,41 +208,52 @@ export const loader = async (args: LoaderFunctionArgs) => {
   await ctx.trackEvent(TrackEvent.WORK_VIEWED, {
     workId: ctx.work.id,
     workTitle: ctx.workDTO.title,
-    versionCount: workVersions.length,
+    versionCount: workVersionsWithMetadata.length,
     submissionCount: submissions.length,
-    isDraft: workVersions.length === 1 && workVersions[0].draft,
+    isDraft: workVersionsWithMetadata.length === 1 && workVersionsWithMetadata[0].draft,
   });
 
   await ctx.analytics.flush();
 
-  const versionIds = workVersions.map((v) => v.id);
+  const versionIds = workVersionsWithMetadata.map((v) => v.id);
+  const canUpload = userHasScope(ctx.user, scopes.app.works.upload);
 
-  // Sign file URLs for versions that have metadata.files (for download links on details page).
-  const versionsWithSignedFileMetadata = await Promise.all(
-    workVersions.map(async (v) => {
-      const meta =
-        v.metadata != null && typeof v.metadata === 'object'
-          ? (v.metadata as Record<string, unknown>)
-          : null;
-      if (!meta?.files || typeof meta.files !== 'object') return v;
-      const signed = await signFilesInMetadata(
-        meta as Parameters<typeof signFilesInMetadata>[0],
-        v.cdn ?? '',
-        ctx,
-      );
-      return { ...v, metadata: signed };
+  const latestVersion = workVersionsWithMetadata[0];
+  const latestNonDraftWithMetadata = workVersionsWithMetadata.find((v) => !v.draft);
+
+  const canResumeDraft = computeCanResumeDraftUpload(
+    canUpload,
+    latestVersion,
+    latestVersion?.metadata,
+  );
+  const resumeDraftVersionId = canResumeDraft ? latestVersion?.id : undefined;
+
+  const latestNonDraftContentCard: WorkVersionContentCardData | null = latestNonDraftWithMetadata
+    ? {
+        title: latestNonDraftWithMetadata.title,
+        authors: latestNonDraftWithMetadata.authors,
+        author_details: latestNonDraftWithMetadata.author_details,
+        doi: latestNonDraftWithMetadata.doi,
+        license: getLicenseDisplayFromMetadata(latestNonDraftWithMetadata.metadata),
+      }
+    : null;
+
+  // Sign file URLs for versions that have metadata.files (timeline download links only).
+  const versionsForClient: WorkVersionForDetailsClient[] = await Promise.all(
+    workVersionsWithMetadata.map(async (version) => {
+      const { metadata, ...rest } = version;
+      const fileMetadata = await signVersionFilesForClient(version, metadata, ctx);
+      return fileMetadata ? { ...rest, metadata: fileMetadata } : rest;
     }),
   );
 
   const workOwnerName = await dbGetWorkOwnerName(ctx.work.id);
   const activities = await dbGetWorkActivities(ctx.work.id);
   const checkServiceRunsByWorkVersionId = await dbGetCheckServiceRunsByWorkVersionIds(versionIds);
-  const canUpload = userHasScope(ctx.user, scopes.app.works.upload);
 
-  // Use latest non-draft work version for card and details metadata; fall back to ctx.workDTO if all are drafts
-  const latestNonDraftVersion = versionsWithSignedFileMetadata.find((v) => !v.draft);
-  const work = latestNonDraftVersion
-    ? worksLoaders.formatWorkDTO(ctx, ctx.work, latestNonDraftVersion)
+  const latestNonDraftVersion = versionsForClient.find((v) => !v.draft);
+  const work = latestNonDraftWithMetadata
+    ? worksLoaders.formatWorkDTO(ctx, ctx.work, latestNonDraftWithMetadata)
     : ctx.workDTO;
   const usersDbo = await dbGetWorkUsers(ctx.work.id);
   const users = usersDbo ? dtoWorkUsers(usersDbo) : [];
@@ -249,13 +262,16 @@ export const loader = async (args: LoaderFunctionArgs) => {
     userScopes: ctx.scopes,
     workflows,
     work,
-    versions: versionsWithSignedFileMetadata,
+    versions: versionsForClient,
     submissions: submissions ?? [],
     linkedJobsByWorkVersionId: dbGetLinkedJobsByWorkVersionIds(versionIds),
     workOwnerName,
     activities,
     checkServiceRunsByWorkVersionId,
     canUpload,
+    canResumeDraft,
+    resumeDraftVersionId,
+    latestNonDraftContentCard,
     users,
     isOnUploadRoute,
   };

--- a/platform/scms/app/routes/app/works.$workId/types.ts
+++ b/platform/scms/app/routes/app/works.$workId/types.ts
@@ -1,12 +1,24 @@
-import type { dbGetSubmission, dbGetWorkVersionsWithSubmissionVersions } from './db.server';
+import type { dbGetSubmission, WorkVersionWithSubmissionVersions } from './db.server';
+import type { LicenseDisplay } from './metadata.server';
 
 export type SubmissionWithSiteAndCollection = NonNullable<
   Awaited<ReturnType<typeof dbGetSubmission>>
 >;
 
-export type WorkVersionWithSubmissionVersions = NonNullable<
-  Awaited<ReturnType<typeof dbGetWorkVersionsWithSubmissionVersions>>
->[0];
+export type { WorkVersionWithSubmissionVersions };
+
+/** Parent loader serializes versions with signed file metadata only (no myst/checks/license). */
+export type WorkVersionForDetailsClient = WorkVersionWithSubmissionVersions & {
+  metadata?: { files?: Record<string, unknown> };
+};
+
+export type WorkVersionContentCardData = {
+  title: string;
+  authors: string[];
+  author_details?: unknown[];
+  doi?: string | null;
+  license: LicenseDisplay;
+};
 
 export type SubmissionWithVersionsAndSite =
   WorkVersionWithSubmissionVersions['submissionVersions'][number]['submission'] & {

--- a/platform/scms/app/routes/app/works._index/db.server.ts
+++ b/platform/scms/app/routes/app/works._index/db.server.ts
@@ -257,6 +257,7 @@ export async function dangerouslyDeleteDraftWork(
     // Delete the work itself
     await tx.work.delete({
       where: { id: workId },
+      select: { id: true },
     });
   });
 

--- a/platform/scms/app/routes/app/works._index/db.server.ts
+++ b/platform/scms/app/routes/app/works._index/db.server.ts
@@ -1,4 +1,10 @@
-import { getPrismaClient, Folder, StorageBackend, KnownBuckets } from '@curvenote/scms-server';
+import {
+  getPrismaClient,
+  Folder,
+  StorageBackend,
+  KnownBuckets,
+  cdnWorkVersionSelect,
+} from '@curvenote/scms-server';
 import type { WorkRole, WorkVersion } from '@curvenote/scms-db';
 import type { SecureContext } from '@curvenote/scms-server';
 
@@ -43,7 +49,7 @@ export async function dbGetWorksAndSubmissionVersions(userId: string) {
                   collection: true,
                 },
               },
-              work_version: true,
+              work_version: { select: cdnWorkVersionSelect },
             },
             orderBy: {
               date_created: 'desc',

--- a/platform/scms/app/routes/app/works.drafts/db.server.ts
+++ b/platform/scms/app/routes/app/works.drafts/db.server.ts
@@ -1,4 +1,4 @@
-import { getPrismaClient } from '@curvenote/scms-server';
+import { getPrismaClient, cdnWorkVersionSelect } from '@curvenote/scms-server';
 import type { WorkRole } from '@curvenote/scms-db';
 
 /**
@@ -50,7 +50,7 @@ export async function dbGetDraftWorks(userId: string) {
                   collection: true,
                 },
               },
-              work_version: true,
+              work_version: { select: cdnWorkVersionSelect },
             },
             orderBy: {
               date_created: 'desc',

--- a/platform/scms/app/routes/build.$jobId.tsx
+++ b/platform/scms/app/routes/build.$jobId.tsx
@@ -8,6 +8,7 @@ import {
   signPrivateUrls,
   sites,
   jobs,
+  siteWorkWorkVersionWithWorkSelect,
 } from '@curvenote/scms-server';
 import {
   primitives,
@@ -53,7 +54,9 @@ async function dbGetSubmissionVersion(submissionVersionId: string) {
           site: { include: { submissionKinds: true, collections: true, domains: true } },
         },
       },
-      work_version: { include: { work: true } },
+      work_version: {
+        select: { ...siteWorkWorkVersionWithWorkSelect, date: true },
+      },
     },
   });
 }

--- a/platform/scms/app/routes/new-account/actionHelpers.server.ts
+++ b/platform/scms/app/routes/new-account/actionHelpers.server.ts
@@ -79,6 +79,7 @@ export async function setNextStep(ctx: Context) {
         },
       },
     },
+    select: { id: true },
   });
 
   return nextStepName;


### PR DESCRIPTION
* narrow selects
* always select on create/update/delete
* more...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide, behavior-preserving refactor across many loaders and mutations; incorrect selects could break code that still expects full nested rows, though changes are mostly mechanical.
> 
> **Overview**
> This PR trims Prisma payload size across **scms-server**, **platform/scms**, and **ee/sites** by using explicit `select`/`include` shapes instead of returning full rows after writes and on heavy reads.
> 
> **Write paths:** Most `create`/`update`/`delete` calls that only need confirmation now use `select: { id: true }` (sites, collections, forms, kinds, domains, submissions, access, roles, jobs, auth sessions, etc.). Activity logging drops broad `include` blocks in favor of minimal `select` on the activity row itself.
> 
> **Read paths:** A new `prisma.selects.server.ts` centralizes slim `WorkVersion` / activity-ref selects (`siteWorkWorkVersionSelect`, `cdnWorkVersionSelect`, etc.) and wires them through submission/work loaders, previews, DOI resolution, storage admin, and related APIs. Submission status updates narrow nested `work_version` fields; publish uses `count` instead of loading all published versions; job scope checks use targeted `select` trees.
> 
> **Work UI:** The work parent route loads version graphs without shipping full `metadata` JSON to the client—metadata is batch-fetched where needed, license/resume-draft logic runs on the server, and the client gets signed `files` only for timeline downloads. Checks and upload-remove paths fetch `metadata` in dedicated queries instead of relying on `WorkContext`.
> 
> **DX:** README documents optional `PRISMA_DEBUG_QUERIES` for local SQL logging. A changeset bumps `@curvenote/scms-server`, `@curvenote/scms`, and `@curvenote/scms-sites-ext` as patches. `package-lock.json` updates appear ancillary to dependency resolution.
> 
> A few call sites add `await` on `tx.activity.create` inside transactions (collections/kinds OCC updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 983176eb7ed353c484c948358090f153eebf9830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->