### PR TITLE
📄 enable pagination by default

### DIFF
--- a/.changeset/long-jobs-warn.md
+++ b/.changeset/long-jobs-warn.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms': patch
+---
+
+Enforce strict paginaton on v1/sites/{site}/works route

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works.tsx
@@ -8,12 +8,15 @@ import {
   vercelCacheHeaders,
 } from 'app/lib/vercel-cache';
 
+/** Default page size when the client omits `limit` / `page` (offset pagination is always applied). */
+const DEFAULT_WORKS_LIMIT = 10;
+
 const ParamsSchema = z.object({
   collection: z.string().min(1).max(64).optional(),
   kind: z.string().min(1).max(64).optional(), // TODO kind name should be url-safe
   status: z.union([z.literal('published'), z.literal('in-review')]).optional(),
-  limit: z.number().int().min(1).max(500).default(500),
-  page: z.number().int().min(0).optional(),
+  limit: z.number().int().min(1).max(500).default(DEFAULT_WORKS_LIMIT),
+  page: z.number().int().min(0).default(0),
 });
 
 export async function loader(args: Route.LoaderArgs) {
@@ -32,11 +35,10 @@ export async function loader(args: Route.LoaderArgs) {
     collection: params.get('collection') ?? undefined,
     kind: params.get('kind') ?? undefined,
     status: params.get('status') ?? undefined,
-    limit: params.get('limit') ? parseInt(params.get('limit')!) : undefined,
-    page: params.get('page') ? parseInt(params.get('page')!) : undefined,
+    limit: params.has('limit') ? parseInt(params.get('limit')!, 10) : undefined,
+    page: params.has('page') ? parseInt(params.get('page')!, 10) : undefined,
   });
 
-  // offset based pagination
   const dto = await sites.submissions.published.list(ctx, extensions, where, { page, limit });
   const headers = vercelCacheHeaders(
     ctx.site.private ? PRIVATE_CACHE_OPTIONS : SEMI_STATIC_BURST_PROTECTION,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default API response size and may break integrations that assumed up to 500 works per request without query params.
> 
> **Overview**
> The **`v1/sites/{site}/works`** list endpoint now **always paginates**: omitted `limit` and `page` resolve to **10** and **0** (via `DEFAULT_WORKS_LIMIT` and a new `page` default), down from an implicit **500**-item default. Query parsing uses **`params.has()`** so absent query keys still receive those schema defaults.
> 
> This is a **contract change** for callers that previously fetched large unbounded lists without pagination parameters; they must pass an explicit `limit` (still capped at 500) and use `page` to walk results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57851b7d7dd60563dec78aaed10ec758d0d45269. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->