### PR TITLE
📝 Increase work title length

### DIFF
--- a/.changeset/better-comics-live.md
+++ b/.changeset/better-comics-live.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms': patch
+---
+
+Increase work title length

--- a/platform/scms/app/routes/api/v1.works.tsx
+++ b/platform/scms/app/routes/api/v1.works.tsx
@@ -42,7 +42,7 @@ export const CreateWorkPostBodySchema = z
       .max(128, { error: 'key must be less than 128 characters' })
       .regex(/[a-zA-Z][a-zA-Z0-9_-]{7,127}/)
       .optional(),
-    title: z.string().min(1).max(255).optional(),
+    title: z.string().min(1).max(1000).optional(),
     description: z.string().max(5000).optional(),
     authors: z.array(z.string()).optional(),
     author_details: z.array(z.record(z.string(), z.any())).optional(),

--- a/platform/scms/app/routes/api/v1.works.tsx
+++ b/platform/scms/app/routes/api/v1.works.tsx
@@ -42,7 +42,7 @@ export const CreateWorkPostBodySchema = z
       .max(128, { error: 'key must be less than 128 characters' })
       .regex(/[a-zA-Z][a-zA-Z0-9_-]{7,127}/)
       .optional(),
-    title: z.string().min(1).max(1000).optional(),
+    title: z.string().min(1).max(500).optional(),
     description: z.string().max(5000).optional(),
     authors: z.array(z.string()).optional(),
     author_details: z.array(z.record(z.string(), z.any())).optional(),


### PR DESCRIPTION
Just increases title length validation from 255 to 500. The example biorxiv articles I inspected that failed this validation had lengths of ~260-280, so hopefully 500 will be more than satisfactory.