### PR TITLE
🕵️‍♂️ Enable Front End Search

### DIFF
--- a/.changeset/works-endpoint-search-sort-date.md
+++ b/.changeset/works-endpoint-search-sort-date.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms': minor
+---
+
+Add `q`, `sort`, `from`, and `to` query params to the public works listing endpoint (`GET /v1/sites/:siteName/works`). `q` runs a case-insensitive substring search across each work version's title, authors, and DOI (backed by the existing pg_trgm indexes); `sort` toggles publication-date ordering (`published_desc` default / `published_asc`); `from`/`to` apply an inclusive `date_published` window. Pagination links now preserve these params.

--- a/ee/sites/src/routes/sites/SitesSearchInput.tsx
+++ b/ee/sites/src/routes/sites/SitesSearchInput.tsx
@@ -1,49 +1,60 @@
 import { useEffect, useId, useRef, useState, useTransition } from 'react';
+import { useSearchParams } from 'react-router';
 import { Loader2, Search, X } from 'lucide-react';
 import { cn, ui } from '@curvenote/scms-core';
 
 /**
  * Throttle interval for the client-side filter. Short enough that the list
  * visibly refreshes while the user is still typing, long enough that we don't
- * thrash the parent transition on every keystroke.
+ * thrash the URL update on every keystroke.
  */
 const SEARCH_THROTTLE_MS = 200;
 
+export const SITES_SEARCH_PARAM = 'q';
+
 export const SITES_SEARCH_MIN_LENGTH = 1;
 
+export function readSitesSearchQuery(searchParams: URLSearchParams): string {
+  return searchParams.get(SITES_SEARCH_PARAM) ?? '';
+}
+
+export function setSitesSearchQuery(
+  searchParams: URLSearchParams,
+  query: string | undefined,
+): URLSearchParams {
+  const next = new URLSearchParams(searchParams);
+  if (query === undefined || query === '') {
+    next.delete(SITES_SEARCH_PARAM);
+  } else {
+    next.set(SITES_SEARCH_PARAM, query);
+  }
+  return next;
+}
+
 interface SitesSearchInputProps {
-  /**
-   * Called with the effective query — the trimmed input once it reaches
-   * `SITES_SEARCH_MIN_LENGTH`, or `''` to clear the filter. The parent owns
-   * the filter state; this component only handles the throttle + min-length
-   * gate so the typing thread stays responsive.
-   */
-  onQueryChange: (query: string) => void;
   /** Number of sites currently visible after filtering. */
   sitesShownCount: number;
   className?: string;
 }
 
 /**
- * Local, throttled search box for the My Sites grid.
+ * URL-bound, throttled search box for the My Sites grid.
  *
- * Unlike the submissions listing search this one is purely client-side — the
- * URL is never touched. Local state mirrors the input. A leading-and-trailing
- * throttle (200ms) pushes the effective query up to the parent inside a
- * transition, so the list visibly refreshes while the user is still typing
- * without thrashing the parent on every keystroke.
+ * Filtering is purely client-side — the loader never reads `?q=` — but the URL
+ * is the source of truth so back/forward and remounts stay in sync with the
+ * input. Updates use `replace: true` so typing does not push history entries.
  *
- * The trailing × clears in one click; Esc clears via the keyboard; Enter
- * flushes immediately (bypassing the throttle) so power users don't wait.
+ * Local state mirrors the input. A leading-and-trailing throttle (200ms) writes
+ * the effective query to `?q=` inside a transition. The trailing × clears in
+ * one click; Esc clears via the keyboard; Enter flushes immediately.
  */
-export function SitesSearchInput({
-  onQueryChange,
-  sitesShownCount,
-  className,
-}: SitesSearchInputProps) {
+export function SitesSearchInput({ sitesShownCount, className }: SitesSearchInputProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
   const inputId = useId();
-  const [value, setValue] = useState('');
+  const initialValue = readSitesSearchQuery(searchParams);
+  const [value, setValue] = useState(initialValue);
   const [isPending, startTransition] = useTransition();
+  const lastPushedRef = useRef(initialValue);
 
   // Throttle bookkeeping. `lastFireAtRef` is the timestamp of the last actual
   // flush; `trailingTimerRef` is the scheduled trailing fire (if any);
@@ -53,6 +64,16 @@ export function SitesSearchInput({
   const lastFireAtRef = useRef(0);
   const trailingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingValueRef = useRef<string | null>(null);
+
+  // Resync local state when the URL changes from outside (browser back/forward,
+  // clear button on a stale mount). Avoid clobbering an in-flight edit.
+  useEffect(() => {
+    const urlValue = readSitesSearchQuery(searchParams);
+    if (urlValue !== lastPushedRef.current) {
+      lastPushedRef.current = urlValue;
+      setValue(urlValue);
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     return () => {
@@ -68,13 +89,21 @@ export function SitesSearchInput({
     pendingValueRef.current = null;
   };
 
-  const flushQuery = (next: string) => {
+  const pushToUrl = (next: string) => {
     const trimmed = next.trim();
     const effective = trimmed.length >= SITES_SEARCH_MIN_LENGTH ? trimmed : '';
-    lastFireAtRef.current = Date.now();
+    lastPushedRef.current = effective;
     startTransition(() => {
-      onQueryChange(effective);
+      setSearchParams((prev) => setSitesSearchQuery(prev, effective || undefined), {
+        replace: true,
+        preventScrollReset: true,
+      });
     });
+  };
+
+  const flushQuery = (next: string) => {
+    lastFireAtRef.current = Date.now();
+    pushToUrl(next);
   };
 
   const scheduleThrottledFlush = (next: string) => {

--- a/ee/sites/src/routes/sites/route.tsx
+++ b/ee/sites/src/routes/sites/route.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useLocation, data } from 'react-router';
+import { Outlet, useLocation, useSearchParams, data } from 'react-router';
 import type { LoaderFunctionArgs, ActionFunctionArgs } from 'react-router';
 import { useMemo, useState } from 'react';
 import {
@@ -12,7 +12,7 @@ import SiteCard from './SiteCard.js';
 import RequestSiteCTA from './RequestSiteCTA.js';
 import type { FeaturedSitesData } from './RequestSiteCTA.js';
 import PendingSiteCard from './PendingSiteCard.js';
-import { SitesSearchInput } from './SitesSearchInput.js';
+import { readSitesSearchQuery, SitesSearchInput } from './SitesSearchInput.js';
 import { MainWrapper, PageFrame, scopes, clientCheckSiteScopes } from '@curvenote/scms-core';
 import type { ui } from '@curvenote/scms-core';
 import { actionCreateSite, actionRequestSite } from './actionHelpers.server.js';
@@ -21,8 +21,8 @@ import type { SiteCardListing } from './types.js';
 import { z } from 'zod';
 import { zfd } from 'zod-form-data';
 
-/** Minimum number of sites before the client-side filter is shown. */
-const SITES_SEARCH_VISIBILITY_THRESHOLD = 8;
+/** Show the client-side filter when the user has at least this many sites. */
+const SITES_SEARCH_VISIBILITY_THRESHOLD = 2;
 
 interface LoaderData {
   video?: ui.VideoData;
@@ -102,13 +102,14 @@ export const action = async (args: ActionFunctionArgs) => {
 
 export default function Sites({ loaderData }: { loaderData: LoaderData }) {
   const location = useLocation();
+  const [searchParams] = useSearchParams();
   const { video, featured, canCreateSite, scopes: userScopes, sites } = loaderData;
   const [showPendingCard, setShowPendingCard] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
+  const searchQuery = readSitesSearchQuery(searchParams);
 
   const canRequestSite = clientCheckSiteScopes(userScopes, [scopes.app.sites.request], '');
 
-  const showSearch = sites.items.length > SITES_SEARCH_VISIBILITY_THRESHOLD;
+  const showSearch = sites.items.length >= SITES_SEARCH_VISIBILITY_THRESHOLD;
   const hasActiveSearch = searchQuery.length > 0;
 
   const filteredSites = useMemo(() => {
@@ -156,12 +157,7 @@ export default function Sites({ loaderData }: { loaderData: LoaderData }) {
               />
             )}
 
-            {showSearch && (
-              <SitesSearchInput
-                onQueryChange={setSearchQuery}
-                sitesShownCount={filteredSites.length}
-              />
-            )}
+            {showSearch && <SitesSearchInput sitesShownCount={filteredSites.length} />}
 
             {(filteredSites.length > 0 || showPendingCard) && (
               <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">

--- a/ee/sites/src/routes/sites/route.tsx
+++ b/ee/sites/src/routes/sites/route.tsx
@@ -1,5 +1,9 @@
 import { Outlet, useLocation, useSearchParams, data } from 'react-router';
-import type { LoaderFunctionArgs, ActionFunctionArgs } from 'react-router';
+import type {
+  LoaderFunctionArgs,
+  ActionFunctionArgs,
+  ShouldRevalidateFunctionArgs,
+} from 'react-router';
 import { useMemo, useState } from 'react';
 import {
   withAppContext,
@@ -12,7 +16,7 @@ import SiteCard from './SiteCard.js';
 import RequestSiteCTA from './RequestSiteCTA.js';
 import type { FeaturedSitesData } from './RequestSiteCTA.js';
 import PendingSiteCard from './PendingSiteCard.js';
-import { readSitesSearchQuery, SitesSearchInput } from './SitesSearchInput.js';
+import { readSitesSearchQuery, SITES_SEARCH_PARAM, SitesSearchInput } from './SitesSearchInput.js';
 import { MainWrapper, PageFrame, scopes, clientCheckSiteScopes } from '@curvenote/scms-core';
 import type { ui } from '@curvenote/scms-core';
 import { actionCreateSite, actionRequestSite } from './actionHelpers.server.js';
@@ -45,6 +49,35 @@ export const loader = async (args: LoaderFunctionArgs): Promise<LoaderData> => {
     sites,
   };
 };
+
+/**
+ * The loader ignores `?q=` — filtering is client-side — so skip revalidation when
+ * only that param changes. Without this, each throttled `setSearchParams` call
+ * while typing re-runs auth checks and `dbListSiteCards`.
+ */
+export function shouldRevalidate({
+  currentUrl,
+  nextUrl,
+  formData,
+  defaultShouldRevalidate,
+}: ShouldRevalidateFunctionArgs) {
+  if (formData?.get('intent') === 'check-site-name') {
+    return false;
+  }
+
+  if (currentUrl.pathname === nextUrl.pathname) {
+    const currentParams = new URLSearchParams(currentUrl.searchParams);
+    const nextParams = new URLSearchParams(nextUrl.searchParams);
+    if (currentParams.get(SITES_SEARCH_PARAM) !== nextParams.get(SITES_SEARCH_PARAM)) {
+      currentParams.delete(SITES_SEARCH_PARAM);
+      nextParams.delete(SITES_SEARCH_PARAM);
+      if (currentParams.toString() === nextParams.toString()) {
+        return false;
+      }
+    }
+  }
+  return defaultShouldRevalidate;
+}
 
 const IntentSchema = zfd.formData({
   intent: z.enum(['request-site', 'check-site-name', 'create-site']),

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
@@ -23,6 +23,55 @@ function getListingSelects() {
   return { submissionInnerSelect: submission.select, submissionVersionSelect };
 }
 
+/** Publication-date sort direction supported by the public listing. */
+export type WorksSort = 'published_desc' | 'published_asc';
+
+/**
+ * Optional listing refinements layered on top of the base site/collection/kind/
+ * status filter: a `date_published` window and a pre-resolved set of submission
+ * ids (the search path narrows by `q` via raw SQL, then hands the matching ids
+ * here so the select/count run through Prisma unchanged).
+ */
+type ListingExtras = {
+  from?: string;
+  to?: string;
+  ids?: string[];
+};
+
+/**
+ * Escape only the ILIKE escape character itself (`\`) so a user-supplied
+ * backslash matches literally. `%` and `_` are intentionally passed through to
+ * Postgres as wildcards, matching the submissions-index search contract.
+ */
+function escapeIlikePattern(q: string): string {
+  return q.replace(/\\/g, '\\\\');
+}
+
+/**
+ * Inclusive upper bound expressed as the start of the next day, so
+ * `date_published < toExclusiveDateUpperBound(to)` matches all timestamps
+ * within `to`. Built from UTC components so it never depends on the server
+ * timezone; the comparison runs against ISO-string columns that sort
+ * chronologically by lexicographic order.
+ */
+function toExclusiveDateUpperBound(toIsoDate: string): string {
+  const next = new Date(`${toIsoDate}T00:00:00Z`);
+  next.setUTCDate(next.getUTCDate() + 1);
+  const y = next.getUTCFullYear();
+  const m = String(next.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(next.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function buildOrderBy(sort: WorksSort): Prisma.SubmissionOrderByWithRelationInput[] {
+  // `id ASC` is appended as a deterministic tie-breaker so LIMIT/OFFSET pages
+  // never shift between requests when rows tie on `date_published`.
+  if (sort === 'published_asc') {
+    return [{ date_published: 'asc' }, { date_created: 'asc' }, { id: 'asc' }];
+  }
+  return [{ date_published: 'desc' }, { date_created: 'desc' }, { id: 'asc' }];
+}
+
 /**
  * Shared filter for the listing: submissions on this site (optionally scoped to
  * a collection / kind) that have at least one version in the requested status.
@@ -32,19 +81,70 @@ function getListingSelects() {
  * than joining `Site` by name, so the planner can use the
  * `(site_id, date_published DESC, date_created DESC)` index for both the
  * ordered page scan and the COUNT.
+ *
+ * `extras` layers on the optional `date_published` window (NULL dates fail the
+ * comparison and are excluded, as intended) and the search-resolved id set.
  */
 function buildListingWhere(
   siteId: string,
   collectionName: string | undefined,
   status: string,
   kind: string | undefined,
+  extras?: ListingExtras,
 ): Prisma.SubmissionWhereInput {
-  return {
+  const where: Prisma.SubmissionWhereInput = {
     site_id: siteId,
     collection: { name: collectionName },
     kind: { name: kind },
     versions: { some: { status } },
   };
+  const toExclusive = extras?.to ? toExclusiveDateUpperBound(extras.to) : undefined;
+  if (extras?.from || toExclusive) {
+    const publishedFilter: Prisma.StringNullableFilter = {};
+    if (extras?.from) publishedFilter.gte = extras.from;
+    if (toExclusive) publishedFilter.lt = toExclusive;
+    where.date_published = publishedFilter;
+  }
+  if (extras?.ids) {
+    where.id = { in: extras.ids };
+  }
+  return where;
+}
+
+/**
+ * Resolve the submission ids matching a free-text query via a single raw SQL
+ * EXISTS subquery that ILIKE-substrings the newest work versions' title /
+ * authors / DOI and the underlying work's DOI. The pg_trgm GIN indexes from
+ * `20260526223800_add_submission_search_trgm_indexes` serve these predicates.
+ *
+ * `immutable_array_to_string(authors, ' ')` MUST match the expression index
+ * exactly for the planner to use it.
+ */
+async function dbSearchSubmissionIds(
+  siteId: string,
+  q: string,
+  tx?: Prisma.TransactionClient,
+): Promise<string[]> {
+  const prisma = await getPrismaClient();
+  const pattern = `%${escapeIlikePattern(q)}%`;
+  const rows = await (tx ?? prisma).$queryRaw<{ id: string }[]>`
+    SELECT s.id FROM "Submission" s
+    WHERE s.site_id = ${siteId}
+      AND EXISTS (
+        SELECT 1
+        FROM "SubmissionVersion" sv
+        JOIN "WorkVersion" wv ON wv.id = sv.work_version_id
+        LEFT JOIN "Work" w ON w.id = wv.work_id
+        WHERE sv.submission_id = s.id
+          AND (
+            wv.title ILIKE ${pattern}
+            OR wv.doi ILIKE ${pattern}
+            OR w.doi ILIKE ${pattern}
+            OR immutable_array_to_string(wv.authors, ' ') ILIKE ${pattern}
+          )
+      )
+  `;
+  return rows.map((r) => r.id);
 }
 
 /**
@@ -59,11 +159,12 @@ async function dbCountSubmissions(
   collectionName: string | undefined,
   status: string,
   kind?: string,
+  extras?: ListingExtras,
   tx?: Prisma.TransactionClient,
 ) {
   const prisma = await getPrismaClient();
   return (tx ?? prisma).submission.count({
-    where: buildListingWhere(siteId, collectionName, status, kind),
+    where: buildListingWhere(siteId, collectionName, status, kind, extras),
   });
 }
 
@@ -83,7 +184,7 @@ async function dbQuerySubmissions(
   collectionName: string | undefined,
   status: string,
   kind?: string,
-  opts?: { page?: number; limit?: number },
+  opts?: { page?: number; limit?: number; sort?: WorksSort; extras?: ListingExtras },
   tx?: Prisma.TransactionClient,
 ): Promise<RowDBO[]> {
   const skip = opts?.limit ? (opts?.page ?? 0) * opts?.limit : undefined;
@@ -93,8 +194,8 @@ async function dbQuerySubmissions(
   const submissions = await (tx ?? prisma).submission.findMany({
     skip,
     take,
-    where: buildListingWhere(siteId, collectionName, status, kind),
-    orderBy: [{ date_published: 'desc' }, { date_created: 'desc' }],
+    where: buildListingWhere(siteId, collectionName, status, kind, opts?.extras),
+    orderBy: buildOrderBy(opts?.sort ?? 'published_desc'),
     select: {
       ...submissionInnerSelect,
       versions: {
@@ -117,8 +218,8 @@ async function dbQuerySubmissions(
 export async function dbListLatestPublishedSubmissions(
   ctx: SiteContext,
   extensions: ClientExtension[],
-  where?: { collection?: string; kind?: string; status?: string },
-  opts?: { page?: number; limit?: number },
+  where?: { collection?: string; kind?: string; status?: string; q?: string; from?: string; to?: string },
+  opts?: { page?: number; limit?: number; sort?: WorksSort },
 ): Promise<ListDBO | undefined> {
   // only allow lookup on status if collection is also provided
   // and limit to allowed statuses for now
@@ -129,6 +230,19 @@ export async function dbListLatestPublishedSubmissions(
       'Can only filter by a status other than "published" when also filtering by collection',
     );
   }
+
+  // Search narrows to a pre-resolved id set via raw SQL (covers the authors
+  // text[] substring match Prisma can't express); the select/count then run
+  // through the shared Prisma filter. An empty match short-circuits.
+  let searchIds: string[] | undefined;
+  if (where?.q) {
+    searchIds = await dbSearchSubmissionIds(ctx.site.id, where.q);
+    if (searchIds.length === 0) {
+      return { items: [], total: 0 };
+    }
+  }
+  const extras: ListingExtras = { from: where?.from, to: where?.to, ids: searchIds };
+  const queryOpts = { ...opts, extras };
 
   const workflows = getWorkflows(ctx.$config, registerExtensionWorkflows(extensions));
   let collectionName: string | undefined;
@@ -157,8 +271,8 @@ export async function dbListLatestPublishedSubmissions(
 
   if (isOffsetPaginationRequested(opts ?? {})) {
     const [items, total] = await Promise.all([
-      dbQuerySubmissions(ctx.site.id, collectionName, status, where?.kind, opts),
-      dbCountSubmissions(ctx.site.id, collectionName, status, where?.kind),
+      dbQuerySubmissions(ctx.site.id, collectionName, status, where?.kind, queryOpts),
+      dbCountSubmissions(ctx.site.id, collectionName, status, where?.kind, extras),
     ]);
     return { items, total };
   }
@@ -167,7 +281,13 @@ export async function dbListLatestPublishedSubmissions(
   // we can still limit, but in this branch we avoid
   // the extra count query
   if (opts?.page === undefined) {
-    const items = await dbQuerySubmissions(ctx.site.id, collectionName, status, where?.kind, opts);
+    const items = await dbQuerySubmissions(
+      ctx.site.id,
+      collectionName,
+      status,
+      where?.kind,
+      queryOpts,
+    );
     return { items, total: items.length };
   }
 
@@ -182,8 +302,8 @@ export async function dbListLatestPublishedSubmissions(
 export async function listPublishedWorks(
   ctx: SiteContext,
   extensions: ClientExtension[],
-  where?: { collection?: string; kind?: string; status?: string },
-  opts?: { page?: number; limit?: number },
+  where?: { collection?: string; kind?: string; status?: string; q?: string; from?: string; to?: string },
+  opts?: { page?: number; limit?: number; sort?: WorksSort },
 ) {
   const dbo = await dbListLatestPublishedSubmissions(ctx, extensions, where, opts);
   if (!dbo) throw error404();

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
@@ -218,7 +218,14 @@ async function dbQuerySubmissions(
 export async function dbListLatestPublishedSubmissions(
   ctx: SiteContext,
   extensions: ClientExtension[],
-  where?: { collection?: string; kind?: string; status?: string; q?: string; from?: string; to?: string },
+  where?: {
+    collection?: string;
+    kind?: string;
+    status?: string;
+    q?: string;
+    from?: string;
+    to?: string;
+  },
   opts?: { page?: number; limit?: number; sort?: WorksSort },
 ): Promise<ListDBO | undefined> {
   // only allow lookup on status if collection is also provided
@@ -302,7 +309,14 @@ export async function dbListLatestPublishedSubmissions(
 export async function listPublishedWorks(
   ctx: SiteContext,
   extensions: ClientExtension[],
-  where?: { collection?: string; kind?: string; status?: string; q?: string; from?: string; to?: string },
+  where?: {
+    collection?: string;
+    kind?: string;
+    status?: string;
+    q?: string;
+    from?: string;
+    to?: string;
+  },
   opts?: { page?: number; limit?: number; sort?: WorksSort },
 ) {
   const dbo = await dbListLatestPublishedSubmissions(ctx, extensions, where, opts);

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
@@ -56,6 +56,12 @@ function escapeIlikePattern(q: string): string {
  */
 function toExclusiveDateUpperBound(toIsoDate: string): string {
   const next = new Date(`${toIsoDate}T00:00:00Z`);
+  // Defense-in-depth: the route schema rejects calendar-invalid dates, but an
+  // invalid `Date` here would serialize to "NaN-NaN-NaN" and (sorting after
+  // every digit) silently match all rows, disabling the bound. Fail loudly.
+  if (Number.isNaN(next.getTime())) {
+    throw httpError(400, `Invalid date for upper bound: ${toIsoDate}`);
+  }
   next.setUTCDate(next.getUTCDate() + 1);
   const y = next.getUTCFullYear();
   const m = String(next.getUTCMonth() + 1).padStart(2, '0');

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/format.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/format.server.ts
@@ -181,13 +181,25 @@ export function formatSiteWorkDTO(ctx: SiteContext, dbo: RowDBO): ModifiedSiteWo
 export function formatSiteWorkDTOFromSubmissions(
   ctx: SiteContext,
   dbo: ListDBO,
-  where?: { collection?: string; kind?: string; status?: string },
-  opts?: { page?: number; limit?: number },
+  where?: {
+    collection?: string;
+    kind?: string;
+    status?: string;
+    q?: string;
+    from?: string;
+    to?: string;
+  },
+  opts?: { page?: number; limit?: number; sort?: 'published_desc' | 'published_asc' },
 ): Omit<SiteWorkListingDTO, 'items'> & { items: ModifiedSiteWorkDTO[] } {
   const selfUrl = new URL(ctx.asApiUrl(`/sites/${ctx.site.name}/works`));
   if (where?.collection) selfUrl.searchParams.set('collection', where?.collection ?? '');
   if (where?.kind) selfUrl.searchParams.set('kind', where?.kind ?? '');
   if (where?.status) selfUrl.searchParams.set('status', where?.status ?? '');
+  if (where?.q) selfUrl.searchParams.set('q', where.q);
+  if (where?.from) selfUrl.searchParams.set('from', where.from);
+  if (where?.to) selfUrl.searchParams.set('to', where.to);
+  // Only emit a non-default sort so default listings keep clean, cache-friendly URLs.
+  if (opts?.sort && opts.sort !== 'published_desc') selfUrl.searchParams.set('sort', opts.sort);
 
   const links = makePaginationLinks(
     {

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/route.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/route.tsx
@@ -21,6 +21,40 @@ const WORKS_SEARCH_MIN_LENGTH = 3;
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
+/**
+ * True only when `v` is a real calendar date in strict `yyyy-mm-dd` form. The
+ * shape regex alone admits impossible dates (`2024-13-45`, `2024-02-30`); we
+ * confirm by parsing as UTC and round-tripping back to the same string. The
+ * round-trip is what rejects both out-of-range components (which parse to
+ * `Invalid Date`) and overflow that `Date` would otherwise silently normalize
+ * (`2024-02-30` → `2024-03-01`). Without this, an invalid `to` flows into
+ * `toExclusiveDateUpperBound` and yields `"NaN-NaN-NaN"`, which sorts after every
+ * digit and silently disables the upper bound instead of erroring.
+ */
+function isValidIsoCalendarDate(v: string): boolean {
+  if (!ISO_DATE.test(v)) return false;
+  const parsed = new Date(`${v}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return false;
+  return parsed.toISOString().slice(0, 10) === v;
+}
+
+/**
+ * Optional inclusive `yyyy-mm-dd` bound on `date_published`. Rejects
+ * calendar-invalid input with a 400 (via `validate`) rather than letting it
+ * degrade the filter silently.
+ */
+const IsoCalendarDateParam = z.preprocess(
+  // An absent or empty/whitespace-only param is treated as "no bound"; a
+  // non-empty value must be a valid calendar date or `refine` rejects it (400).
+  (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+  z
+    .string()
+    .refine(isValidIsoCalendarDate, {
+      message: 'Expected a valid calendar date in yyyy-mm-dd form',
+    })
+    .optional(),
+);
+
 const ParamsSchema = z.object({
   collection: z.string().min(1).max(64).optional(),
   kind: z.string().min(1).max(64).optional(), // TODO kind name should be url-safe
@@ -34,15 +68,9 @@ const ParamsSchema = z.object({
   /** Publication-date sort direction; defaults to newest first. */
   sort: z.enum(['published_desc', 'published_asc']).default('published_desc'),
   /** Inclusive ISO `yyyy-mm-dd` lower bound on `date_published`. */
-  from: z.preprocess(
-    (v) => (typeof v === 'string' && ISO_DATE.test(v) ? v : undefined),
-    z.string().optional(),
-  ),
+  from: IsoCalendarDateParam,
   /** Inclusive ISO `yyyy-mm-dd` upper bound on `date_published`. */
-  to: z.preprocess(
-    (v) => (typeof v === 'string' && ISO_DATE.test(v) ? v : undefined),
-    z.string().optional(),
-  ),
+  to: IsoCalendarDateParam,
   limit: z.number().int().min(1).max(500).default(DEFAULT_WORKS_LIMIT),
   page: z.number().int().min(0).default(0),
 });

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/route.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/route.tsx
@@ -12,10 +12,37 @@ import { listPublishedWorks } from './db.server';
 /** Default page size when the client omits `limit` / `page` (offset pagination is always applied). */
 const DEFAULT_WORKS_LIMIT = 10;
 
+/**
+ * Minimum trigram-friendly search length. Substrings shorter than 3 chars can't
+ * use the pg_trgm GIN indexes and match nearly everything, so they are dropped
+ * (mirrors the submissions-index search contract).
+ */
+const WORKS_SEARCH_MIN_LENGTH = 3;
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
 const ParamsSchema = z.object({
   collection: z.string().min(1).max(64).optional(),
   kind: z.string().min(1).max(64).optional(), // TODO kind name should be url-safe
   status: z.union([z.literal('published'), z.literal('in-review')]).optional(),
+  /** Case-insensitive substring search across title / authors / DOI. */
+  q: z.preprocess((v) => {
+    if (typeof v !== 'string') return undefined;
+    const trimmed = v.trim();
+    return trimmed.length >= WORKS_SEARCH_MIN_LENGTH ? trimmed : undefined;
+  }, z.string().min(WORKS_SEARCH_MIN_LENGTH).max(200).optional()),
+  /** Publication-date sort direction; defaults to newest first. */
+  sort: z.enum(['published_desc', 'published_asc']).default('published_desc'),
+  /** Inclusive ISO `yyyy-mm-dd` lower bound on `date_published`. */
+  from: z.preprocess(
+    (v) => (typeof v === 'string' && ISO_DATE.test(v) ? v : undefined),
+    z.string().optional(),
+  ),
+  /** Inclusive ISO `yyyy-mm-dd` upper bound on `date_published`. */
+  to: z.preprocess(
+    (v) => (typeof v === 'string' && ISO_DATE.test(v) ? v : undefined),
+    z.string().optional(),
+  ),
   limit: z.number().int().min(1).max(500).default(DEFAULT_WORKS_LIMIT),
   page: z.number().int().min(0).default(0),
 });
@@ -32,15 +59,19 @@ export async function loader(args: Route.LoaderArgs) {
     return Response.json({ items: [], total: 0, links: {} }, { headers });
   }
 
-  const { limit, page, ...where } = validate(ParamsSchema, {
+  const { limit, page, sort, ...where } = validate(ParamsSchema, {
     collection: params.get('collection') ?? undefined,
     kind: params.get('kind') ?? undefined,
     status: params.get('status') ?? undefined,
+    q: params.get('q') ?? undefined,
+    sort: params.get('sort') ?? undefined,
+    from: params.get('from') ?? undefined,
+    to: params.get('to') ?? undefined,
     limit: params.has('limit') ? parseInt(params.get('limit')!, 10) : undefined,
     page: params.has('page') ? parseInt(params.get('page')!, 10) : undefined,
   });
 
-  const dto = await listPublishedWorks(ctx, extensions, where, { page, limit });
+  const dto = await listPublishedWorks(ctx, extensions, where, { page, limit, sort });
   const headers = vercelCacheHeaders(
     ctx.site.private ? PRIVATE_CACHE_OPTIONS : SEMI_STATIC_BURST_PROTECTION,
   );

--- a/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
@@ -145,8 +145,18 @@ describe('site works listing — delivered package (limit=10)', () => {
   });
 
   test('the second offset page returns the remaining works, disjoint and correctly ordered', async () => {
-    const page0 = await listPublishedWorks(testData.context, [], {}, { page: 0, limit: PAGE_LIMIT });
-    const page1 = await listPublishedWorks(testData.context, [], {}, { page: 1, limit: PAGE_LIMIT });
+    const page0 = await listPublishedWorks(
+      testData.context,
+      [],
+      {},
+      { page: 0, limit: PAGE_LIMIT },
+    );
+    const page1 = await listPublishedWorks(
+      testData.context,
+      [],
+      {},
+      { page: 1, limit: PAGE_LIMIT },
+    );
 
     // total is stable across pages; the second page holds the remainder.
     expect(page0.total).toBe(TOTAL_PUBLISHED);
@@ -238,6 +248,89 @@ describe('site works listing — delivered package (limit=10)', () => {
       `/sites/${testData.siteName}/works/${newest.workId}/versions/${newest.workVersionId}/social`,
     );
     expect(item.cdn_query).toBeUndefined();
+  });
+});
+
+describe('site works listing — search / sort / date filters', () => {
+  let testData: TestData;
+  let seeds: SeedWork[];
+
+  beforeEach(async () => {
+    testData = await createTestData('ADMIN' as SiteRole);
+    await attachDefaultDomain(testData);
+    seeds = await seedPublishedWorks(testData, TOTAL_PUBLISHED);
+    await seedDraftWorks(testData, 2);
+  });
+
+  test('q matches a title substring', async () => {
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'work 03' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(1);
+    expect(dto.items[0].title).toBe('Benchmark work 03');
+  });
+
+  test('q matches an author substring (text[] column)', async () => {
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'Author 5A' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(1);
+    expect(dto.items[0].id).toBe(seeds[5].workId);
+  });
+
+  test('q matches a DOI substring', async () => {
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'bench-work-07' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(1);
+    expect(dto.items[0].id).toBe(seeds[7].workId);
+  });
+
+  test('q with no matches returns an empty listing', async () => {
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'no-such-work-zzz' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(0);
+    expect(dto.items).toHaveLength(0);
+  });
+
+  test('sort published_asc reverses the default ordering', async () => {
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      {},
+      { page: 0, limit: 500, sort: 'published_asc' },
+    );
+    const expectedOrder = [...seeds]
+      .sort((a, b) => (a.datePublished < b.datePublished ? -1 : 1))
+      .map((s) => s.workId);
+    expect(dto.items.map((i) => i.id)).toEqual(expectedOrder);
+  });
+
+  test('from/to filters to an inclusive date_published window', async () => {
+    // seeds[i].datePublished === 2024-01-(i+1); window 2024-01-05..2024-01-07
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { from: '2024-01-05', to: '2024-01-07' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(3);
+    expect(new Set(dto.items.map((i) => i.id))).toEqual(
+      new Set([seeds[4].workId, seeds[5].workId, seeds[6].workId]),
+    );
   });
 });
 

--- a/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
@@ -332,6 +332,16 @@ describe('site works listing — search / sort / date filters', () => {
       new Set([seeds[4].workId, seeds[5].workId, seeds[6].workId]),
     );
   });
+
+  // A calendar-invalid `to` parses to `Invalid Date` → "NaN-NaN-NaN", which
+  // sorts after every digit and would silently disable the upper bound (match
+  // all rows). The db-layer guard must reject it instead. (The route schema is
+  // the primary gate; this locks the lower-layer defense-in-depth.)
+  test('a calendar-invalid `to` is rejected, not silently ignored', async () => {
+    await expect(
+      listPublishedWorks(testData.context, [], { to: '2024-13-45' }, { page: 0, limit: 500 }),
+    ).rejects.toThrow();
+  });
 });
 
 /* ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Public listing behavior and raw SQL search paths affect query performance and pagination correctness; My Sites URL/revalidation changes are lower risk but touch shared routing.
> 
> **Overview**
> Extends the public works listing API (`GET /v1/sites/:siteName/works`) with **`q`**, **`sort`**, **`from`**, and **`to`**. Clients can substring-search titles, authors, and DOIs (min length 3, ILIKE + existing pg_trgm indexes), sort by publication date (`published_desc` default / `published_asc`), and bound results with an inclusive **`date_published`** window. Invalid calendar dates return 400 instead of silently widening filters; pagination **`links`** keep the new query params (non-default sort is omitted from URLs).
> 
> On **My Sites**, the grid search box now drives **`?q=`** in the URL (replace navigation, throttled) while filtering stays client-side. **`shouldRevalidate`** skips the loader when only **`q`** changes so typing does not re-fetch site cards. The search UI appears when users have **at least two** sites (down from eight).
> 
> Integration tests cover search, ascending sort, date windows, and rejection of invalid **`to`** dates at the DB layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e5084f9f199c9941d4690ceb59f5a8f805e1f3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->