### PR TITLE
🏎️ DOI route indexes and performance improvements

### DIFF
--- a/.changeset/optimise-site-doi-resolution.md
+++ b/.changeset/optimise-site-doi-resolution.md
@@ -1,0 +1,13 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms-db': patch
+'@curvenote/scms': patch
+---
+
+Optimise the site DOI endpoint (`GET /v1/sites/:site/doi/:first/:second`).
+
+- **Correctness:** the no-tag path is now scoped to the requesting site. Previously it resolved a DOI published on _any_ site, so a DOI could leak a work from a different site; it now 404s like the tag path.
+- **Indexes:** added btree indexes on `Work.doi`, `WorkVersion.doi`, and `SubmissionVersion.work_version_id` (the existing trigram GIN indexes only serve `LIKE`/search, and the FK was unindexed), so DOI equality lookups and the DOI→published-version join no longer sequential-scan.
+- **Query:** unified the tag and no-tag paths into a single `SubmissionVersion`-rooted lookup over a shared `where` builder, letting `ORDER BY date_created DESC` + `LIMIT 1` short-circuit at the first match.
+- **Payload:** a narrower select (`siteWorkDtoSelect`) drops the `submitted_by` → `User` join and the submission-version bookkeeping columns the DTO never reads; `formatSiteWorkDTO` now accepts the narrower `SiteWorkDtoInput` (existing callers pass a structural superset and are unaffected).
+- **Caching:** the route now sets Vercel cache headers — semi-static for successful lookups and a burst-protection preset for 404s — so the CDN absorbs repeat traffic (including DOI-scanner probes) instead of the origin/DB.

--- a/docs/planning/site-doi-resolve-performance.md
+++ b/docs/planning/site-doi-resolve-performance.md
@@ -23,6 +23,7 @@ provably behaviour-preserving:
 | 2   | Unified the tag / no-tag paths into one `SubmissionVersion.findFirst` over a shared `buildPublishedByDoiWhere` | one code path, `date_created DESC` + LIMIT 1 short-circuits at the first match                           |
 | 3   | **Correctness:** the no-tag path is now site-scoped                                                            | a DOI published only on _another_ site no longer resolves                                                |
 | 4   | Narrow `siteWorkDtoSelect` for this flow                                                                       | drops the `submitted_by` → `User` join and the SubmissionVersion bookkeeping columns the DTO never reads |
+| 5   | Edge caching on the route (success + 404)                                                                      | DOI→work mappings and junk-DOI scans are absorbed by the CDN instead of the origin/DB                    |
 
 ### 1. Indexes
 
@@ -81,6 +82,31 @@ importantly, `submitted_by`, which otherwise pulls a whole `User` row.
 `SiteWorkDtoInput` derived from the narrow select. The broad payload is a
 structural superset, so the other callers (`published/get`, `versions/get`,
 `previews/get`) that pass a wider row still satisfy it unchanged.
+
+### 5. Edge caching
+
+The route ([`v1.sites.$siteName.doi.$first.$second.tsx`](../../platform/scms/app/routes/api/v1.sites.$siteName.doi.$first.$second.tsx))
+previously returned a bare `Response.json(dto)` with no cache directives — every
+hit, including scanner traffic probing unknown DOIs, reached the origin/DB. It
+now applies the same `vercelCacheHeaders` pattern as the works listing and the
+`published/` endpoint:
+
+- **Success:** `SEMI_STATIC_BURST_PROTECTION` (public sites) / `PRIVATE_CACHE_OPTIONS`
+  (private sites). A DOI→work mapping is stable and identical for every caller.
+- **404:** `sites.doi` signals not-found by throwing a 404 `Response`, so the
+  loader catches it and re-emits with `NOT_FOUND_PUBLIC_BURST` headers — the
+  preset written for "unknown work / junk path segments from scans" — preserving
+  the original body and `statusText` (the distinct 404 messages the e2e asserts).
+
+**Freshness cost:** a newly published DOI may 404 (or a just-superseded version
+may resolve) at the edge until the TTL lapses (`s-maxage` 60s success / 300s
+404, with `stale-while-revalidate`). Tune the presets if DOI propagation needs
+to be faster.
+
+> Not verified against a live server — the SCMS API was not running locally and
+> e2e needs a populated fixture DB. The change is lint-clean and mirrors the
+> established pattern in `published.tsx` and the thumbnail/social routes; the
+> package-level integration spec is route-independent and still green.
 
 ## Remaining / optional work
 

--- a/docs/planning/site-doi-resolve-performance.md
+++ b/docs/planning/site-doi-resolve-performance.md
@@ -1,0 +1,126 @@
+# Follow-up Plan: Site DOI Resolution Performance
+
+## Endpoint
+
+`GET /v1/sites/:siteName/doi/:first/:second` — resolves a DOI to the latest
+published work on a site (optionally pinned to a version `tag`), returning the
+site-work DTO plus an embedded `versions` array.
+
+- Route: [`v1.sites.$siteName.doi.$first.$second.tsx`](../../platform/scms/app/routes/api/v1.sites.$siteName.doi.$first.$second.tsx)
+- Loader: [`sites/doi.server.ts`](../../packages/scms-server/src/backend/loaders/sites/doi.server.ts)
+- DTO formatter (shared): [`sites/submissions/published/get.server.ts`](../../packages/scms-server/src/backend/loaders/sites/submissions/published/get.server.ts)
+
+A golden-payload regression test locks the delivered DTO (shape, field mapping,
+`versions` array, tag path, and the 404 contract) so the optimisation below is
+provably behaviour-preserving:
+[`tests/integration/workflow/site-doi-resolve.spec.ts`](../../platform/scms/tests/integration/workflow/site-doi-resolve.spec.ts).
+
+## What has landed
+
+| #   | Change                                                                                                         | Effect                                                                                                   |
+| --- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| 1   | Btree indexes on `Work.doi`, `WorkVersion.doi`, `SubmissionVersion.work_version_id`                            | DOI equality lookup + the DOI→version join stop sequential-scanning                                      |
+| 2   | Unified the tag / no-tag paths into one `SubmissionVersion.findFirst` over a shared `buildPublishedByDoiWhere` | one code path, `date_created DESC` + LIMIT 1 short-circuits at the first match                           |
+| 3   | **Correctness:** the no-tag path is now site-scoped                                                            | a DOI published only on _another_ site no longer resolves                                                |
+| 4   | Narrow `siteWorkDtoSelect` for this flow                                                                       | drops the `submitted_by` → `User` join and the SubmissionVersion bookkeeping columns the DTO never reads |
+
+### 1. Indexes
+
+Migration
+[`20260529130000_add_doi_lookup_indexes`](../../prisma/schema/migrations/20260529130000_add_doi_lookup_indexes/migration.sql)
+adds btree `@@index([doi])` on `Work` and `WorkVersion`, and
+`@@index([work_version_id])` on `SubmissionVersion`.
+
+The pre-existing `Work_doi_trgm_idx` / `WorkVersion_doi_trgm_idx` (migration
+`20260526223800`) are `gin_trgm_ops` indexes — they only serve `LIKE`/similarity
+search and Postgres cannot use them for `doi = ?`, so the equality lookup was a
+seq scan. `SubmissionVersion.work_version_id` is an FK with no implicit index in
+Postgres, so the DOI→published-version join walked it unindexed.
+
+### 2/3. Re-root + site-scope
+
+Both branches now build their filter from one function:
+
+```ts
+function buildPublishedByDoiWhere(siteName, doiNormalized, tag?) {
+  return {
+    status: 'PUBLISHED',
+    submission: { site: { name: siteName } },
+    ...(tag ? { tags: { has: tag } } : {}),
+    OR: [
+      { work_version: { doi: doiNormalized } },
+      { work_version: { work: { doi: doiNormalized } } },
+    ],
+  };
+}
+```
+
+The old no-tag path rooted at `WorkVersion.findMany` **without** a site filter,
+so it could return a work published on a different site (the tag path already
+scoped correctly). Rooting at `SubmissionVersion` makes the two paths identical
+apart from the tag predicate and folds the previous "newest work version → its
+newest published submission version" two-step into a single
+"newest published submission version" ordering.
+
+> Note: the ordering semantics shift from _newest WorkVersion_ to _newest
+> published SubmissionVersion_. For the common single-version work these are the
+> same; the SubmissionVersion ordering matches the tag path and the embedded
+> `versions` array, so the response is internally consistent.
+
+### 4. Narrow select
+
+`siteWorkDtoSelect` (in
+[`prisma.selects.server.ts`](../../packages/scms-server/src/backend/prisma.selects.server.ts))
+keeps the same relation shape as the shared `submissionVersionForSiteWorkSelect`
+— so the nested kind/collection summary formatters still type-check — but drops
+the SubmissionVersion-level columns `formatSiteWorkDTO` never reads (`status`,
+`transition`, `job_id`, `work_version_id`, version-level `date_*`) and, most
+importantly, `submitted_by`, which otherwise pulls a whole `User` row.
+
+`formatSiteWorkDTO`'s parameter type was relaxed from the broad `DBO` to a new
+`SiteWorkDtoInput` derived from the narrow select. The broad payload is a
+structural superset, so the other callers (`published/get`, `versions/get`,
+`previews/get`) that pass a wider row still satisfy it unchanged.
+
+## Remaining / optional work
+
+### A. Narrow the shared site-work formatter further
+
+`formatSiteWorkDTO` still receives full `kind` / `collection` / `work` /
+`slugs` relations because the shared summary formatters
+(`formatSubmissionKindSummaryDTO`, `formatCollectionSummaryDTO`) are typed to the
+full models. The works-listing endpoint solved this by copying a local formatter
+with a narrow input type. Doing the same here (or relaxing the summary
+formatters to structural inputs) would let `siteWorkDtoSelect` select only the
+summary columns (`kind {id,name,content,default}`, `collection
+{id,name,slug,workflow,content,open}`, `work {doi,key}`, primary slug only).
+Low payoff for a single-row endpoint; medium blast radius. Defer.
+
+### B. Single round trip for the `versions` array
+
+The endpoint issues a second query (`dbGetPublishedVersionsForSubmission`) for
+the version list. It is small and indexed by `(submission_id, date_created)`, so
+it is cheap; only worth folding in if profiling shows the extra round trip
+matters.
+
+## Tests locking the contract
+
+- [`tests/integration/workflow/site-doi-resolve.spec.ts`](../../platform/scms/tests/integration/workflow/site-doi-resolve.spec.ts)
+  — 7 assertions over a deterministic seed: DTO + `versions` shape, full field
+  mapping, multi-version ordering (newest resolved + array newest-first), the
+  tag path (hit + miss 404), the **cross-site 404** (the intended behaviour
+  change — this test fails on the pre-rewrite code), and the invalid / unknown
+  DOI 404 messages.
+- [`tests/e2e/sites.doi.spec.ts`](../../platform/scms/tests/e2e/sites.doi.spec.ts)
+  — added `find work by doi, incorrect site` asserting `sites/newscience/doi/...`
+  404s against the fixture work that lives on `science`. The prior cross-site
+  test there targeted the `published/` endpoint, so the `doi/` path's
+  site-scoping was previously uncovered end-to-end.
+
+## References
+
+- [`site-works-listing-performance.md`](./site-works-listing-performance.md)
+  — sibling endpoint; the narrow-select / local-formatter pattern referenced in
+  (A).
+- [`20260526204900_add_listing_lookup_indexes`](../../prisma/schema/migrations/20260526204900_add_listing_lookup_indexes/migration.sql)
+  — the `IF NOT EXISTS` + Prisma-default-name convention this migration follows.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5049,6 +5049,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+      "integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
@@ -5189,6 +5206,23 @@
       "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
       "cpu": [
         "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+      "integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+      "cpu": [
+        "loong64"
       ],
       "dev": true,
       "license": "MIT",
@@ -6621,6 +6655,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jest/schemas": {
@@ -10155,6 +10201,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@rgrove/parse-xml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@rgrove/parse-xml/-/parse-xml-4.2.0.tgz",
+      "integrity": "sha512-UuBOt7BOsKVOkFXRe4Ypd/lADuNIfqJXv8GvHqtXaTYXPPKkj2nS2zPllVsrtRjcomDhIJVBnZwfmlI222WH8g==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@rjsf/utils": {
       "version": "5.24.13",
       "license": "Apache-2.0",
@@ -12815,6 +12870,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2-sftp-client": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-sftp-client/-/ssh2-sftp-client-9.0.6.tgz",
+      "integrity": "sha512-4+KvXO/V77y9VjI2op2T8+RCGI/GXQAwR0q5Qkj/EJ5YSeyKszqZP6F8i3H3txYoBqjc7sgorqyvBP3+w1EHyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ssh2": "^1.0.0"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/supports-color": {
       "version": "8.1.3",
       "license": "MIT"
@@ -12864,6 +12956,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/xast": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/xast/-/xast-2.0.4.tgz",
+      "integrity": "sha512-6Q6HWhHXR5EEKcxgF5YBW5XPAAtCi/GgyCWHx6wR7dZTXF5rv2B2fm0hgpSscJqaVDVm6n1DAVbsM8RSM5PlMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -14530,7 +14631,6 @@
     },
     "node_modules/asn1": {
       "version": "0.2.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
@@ -14811,7 +14911,6 @@
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
@@ -15123,6 +15222,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/builtins": {
@@ -16413,6 +16521,21 @@
       "version": "0.0.1",
       "license": "MIT"
     },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/concurrently": {
       "version": "9.2.1",
       "dev": true,
@@ -16608,6 +16731,20 @@
       "license": "MIT",
       "dependencies": {
         "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/cpx": {
@@ -17130,6 +17267,22 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/css-selector-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
+      "integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -18811,6 +18964,346 @@
         "@esbuild/win32-arm64": "0.28.0",
         "@esbuild/win32-ia32": "0.28.0",
         "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/esbuild-android-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+      "integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+      "integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+      "integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+      "integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+      "integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+      "integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+      "integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+      "integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+      "integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+      "integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+      "integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+      "integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+      "integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+      "integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+      "integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+      "integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+      "integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+      "integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+      "integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+      "integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
@@ -27606,7 +28099,6 @@
     },
     "node_modules/nan": {
       "version": "2.25.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -30183,6 +30675,279 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pmc-node-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pmc-node-utils/-/pmc-node-utils-0.3.1.tgz",
+      "integrity": "sha512-ofCqphRccMNw32sugWWU3BMNnj7Yis3XkNRntq2+SfpQy60pji28tlhwrnxW/cZuWVpVGuHg6k241X0Lv60SQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/xast": "^2.0.4",
+        "adm-zip": "^0.5.10",
+        "chalk": "^5.3.0",
+        "commander": "^11.1.0",
+        "css-selector-parser": "^3.0.5",
+        "doi-utils": "^2.0.3",
+        "inquirer": "^9.2.23",
+        "js-yaml": "^4.1.0",
+        "myst-cli": "^1.3.1",
+        "myst-cli-utils": "^2.0.10",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
+        "myst-to-jats": "^1.0.27",
+        "nanoid": "^5.0.9",
+        "pmc-utils": "0.3.1",
+        "tar": "^7.4.3",
+        "unist-builder": "^4.0.0",
+        "unist-util-select": "^5.1.0",
+        "unist-util-visit": "^5.0.0",
+        "uuid": "^10.0.0",
+        "vfile": "^5.0.0",
+        "which": "^4.0.0",
+        "xast-util-to-xml": "^4.0.0",
+        "zod": "^3.23.8"
+      },
+      "bin": {
+        "pmc": "dist/pmc.cjs"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-builder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-4.0.0.tgz",
+      "integrity": "sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-util-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-5.1.0.tgz",
+      "integrity": "sha512-4A5mfokSHG/rNQ4g7gSbdEs+H586xyd24sdJqF1IWamqrLHvYb+DH48fzxowyOhOfK7YSqX+XlCojAyuuyyT2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.1.0",
+        "nth-check": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/pmc-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pmc-utils/-/pmc-utils-0.3.1.tgz",
+      "integrity": "sha512-ri9DmmEf4375ES9+xjLqdfX4Y++QzBVfXkSgsrepBmYVnoF4j8CJy/Cqt/0gcLWjWaB2Ilih7v83yJP3+Vdj3w==",
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "^0.5.10",
+        "css-selector-parser": "^3.0.5",
+        "doi-utils": "^2.0.3",
+        "js-yaml": "^4.1.0",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
+        "myst-to-jats": "^1.0.27",
+        "nanoid": "^5.0.9",
+        "unist-builder": "^4.0.0",
+        "unist-util-select": "^5.1.0",
+        "unist-util-visit": "^5.0.0",
+        "uuid": "^10.0.0",
+        "xast-util-from-xml": "^4.0.0",
+        "xast-util-to-xml": "^4.0.0",
+        "xml-formatter": "^3.6.3",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-builder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-4.0.0.tgz",
+      "integrity": "sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-util-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-5.1.0.tgz",
+      "integrity": "sha512-4A5mfokSHG/rNQ4g7gSbdEs+H586xyd24sdJqF1IWamqrLHvYb+DH48fzxowyOhOfK7YSqX+XlCojAyuuyyT2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.1.0",
+        "nth-check": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/points-on-curve": {
@@ -33257,6 +34022,40 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
+    "node_modules/ssh2-sftp-client": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-12.1.1.tgz",
+      "integrity": "sha512-wYVDgwkpcKG2iPGQQ+QR33xkWqLFIaVrYvA+uON4pmxTPaPuB81f1aooUEPN75e/9DCK6rrKYXb6zR6zP3+EtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "concat-stream": "^2.0.0",
+        "ssh2": "^1.16.0"
+      },
+      "engines": {
+        "node": ">=18.20.4"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://square.link/u/4g7sPflL"
+      }
+    },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "dev": true,
@@ -34159,6 +34958,52 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/teeny-request": {
@@ -35900,7 +36745,6 @@
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
-      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/type-check": {
@@ -38787,6 +39631,64 @@
         }
       }
     },
+    "node_modules/xast-util-from-xml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xast-util-from-xml/-/xast-util-from-xml-4.0.0.tgz",
+      "integrity": "sha512-Pwj6Bw5XARduMeTWpeEfmfgT8/Ma3oiMI4bBIRzCd7GH26A/dn3x7jDc2BHBCQxxdQniTh0MjVUYbjaj4Ljb+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@rgrove/parse-xml": "^4.1.0",
+        "@types/xast": "^2.0.0",
+        "vfile-location": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/xast-util-from-xml/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/xast-util-from-xml/node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/xast-util-to-xml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xast-util-to-xml/-/xast-util-to-xml-4.0.0.tgz",
+      "integrity": "sha512-r1euIWS5yZJUNpfN+ReE4m7Vld2iytaOPJtuXVuRQacRZwqRN1MAb+dv0aGLrdXOZrpGLyvUFf1Upyrb3R5qBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/xast": "^2.0.0",
+        "ccount": "^2.0.0",
+        "stringify-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
       "license": "MIT",
@@ -38797,6 +39699,18 @@
     "node_modules/xml": {
       "version": "1.0.1",
       "license": "MIT"
+    },
+    "node_modules/xml-formatter": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/xml-formatter/-/xml-formatter-3.7.0.tgz",
+      "integrity": "sha512-+8qTc3zv2UcJ1v9IsSIce37Dl4MQG14Cp7tWrwmy202UaI1wqRukw5QMX1JHsV+DX64yw77EgGsj2s5wGvuMbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-parser-xo": "^4.1.5"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/xml-js": {
       "version": "1.6.11",
@@ -38813,6 +39727,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xml-parser-xo": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/xml-parser-xo/-/xml-parser-xo-4.1.6.tgz",
+      "integrity": "sha512-mXbSNSM+rIwndoxSwmFa83bOdeP8G/cOGr7XvxA67X7ebCzoAuVez9JYDCDub3zRDNBZxIbfjuXLSsamr7NfwQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/xmlchars": {
@@ -41415,7 +42338,7 @@
     },
     "platform/scms": {
       "name": "@curvenote/scms",
-      "version": "0.18.2",
+      "version": "0.18.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/packages/scms-server/src/backend/loaders/sites/doi.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/doi.server.ts
@@ -6,66 +6,51 @@ import type { SiteWorkVersionDTO } from '@curvenote/common';
 import { formatSiteWorkDTO } from './submissions/published/get.server.js';
 import type { ModifiedSiteWorkDTO } from './submissions/published/get.server.js';
 import type { SiteContext } from '../../context.site.server.js';
-import {
-  siteWorkWorkVersionSelect,
-  submissionVersionForSiteWorkSelect,
-} from '../../prisma.selects.server.js';
+import type { Prisma } from '@curvenote/scms-db';
+import { siteWorkDtoSelect } from '../../prisma.selects.server.js';
 
 export type SiteDoiResolveOptions = {
   /** If set, pick the latest *published* submission version for this DOI whose `tags` contains this string */
   tag?: string;
 };
 
-async function dbGetLatestPublishedWorkByDoi(doiNormalized: string) {
-  const prisma = await getPrismaClient();
-  return await prisma.workVersion.findMany({
-    where: {
-      OR: [{ doi: doiNormalized }, { work: { doi: doiNormalized } }],
-      submissionVersions: {
-        some: {
-          status: 'PUBLISHED',
-        },
-      },
-    },
-    orderBy: {
-      date_created: 'desc',
-    },
-    take: 1,
-    select: {
-      ...siteWorkWorkVersionSelect,
-      work: { select: { id: true, doi: true, key: true } },
-      submissionVersions: {
-        where: {
-          status: 'PUBLISHED',
-        },
-        orderBy: {
-          date_created: 'desc',
-        },
-        take: 1,
-        select: submissionVersionForSiteWorkSelect,
-      },
-    },
-  });
-}
-
-async function dbGetPublishedSubmissionVersionByDoiAndTag(
+/**
+ * Filter for the latest *published* submission version of a DOI on this site.
+ *
+ * Rooting at `SubmissionVersion` (rather than `WorkVersion`) makes the tag and
+ * no-tag paths a single query and lets the `date_created DESC` + LIMIT 1
+ * short-circuit at the first match. The DOI is matched against either the
+ * version's own `doi` or the parent work's `doi` — both now backed by btree
+ * indexes (migration `20260529130000`) so the equality lookup no longer
+ * sequential-scans.
+ *
+ * Crucially this is always scoped to `siteName`. The previous no-tag path
+ * (`WorkVersion`-rooted) omitted the site filter and could resolve a DOI that
+ * was only published on a *different* site; the tag path already scoped
+ * correctly, and the regression spec pins this down.
+ */
+function buildPublishedByDoiWhere(
   siteName: string,
   doiNormalized: string,
-  tag: string,
-) {
+  tag?: string,
+): Prisma.SubmissionVersionWhereInput {
+  return {
+    status: 'PUBLISHED',
+    submission: { site: { name: siteName } },
+    ...(tag ? { tags: { has: tag } } : {}),
+    OR: [
+      { work_version: { doi: doiNormalized } },
+      { work_version: { work: { doi: doiNormalized } } },
+    ],
+  };
+}
+
+async function dbGetPublishedSiteWorkByDoi(siteName: string, doiNormalized: string, tag?: string) {
   const prisma = await getPrismaClient();
   return prisma.submissionVersion.findFirst({
-    where: {
-      status: 'PUBLISHED',
-      tags: { has: tag },
-      submission: { site: { name: siteName } },
-      OR: [
-        { work_version: { doi: doiNormalized } },
-        { work_version: { work: { doi: doiNormalized } } },
-      ],
-    },
+    where: buildPublishedByDoiWhere(siteName, doiNormalized, tag),
     orderBy: { date_created: 'desc' },
-    select: submissionVersionForSiteWorkSelect,
+    select: siteWorkDtoSelect,
   });
 }
 
@@ -113,24 +98,15 @@ export default async function (
   if (!doiNormalized) throw error404('Not Found - Invalid DOI');
 
   const tag = opts?.tag?.trim();
-  let siteWork: ModifiedSiteWorkDTO;
-  if (tag) {
-    const sv = await dbGetPublishedSubmissionVersionByDoiAndTag(ctx.site.name, doiNormalized, tag);
-    if (!sv) {
-      throw error404(
-        'Not Found - No published submission version with that tag for this DOI on this site',
-      );
-    }
-    siteWork = formatSiteWorkDTO(ctx, { ...sv, work_version: sv.work_version });
-  } else {
-    const dbo = await dbGetLatestPublishedWorkByDoi(doiNormalized);
-    if (!dbo || dbo.length === 0)
-      throw error404('Not Found - No work with that DOI exists in database');
-
-    const { submissionVersions, ...work_version } = dbo[0];
-    const sv = submissionVersions[0];
-    siteWork = formatSiteWorkDTO(ctx, { ...sv, work_version });
+  const sv = await dbGetPublishedSiteWorkByDoi(ctx.site.name, doiNormalized, tag);
+  if (!sv) {
+    throw error404(
+      tag
+        ? 'Not Found - No published submission version with that tag for this DOI on this site'
+        : 'Not Found - No work with that DOI exists in database',
+    );
   }
+  const siteWork = formatSiteWorkDTO(ctx, sv);
 
   // One indexed query for the work's published versions, replacing a second
   // client round-trip to the submission `versions` listing.

--- a/packages/scms-server/src/backend/loaders/sites/submissions/published/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/published/get.server.ts
@@ -2,10 +2,8 @@ import type { SiteContext } from '../../../../context.site.server.js';
 import type { HostSpec, SiteWorkDTO } from '@curvenote/common';
 import { formatDate, concatSiteWorkTags } from '@curvenote/common';
 import { getPrismaClient } from '../../../../prisma.server.js';
-import {
-  siteWorkDtoSelect,
-  submissionVersionForSiteWorkSelect,
-} from '../../../../prisma.selects.server.js';
+import type { siteWorkDtoSelect } from '../../../../prisma.selects.server.js';
+import { submissionVersionForSiteWorkSelect } from '../../../../prisma.selects.server.js';
 import type { Prisma } from '@curvenote/scms-db';
 import { signPrivateUrls } from '../../../../sign.private.server.js';
 import { formatCollectionSummaryDTO } from '../../get.server.js';

--- a/packages/scms-server/src/backend/loaders/sites/submissions/published/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/published/get.server.ts
@@ -2,7 +2,10 @@ import type { SiteContext } from '../../../../context.site.server.js';
 import type { HostSpec, SiteWorkDTO } from '@curvenote/common';
 import { formatDate, concatSiteWorkTags } from '@curvenote/common';
 import { getPrismaClient } from '../../../../prisma.server.js';
-import { submissionVersionForSiteWorkSelect } from '../../../../prisma.selects.server.js';
+import {
+  siteWorkDtoSelect,
+  submissionVersionForSiteWorkSelect,
+} from '../../../../prisma.selects.server.js';
 import type { Prisma } from '@curvenote/scms-db';
 import { signPrivateUrls } from '../../../../sign.private.server.js';
 import { formatCollectionSummaryDTO } from '../../get.server.js';
@@ -50,6 +53,16 @@ export type DBO = Prisma.SubmissionVersionGetPayload<{
   select: typeof submissionVersionForSiteWorkSelect;
 }>;
 
+/**
+ * The minimal input `formatSiteWorkDTO` actually reads. Derived from the narrow
+ * `siteWorkDtoSelect`; the broader `DBO` (and any other site-work payload) is a
+ * structural superset, so existing callers that pass a wider row still satisfy
+ * this type.
+ */
+export type SiteWorkDtoInput = Prisma.SubmissionVersionGetPayload<{
+  select: typeof siteWorkDtoSelect;
+}>;
+
 type ModifiedSiteWorkLinksDTO = Omit<SiteWorkDTO['links'], 'thumbnail' | 'social' | 'config'> & {
   thumbnail?: string;
   social?: string;
@@ -62,7 +75,7 @@ export type ModifiedSiteWorkDTO = Omit<SiteWorkDTO, 'links' | 'cdn' | 'cdn_key'>
   cdn?: string;
   cdn_key?: string;
 };
-export function formatSiteWorkDTO(ctx: SiteContext, dbo: DBO): ModifiedSiteWorkDTO {
+export function formatSiteWorkDTO(ctx: SiteContext, dbo: SiteWorkDtoInput): ModifiedSiteWorkDTO {
   const { cdn_key, cdn, title, description, canonical, authors, date_created } = dbo.work_version;
   const tags = concatSiteWorkTags(dbo.tags ?? [], dbo.work_version.tags ?? []);
   const submission_version_id = dbo.id;

--- a/packages/scms-server/src/backend/prisma.selects.server.ts
+++ b/packages/scms-server/src/backend/prisma.selects.server.ts
@@ -60,6 +60,34 @@ export const submissionVersionForListSelect = {
 } satisfies Prisma.SubmissionVersionSelect;
 
 /**
+ * Minimal select for rows formatted *only* by `formatSiteWorkDTO` (the public
+ * site-work DTO). Same relation shape as `submissionVersionForSiteWorkSelect`
+ * so the nested summary formatters still type-check, but drops the
+ * SubmissionVersion-level bookkeeping the DTO never reads — `status`,
+ * `transition`, `job_id`, `work_version_id`, the version-level `date_*`, and
+ * crucially `submitted_by` (which otherwise pulls a whole `User` row).
+ *
+ * Use this for endpoints that resolve a single site-work and run it straight
+ * through `formatSiteWorkDTO` (e.g. `sites.doi`). Endpoints that also build a
+ * `SubmissionVersionDTO` (versions list/get) need the broader select above.
+ */
+export const siteWorkDtoSelect = {
+  id: true,
+  tags: true,
+  work_version: { select: siteWorkWorkVersionSelect },
+  submission: {
+    select: {
+      id: true,
+      date_published: true,
+      kind: true,
+      collection: true,
+      slugs: true,
+      work: true,
+    },
+  },
+} satisfies Prisma.SubmissionVersionSelect;
+
+/**
  * Submission version rows formatted as SiteWorkDTO / SubmissionVersionDTO
  * (excludes submission-version metadata JSON).
  */

--- a/platform/scms/app/routes/api/v1.sites.$siteName.doi.$first.$second.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.doi.$first.$second.tsx
@@ -1,11 +1,25 @@
 import type { Route } from './+types/v1.sites.$siteName.doi.$first.$second';
 import { httpError } from '@curvenote/scms-core';
 import { withSecureSiteContext, sites } from '@curvenote/scms-server';
+import {
+  NOT_FOUND_PUBLIC_BURST,
+  PRIVATE_CACHE_OPTIONS,
+  SEMI_STATIC_BURST_PROTECTION,
+  vercelCacheHeaders,
+} from 'app/lib/vercel-cache';
 
 /**
  * `GET …/sites/:siteName/doi/:first/:second` → DOI `:first/:second` (e.g. `10.1101` / `711317`).
  * Optional query `tag` — same JSON shape, but resolves to the latest *published* submission version
  * whose `tags` array contains that string (PostgreSQL array `has`, exact string after trim in query param).
+ *
+ * Responses are edge-cached: a DOI→work mapping is stable and identical for every
+ * caller on a public site, and DOI resolvers attract heavy scanner traffic probing
+ * unknown DOIs. Successful lookups use the semi-static preset; not-found responses
+ * use the burst-protection 404 preset so junk-DOI scans are absorbed by the CDN
+ * rather than hitting the origin/DB. Private sites fall back to a private,
+ * browser-only cache. The freshness cost: a newly published DOI may 404 (or a stale
+ * version may resolve) at the edge until the TTL lapses.
  */
 export async function loader(args: Route.LoaderArgs) {
   const ctx = await withSecureSiteContext(args);
@@ -20,6 +34,28 @@ export async function loader(args: Route.LoaderArgs) {
   const tagRaw = new URL(args.request.url).searchParams.get('tag');
   const tag = tagRaw?.trim() ? tagRaw.trim() : undefined;
 
-  const dto = await sites.doi(ctx, doiLookup, tag ? { tag } : undefined);
-  return Response.json(dto);
+  try {
+    const dto = await sites.doi(ctx, doiLookup, tag ? { tag } : undefined);
+    const headers = vercelCacheHeaders(
+      ctx.site.private ? PRIVATE_CACHE_OPTIONS : SEMI_STATIC_BURST_PROTECTION,
+    );
+    return Response.json(dto, { headers });
+  } catch (err) {
+    // `sites.doi` signals not-found by throwing a 404 Response (invalid DOI,
+    // unknown DOI, or absent tag). Re-emit it with edge-cache headers so the CDN
+    // absorbs repeat scans; preserve the original body and statusText so the
+    // distinct 404 messages are unchanged.
+    if (err instanceof Response && err.status === 404) {
+      const nfHeaders = vercelCacheHeaders(
+        ctx.site.private ? PRIVATE_CACHE_OPTIONS : NOT_FOUND_PUBLIC_BURST,
+      );
+      const body = await err.text();
+      return new Response(body, {
+        status: 404,
+        statusText: err.statusText,
+        headers: { ...Object.fromEntries(err.headers), ...nfHeaders },
+      });
+    }
+    throw err;
+  }
 }

--- a/platform/scms/tests/e2e/sites.doi.spec.ts
+++ b/platform/scms/tests/e2e/sites.doi.spec.ts
@@ -16,4 +16,9 @@ describe('sites doi API', () => {
   test('find work by doi', async () => {
     await expectSuccess('sites/science/doi/10.5281/zenodo.5634114');
   });
+  test('find work by doi, incorrect site', async () => {
+    // The work is published on `science`; resolving the same DOI on another
+    // site must 404. Guards the site-scoping of the no-tag DOI path.
+    await expectStatus(404, 'sites/newscience/doi/10.5281/zenodo.5634114');
+  });
 });

--- a/platform/scms/tests/integration/workflow/site-doi-resolve.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-doi-resolve.spec.ts
@@ -1,0 +1,390 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { describe, test, expect, beforeEach } from 'vitest';
+import type { SiteRole } from '@curvenote/scms-db';
+import { getPrismaClient, sites } from '@curvenote/scms-server';
+import { doi as doiUtil } from 'doi-utils';
+import { uuidv7 } from 'uuidv7';
+import { createTestData, type TestData } from '../helpers/mocks';
+
+/**
+ * Golden-payload regression guard for `GET /v1/sites/:siteName/doi/:first/:second`
+ * (resolved by `sites.doi`).
+ *
+ * Locks the delivered package — DTO shape, field mapping, the embedded
+ * `versions` array, the tag path, and the 404 contract — so the performance
+ * rewrite (DOI btree indexes, SubmissionVersion-rooted query, site-scoped
+ * lookup, trimmed select) can be proven behaviour-preserving.
+ *
+ * The one *intended* behaviour change is asserted by `does not resolve a DOI
+ * published on another site`: the pre-rewrite no-tag path ignored the site and
+ * could return another site's work; the rewrite scopes every path to the site.
+ */
+
+const ITEM_KEYS = [
+  'id',
+  'version_id',
+  'submission_version_id',
+  'cdn',
+  'cdn_key',
+  'slug',
+  'doi',
+  'key',
+  'cdn_query',
+  'title',
+  'description',
+  'authors',
+  'canonical',
+  'tags',
+  'date_created',
+  'date',
+  'date_published',
+  'kind',
+  'collection',
+  'submission_id',
+  'links',
+  'versions',
+] as const;
+
+const ITEM_LINK_KEYS = [
+  'self',
+  'site',
+  'work',
+  'submission',
+  'versions',
+  'html',
+  'thumbnail',
+  'social',
+  'config',
+  'doi',
+] as const;
+
+const VERSION_KEYS = ['submission_version_id', 'version', 'date', 'tags'] as const;
+
+describe('site doi resolve — delivered package', () => {
+  let testData: TestData;
+  let hostname: string;
+
+  beforeEach(async () => {
+    testData = await createTestData('ADMIN' as SiteRole);
+    hostname = await attachDefaultDomain(testData);
+  });
+
+  test('resolves a published DOI to the full work DTO with a versions array', async () => {
+    const seed = await seedPublishedWorkWithDoi(testData, {});
+    const dto = await sites.doi(testData.context, seed.rawDoi);
+
+    expect(Object.keys(dto).sort()).toEqual([...ITEM_KEYS].sort());
+    expect(Object.keys(dto.links).sort()).toEqual([...ITEM_LINK_KEYS].sort());
+    expect(Array.isArray(dto.versions)).toBe(true);
+    expect(dto.versions).toHaveLength(1);
+    expect(Object.keys(dto.versions[0]).sort()).toEqual([...VERSION_KEYS].sort());
+  });
+
+  test('maps every field of the resolved work correctly', async () => {
+    const seed = await seedPublishedWorkWithDoi(testData, {
+      authors: ['Ada Lovelace', 'Alan Turing'],
+      datePublished: '2024-03-15',
+      wvTags: ['preprint'],
+    });
+    const dto = await sites.doi(testData.context, seed.rawDoi);
+
+    expect(dto.id).toBe(seed.workId);
+    expect(dto.version_id).toBe(seed.workVersionId);
+    expect(dto.submission_version_id).toBe(seed.svId);
+    expect(dto.submission_id).toBe(seed.submissionId);
+    expect(dto.doi).toBe(seed.normDoi);
+    expect(dto.key).toBe(seed.workKey);
+    expect(dto.slug).toBe(`${seed.slug}-${testData.siteId}`);
+    expect(dto.title).toBe(seed.title);
+    expect(dto.description).toBe(seed.description);
+    expect(dto.authors).toEqual(seed.authors.map((name) => ({ name })));
+    expect(dto.canonical).toBe(true);
+    expect(dto.date).toBe(seed.datePublished);
+    expect(dto.date_published).toBe(seed.datePublished);
+    expect(dto.cdn).toBe('https://test-cdn.com');
+    expect(dto.cdn_key).toBe(`cdn-key-${seed.workId}`);
+
+    expect(dto.kind?.name).toBe(`Test Kind ${testData.kindId}`);
+    expect(dto.kind?.default).toBe(true);
+    expect(dto.collection?.slug).toBe(`test-collection-${testData.collectionId}`);
+
+    expect(dto.links.self).toContain(
+      `/sites/${testData.siteName}/works/${seed.workId}/versions/${seed.workVersionId}`,
+    );
+    expect(dto.links.work).toContain(`/works/${seed.workId}`);
+    expect(dto.links.submission).toContain(
+      `/sites/${testData.siteName}/submissions/${seed.submissionId}`,
+    );
+    expect(dto.links.html).toBe(`https://${hostname}/articles/${seed.workId}`);
+    expect(dto.links.doi).toBe(`https://doi.org/${seed.normDoi}`);
+  });
+
+  test('embeds every published version, newest first, and resolves to the newest', async () => {
+    const seed = await seedPublishedWorkWithDoi(testData, { datePublished: '2024-01-01' });
+    const newer = await addPublishedVersion(testData, seed, {
+      datePublished: '2024-06-01',
+      svTags: ['v2'],
+    });
+
+    const dto = await sites.doi(testData.context, seed.rawDoi);
+
+    // Resolves to the newest published submission version.
+    expect(dto.submission_version_id).toBe(newer.svId);
+    // versions array carries both, newest first.
+    expect(dto.versions.map((v) => v.submission_version_id)).toEqual([newer.svId, seed.svId]);
+    expect(dto.versions[0].tags).toEqual(['v2']);
+  });
+
+  test('tag path resolves the tagged version; an absent tag is a 404', async () => {
+    const seed = await seedPublishedWorkWithDoi(testData, { svTags: ['hhmi'] });
+
+    const dto = await sites.doi(testData.context, seed.rawDoi, { tag: 'hhmi' });
+    expect(dto.submission_version_id).toBe(seed.svId);
+
+    await expectRejects404(sites.doi(testData.context, seed.rawDoi, { tag: 'nope' }));
+  });
+
+  test('does not resolve a DOI published on another site', async () => {
+    const otherSiteId = await createBareSite();
+    const seed = await seedPublishedWorkWithDoi(testData, { siteId: otherSiteId });
+
+    // The DOI exists, but only on another site — this site must 404.
+    await expectRejects404(sites.doi(testData.context, seed.rawDoi));
+  });
+
+  test('invalid DOI is a 404', async () => {
+    await expectRejects404(sites.doi(testData.context, 'not-a-doi'), 'Not Found - Invalid DOI');
+  });
+
+  test('unknown DOI is a 404 with the work-not-found message', async () => {
+    await expectRejects404(
+      sites.doi(testData.context, '10.5555/does-not-exist'),
+      'Not Found - No work with that DOI exists in database',
+    );
+  });
+});
+
+/* ---------------------------------------------------------------------------
+ * Helpers
+ * ------------------------------------------------------------------------ */
+
+async function expectRejects404(p: Promise<unknown>, statusText?: string): Promise<void> {
+  const err = await p.then(
+    () => {
+      throw new Error('expected the call to reject with a 404');
+    },
+    (e) => e,
+  );
+  expect(err).toBeInstanceOf(Response);
+  expect((err as Response).status).toBe(404);
+  if (statusText) expect((err as Response).statusText).toBe(statusText);
+}
+
+async function attachDefaultDomain(testData: TestData): Promise<string> {
+  const prisma = await getPrismaClient();
+  const hostname = `t-${testData.siteId}.example.com`;
+  await prisma.domain.create({
+    data: {
+      id: uuidv7(),
+      date_created: new Date().toISOString(),
+      date_modified: new Date().toISOString(),
+      hostname,
+      default: true,
+      site: { connect: { id: testData.siteId } },
+    },
+  });
+  testData.context.site = {
+    ...testData.context.site,
+    domains: [
+      {
+        id: uuidv7(),
+        date_created: new Date().toISOString(),
+        date_modified: new Date().toISOString(),
+        hostname,
+        default: true,
+        site_id: testData.siteId,
+      },
+    ],
+  };
+  return hostname;
+}
+
+async function createBareSite(): Promise<string> {
+  const prisma = await getPrismaClient();
+  const siteId = uuidv7();
+  const now = new Date().toISOString();
+  await prisma.site.create({
+    data: {
+      id: siteId,
+      name: `other-site-${siteId}`,
+      title: 'Other Site',
+      private: false,
+      date_created: now,
+      date_modified: now,
+      metadata: {},
+      external: false,
+      restricted: true,
+      default_workflow: 'SIMPLE',
+      slug_strategy: 'NONE',
+      description: null,
+    },
+  });
+  return siteId;
+}
+
+interface DoiSeed {
+  workId: string;
+  workVersionId: string;
+  submissionId: string;
+  svId: string;
+  rawDoi: string;
+  normDoi: string;
+  workKey: string;
+  title: string;
+  description: string;
+  authors: string[];
+  datePublished: string;
+  slug: string;
+}
+
+async function seedPublishedWorkWithDoi(
+  testData: TestData,
+  opts: {
+    authors?: string[];
+    datePublished?: string;
+    wvTags?: string[];
+    svTags?: string[];
+    siteId?: string;
+  },
+): Promise<DoiSeed> {
+  const prisma = await getPrismaClient();
+  const siteId = opts.siteId ?? testData.siteId;
+  const workId = uuidv7();
+  const workVersionId = uuidv7();
+  const submissionId = uuidv7();
+  const svId = uuidv7();
+  const now = new Date().toISOString();
+  const rawDoi = `10.5555/${workId}`;
+  const normDoi = doiUtil.normalize(rawDoi) as string;
+  const seed: DoiSeed = {
+    workId,
+    workVersionId,
+    submissionId,
+    svId,
+    rawDoi,
+    normDoi,
+    workKey: `key-${workId}`,
+    title: `DOI work ${workId}`,
+    description: `Description for ${workId}`,
+    authors: opts.authors ?? ['Ada Lovelace'],
+    datePublished: opts.datePublished ?? '2024-03-01',
+    slug: `doi-work-${workId}`,
+  };
+
+  await prisma.work.create({
+    data: {
+      id: seed.workId,
+      date_created: now,
+      date_modified: now,
+      doi: seed.normDoi,
+      key: seed.workKey,
+      created_by: { connect: { id: testData.userId } },
+    },
+  });
+  await prisma.workVersion.create({
+    data: {
+      id: seed.workVersionId,
+      date_created: now,
+      date_modified: now,
+      title: seed.title,
+      description: seed.description,
+      doi: seed.normDoi,
+      authors: seed.authors,
+      canonical: true,
+      tags: opts.wvTags ?? [],
+      cdn: 'https://test-cdn.com',
+      cdn_key: `cdn-key-${seed.workId}`,
+      work: { connect: { id: seed.workId } },
+    },
+  });
+  await prisma.submission.create({
+    data: {
+      id: seed.submissionId,
+      date_created: now,
+      date_modified: now,
+      date_published: seed.datePublished,
+      site: { connect: { id: siteId } },
+      work: { connect: { id: seed.workId } },
+      kind: { connect: { id: testData.kindId } },
+      collection: { connect: { id: testData.collectionId } },
+      submitted_by: { connect: { id: testData.userId } },
+    },
+  });
+  await prisma.submissionVersion.create({
+    data: {
+      id: seed.svId,
+      date_created: now,
+      date_modified: now,
+      date_published: seed.datePublished,
+      status: 'PUBLISHED',
+      tags: opts.svTags ?? [],
+      submission: { connect: { id: seed.submissionId } },
+      work_version: { connect: { id: seed.workVersionId } },
+      submitted_by: { connect: { id: testData.userId } },
+    },
+  });
+  await prisma.slug.create({
+    data: {
+      id: uuidv7(),
+      date_created: now,
+      date_modified: now,
+      slug: `${seed.slug}-${siteId}`,
+      primary: true,
+      site: { connect: { id: siteId } },
+      submission: { connect: { id: seed.submissionId } },
+    },
+  });
+
+  return seed;
+}
+
+/** Adds a newer published submission version (new work version) to an existing submission. */
+async function addPublishedVersion(
+  testData: TestData,
+  seed: DoiSeed,
+  opts: { datePublished: string; svTags?: string[] },
+): Promise<{ svId: string; workVersionId: string }> {
+  const prisma = await getPrismaClient();
+  const now = new Date().toISOString();
+  const workVersionId = uuidv7();
+  const svId = uuidv7();
+  await prisma.workVersion.create({
+    data: {
+      id: workVersionId,
+      date_created: now,
+      date_modified: now,
+      title: seed.title,
+      doi: seed.normDoi,
+      authors: seed.authors,
+      canonical: true,
+      tags: [],
+      cdn: 'https://test-cdn.com',
+      cdn_key: `cdn-key-${workVersionId}`,
+      work: { connect: { id: seed.workId } },
+    },
+  });
+  await prisma.submissionVersion.create({
+    data: {
+      id: svId,
+      date_created: now,
+      date_modified: now,
+      date_published: opts.datePublished,
+      status: 'PUBLISHED',
+      tags: opts.svTags ?? [],
+      submission: { connect: { id: seed.submissionId } },
+      work_version: { connect: { id: workVersionId } },
+      submitted_by: { connect: { id: testData.userId } },
+    },
+  });
+  return { svId, workVersionId };
+}

--- a/prisma/schema/migrations/20260529130000_add_doi_lookup_indexes/migration.sql
+++ b/prisma/schema/migrations/20260529130000_add_doi_lookup_indexes/migration.sql
@@ -1,0 +1,28 @@
+-- Indexes powering DOI resolution
+-- (`GET /v1/sites/:siteName/doi/:first/:second`, handled by `sites.doi` in
+-- `packages/scms-server/src/backend/loaders/sites/doi.server.ts`).
+--
+-- The endpoint resolves a published submission version by equality on the DOI,
+-- matching either `WorkVersion.doi` or the underlying `Work.doi`, then joins to
+-- the published `SubmissionVersion` for that work version.
+--
+-- 1/2. Btree on `Work.doi` and `WorkVersion.doi`. The existing
+--      `Work_doi_trgm_idx` / `WorkVersion_doi_trgm_idx` (migration
+--      20260526223800) are `gin_trgm_ops` indexes that only serve `LIKE`/
+--      similarity search — Postgres cannot use them for `doi = ?`, so the
+--      equality lookup was a sequential scan.
+--
+-- 3.   Btree on `SubmissionVersion.work_version_id`. It is a foreign key with
+--      no implicit index in Postgres, so the DOI → published-version join (and
+--      the `submissionVersions.some` probe) walked it unindexed.
+--
+-- IF NOT EXISTS guards + Prisma-default index names follow the convention from
+-- the listing-lookup migrations: Prisma also declares these from the schema
+-- edit, so the migration is robust to whichever side runs first.
+
+CREATE INDEX IF NOT EXISTS "Work_doi_idx" ON "Work" (doi);
+
+CREATE INDEX IF NOT EXISTS "WorkVersion_doi_idx" ON "WorkVersion" (doi);
+
+CREATE INDEX IF NOT EXISTS "SubmissionVersion_work_version_id_idx"
+  ON "SubmissionVersion" (work_version_id);

--- a/prisma/schema/submission.prisma
+++ b/prisma/schema/submission.prisma
@@ -108,6 +108,10 @@ model SubmissionVersion {
   /// listing (count + page query in `v1.sites.$siteName.works/db.server.ts`)
   /// an index-only probe instead of reading version rows to test status.
   @@index([submission_id, status])
+  /// Backs the DOI → published-version join in the DOI resolution endpoint
+  /// (`sites.doi`). `work_version_id` is an FK with no implicit index in
+  /// Postgres, so the lookup walked it unindexed.
+  @@index([work_version_id])
 }
 
 model Submission {

--- a/prisma/schema/work.prisma
+++ b/prisma/schema/work.prisma
@@ -30,6 +30,11 @@ model Work {
   submissions        Submission[]
   landingContentSite Site[]
   access             Access[]
+
+  /// Equality lookup for DOI resolution (`GET /v1/sites/:siteName/doi/...`).
+  /// The `Work_doi_trgm_idx` GIN index (migration 20260526223800) only serves
+  /// `LIKE`/search; a btree is required for `doi = ?`.
+  @@index([doi])
 }
 
 model WorkVersion {
@@ -55,6 +60,11 @@ model WorkVersion {
   checkServiceRuns   CheckServiceRun[]
   linkedJobs         LinkedJob[]
   occ                Int                 @default(0)
+
+  /// Equality lookup for DOI resolution (`GET /v1/sites/:siteName/doi/...`).
+  /// The `WorkVersion_doi_trgm_idx` GIN index (migration 20260526223800) only
+  /// serves `LIKE`/search; a btree is required for `doi = ?`.
+  @@index([doi])
 }
 
 model CheckServiceRun {


### PR DESCRIPTION
v1/sites/<>/doi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes a cross-site data exposure on the no-tag path and adds DB indexes plus CDN caching, where stale edge responses could briefly show wrong 404s or versions until TTL expires.
> 
> **Overview**
> This PR speeds up and hardens **`GET /v1/sites/:siteName/doi/:first/:second`** (optional `tag` query).
> 
> **Correctness:** The no-tag path is now **scoped to the requesting site**. It previously could return a work published only on another site; that case now **404s**, matching the tag path. Integration and e2e tests lock this in.
> 
> **Database:** A migration adds **btree** indexes on `Work.doi`, `WorkVersion.doi`, and `SubmissionVersion.work_version_id` so equality DOI lookups and joins are not sequential scans (existing trigram GIN indexes do not help `doi = ?`).
> 
> **Loader:** Tag and no-tag flows are **one** `SubmissionVersion.findFirst` via shared `buildPublishedByDoiWhere`, ordered by newest published submission version. The DOI route uses **`siteWorkDtoSelect`** (drops unused columns and the `submitted_by` → `User` join). `formatSiteWorkDTO` now takes the narrower **`SiteWorkDtoInput`**; other callers still pass wider rows.
> 
> **HTTP:** The API route applies **Vercel cache headers** (semi-static on success, burst 404 preset on public sites) so repeat DOI traffic and scanner probes hit the CDN; 404 bodies and `statusText` are preserved.
> 
> Also includes a changeset, planning notes, and lockfile churn unrelated to the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e649bbca5195a24819d6df15488b4f5911993217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->