### PR TITLE
🔧 Prevent draft -> submission conversions

### DIFF
--- a/.changeset/hot-planes-invent.md
+++ b/.changeset/hot-planes-invent.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/cli': patch
+---
+
+Prevent draft -> submission conversions

--- a/packages/curvenote-cli/src/submissions/submit.utils.ts
+++ b/packages/curvenote-cli/src/submissions/submit.utils.ts
@@ -433,16 +433,19 @@ export async function getSubmissionToUpdate(
   session: ISession,
   submissions: SubmissionsListItemDTO[],
 ) {
-  if (submissions.length === 0) {
+  const nonDraftSubmissions = submissions.filter((submission) => submission.status !== 'DRAFT');
+  if (nonDraftSubmissions.length === 0) {
     session.log.debug('existing submission not found');
     return;
   }
-  if (submissions.length === 1) {
+  if (nonDraftSubmissions.length === 1) {
     session.log.debug(`${chalk.bold(`🔍 Found one existing submission`)}`);
-    return submissions[0];
+    return nonDraftSubmissions[0];
   }
-  session.log.info(`🔍 Found ${plural('%s existing submission(s)', submissions)} for this work`);
-  const submission = await chooseSubmission(session, submissions);
+  session.log.info(
+    `🔍 Found ${plural('%s existing submission(s)', nonDraftSubmissions)} for this work`,
+  );
+  const submission = await chooseSubmission(session, nonDraftSubmissions);
   return submission;
 }
 


### PR DESCRIPTION
This prevents a workflow bug where the CLI can convert drafts to real submissions.

This workflow will be blocked once the latest API changes are released (then drafts will no longer be returned from the API by default). But for now, this client side fix should suffice (and it will still be fine after API changes too).