### PR TITLE
📄 small pagination fix

### DIFF
--- a/.changeset/little-bugs-speak.md
+++ b/.changeset/little-bugs-speak.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms-core': patch
+---
+
+small fix to pagination

--- a/packages/scms-core/src/utils/pagination.test.ts
+++ b/packages/scms-core/src/utils/pagination.test.ts
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, it, expect } from 'vitest';
+import { getPageValues, isOffsetPaginationRequested, makePaginationLinks } from './pagination.js';
+
+const baseLinks = {
+  self: 'https://api.example.com/v1/sites/demo/works',
+  site: 'https://api.example.com/v1/sites/demo',
+};
+
+describe('isOffsetPaginationRequested', () => {
+  it('is true when limit and page are set, including page 0', () => {
+    expect(isOffsetPaginationRequested({ limit: 30, page: 0 })).toBe(true);
+    expect(isOffsetPaginationRequested({ limit: 10, page: 2 })).toBe(true);
+  });
+
+  it('is false when only limit or only page is set', () => {
+    expect(isOffsetPaginationRequested({ limit: 30 })).toBe(false);
+    expect(isOffsetPaginationRequested({ page: 0 })).toBe(false);
+    expect(isOffsetPaginationRequested({})).toBe(false);
+  });
+});
+
+describe('getPageValues', () => {
+  it('returns no prev on first page (page 0) and next when more items exist', () => {
+    expect(getPageValues(100, { limit: 30, page: 0 })).toEqual({ prev: undefined, next: 1 });
+  });
+
+  it('returns no prev and no next on first page when total fits in one page', () => {
+    expect(getPageValues(25, { limit: 30, page: 0 })).toEqual({ prev: undefined, next: undefined });
+  });
+
+  it('returns prev 0 and next 2 on middle page', () => {
+    expect(getPageValues(100, { limit: 30, page: 1 })).toEqual({ prev: 0, next: 2 });
+  });
+
+  it('returns prev but no next on last page', () => {
+    expect(getPageValues(85, { limit: 30, page: 2 })).toEqual({ prev: 1, next: undefined });
+  });
+
+  it('returns no links when limit is omitted', () => {
+    expect(getPageValues(100, { page: 0 })).toEqual({ prev: undefined, next: undefined });
+  });
+});
+
+describe('makePaginationLinks', () => {
+  it('leaves links unchanged when limit and page are omitted', () => {
+    const links = makePaginationLinks(baseLinks, 100, {});
+    expect(links).toEqual(baseLinks);
+    expect(links).not.toHaveProperty('next');
+    expect(links).not.toHaveProperty('prev');
+  });
+
+  it('includes page=0 on self and next link for first page of a larger catalog', () => {
+    const links = makePaginationLinks(baseLinks, 100, { limit: 30, page: 0 });
+    const self = new URL(links.self);
+    expect(self.searchParams.get('page')).toBe('0');
+    expect(self.searchParams.get('limit')).toBe('30');
+    expect(links.prev).toBeUndefined();
+
+    expect(links.next).toBeDefined();
+    const next = new URL(links.next!);
+    expect(next.searchParams.get('page')).toBe('1');
+    expect(next.searchParams.get('limit')).toBe('30');
+  });
+
+  it('includes prev and next on a middle page', () => {
+    const links = makePaginationLinks(baseLinks, 100, { limit: 30, page: 1 });
+    const prev = new URL(links.prev!);
+    const next = new URL(links.next!);
+    expect(prev.searchParams.get('page')).toBe('0');
+    expect(next.searchParams.get('page')).toBe('2');
+  });
+
+  it('omits next on the last page', () => {
+    const links = makePaginationLinks(baseLinks, 85, { limit: 30, page: 2 });
+    expect(links.next).toBeUndefined();
+    expect(new URL(links.prev!).searchParams.get('page')).toBe('1');
+  });
+});

--- a/packages/scms-core/src/utils/pagination.ts
+++ b/packages/scms-core/src/utils/pagination.ts
@@ -1,3 +1,8 @@
+/** True when the caller requested offset pagination (both `limit` and `page`, including `page: 0`). */
+export function isOffsetPaginationRequested(opts: { page?: number; limit?: number }): boolean {
+  return opts.limit !== undefined && opts.page !== undefined;
+}
+
 /**
  * Calculate the page values for the given total and options for previous and next pages.
  * Will return the previous and next page numbers only if they are in range.
@@ -9,8 +14,8 @@
 export function getPageValues(total: number, opts: { page?: number; limit?: number }) {
   let prev, next;
   if (opts?.limit) {
-    if (opts.page) {
-      const prevPage = Math.max(0, opts.page - 1);
+    if (opts.page !== undefined && opts.page > 0) {
+      const prevPage = opts.page - 1;
       if (prevPage * opts.limit < total) {
         prev = prevPage;
       } else {
@@ -38,7 +43,7 @@ export function makePaginationLinks<T extends { self: string; [key: string]: str
   links: T,
   total: number,
   opts: { page?: number; limit?: number },
-) {
+): T & { prev?: string; next?: string } {
   const updated: T & { prev?: string; next?: string } = { ...links };
 
   // no pagination if limit and page are not provided
@@ -46,10 +51,10 @@ export function makePaginationLinks<T extends { self: string; [key: string]: str
     return links;
   }
 
-  if (opts.limit || opts.page) {
+  if (opts.limit !== undefined || opts.page !== undefined) {
     const selfUrl = new URL(links.self);
-    if (opts.page) selfUrl.searchParams.set('page', opts.page.toString());
-    if (opts.limit && (opts.page || opts.limit < total)) {
+    if (opts.page !== undefined) selfUrl.searchParams.set('page', opts.page.toString());
+    if (opts.limit !== undefined && (opts.page !== undefined || opts.limit < total)) {
       selfUrl.searchParams.set('limit', opts.limit.toString());
     }
     updated.self = selfUrl.toString();

--- a/packages/scms-core/tsconfig.json
+++ b/packages/scms-core/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.svg"],
-  "exclude": ["dist", "node_modules"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"],
   "files": [
     "../../types/app-config.d.ts",
     "../../types/prisma.d.ts",

--- a/packages/scms-server/src/backend/loaders/sites/submissions/published/list.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/published/list.server.ts
@@ -7,6 +7,7 @@ import {
   error404,
   httpError,
   makePaginationLinks,
+  isOffsetPaginationRequested,
   getWorkflows,
   registerExtensionWorkflows,
 } from '@curvenote/scms-core';
@@ -134,8 +135,7 @@ export async function dbListLatestPublishedSubmissions(
     }
   }
 
-  // if we have both limit and page, pagination has been requested
-  if (opts?.limit && opts?.page) {
+  if (isOffsetPaginationRequested(opts ?? {})) {
     const [items, total] = await Promise.all([
       dbQuerySubmissions(ctx.site.name, collectionName, status, where?.kind, opts),
       dbCountSubmissions(ctx.site.name, collectionName, status, where?.kind),
@@ -146,7 +146,7 @@ export async function dbListLatestPublishedSubmissions(
   // no pagination if limit and page are not provided
   // we can still limit, but in this branch we avoid
   // the extra count query
-  if (!opts?.page) {
+  if (opts?.page === undefined) {
     const items = await dbQuerySubmissions(
       ctx.site.name,
       collectionName,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized pagination/link logic and listing branch selection; behavior change only affects callers passing page=0 with limit.
> 
> **Overview**
> Fixes offset pagination when **`page` is `0`**, which was previously treated as “no page” because of truthy checks on numeric query params.
> 
> **`scms-core`** adds **`isOffsetPaginationRequested`** (both `limit` and `page` must be set, including `page: 0`) and updates **`getPageValues`** / **`makePaginationLinks`** to use explicit `undefined` checks—no bogus **prev** on the first page, correct **self**/**next** URLs with `page=0`, and a clearer return type. Vitest coverage is added; **`scms-core` `tsconfig`** excludes `*.test.ts` from the package build.
> 
> **`scms-server`** published works listing uses the shared helper so **`page=0` + `limit`** runs the paginated path (count + query) instead of the non-paginated branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f64365eec92b3fcb92df35ed06b16c5c179544f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->