### PR TITLE
📆 date picker improvements

### DIFF
--- a/.changeset/gentle-showers-yell.md
+++ b/.changeset/gentle-showers-yell.md
@@ -1,0 +1,7 @@
+---
+'@curvenote/scms-core': patch
+'@curvenote/scms-sites-ext': patch
+'@curvenote/scms': patch
+---
+
+Date picker improvements

--- a/ee/sites/src/publicationDateCalendar.ts
+++ b/ee/sites/src/publicationDateCalendar.ts
@@ -1,0 +1,22 @@
+/** Earliest publication year offered in publication-date calendar dropdowns. */
+export const PUBLICATION_DATE_CALENDAR_FROM_YEAR = 1990;
+
+/** Local calendar midnight — avoids timezone/`toISOString` day shifts in matchers. */
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+/**
+ * Calendar props for picking a publication date: year dropdown span plus no
+ * future days (publication dates cannot be after today).
+ */
+export function publicationDateCalendarBounds(now: Date = new Date()) {
+  const today = startOfLocalDay(now);
+  return {
+    fromDate: new Date(PUBLICATION_DATE_CALENDAR_FROM_YEAR, 0, 1),
+    fromYear: PUBLICATION_DATE_CALENDAR_FROM_YEAR,
+    toYear: now.getFullYear(),
+    toDate: today,
+    disabled: { after: today },
+  };
+}

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/PublicationDate.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/PublicationDate.tsx
@@ -1,7 +1,8 @@
 import { useFetcher } from 'react-router';
 import { SquarePen } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ui } from '@curvenote/scms-core';
+import { publicationDateCalendarBounds } from '../../publicationDateCalendar.js';
 
 export function hyphenatedFromDate(date: Date) {
   const year = date.getFullYear().toString();
@@ -9,6 +10,7 @@ export function hyphenatedFromDate(date: Date) {
   const day = date.getDate().toString().padStart(2, '0');
   return `${year}-${month}-${day}`;
 }
+
 export function hyphenatedToDate(date: string) {
   if (!date.match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/)) {
     return new Date(date);
@@ -17,6 +19,17 @@ export function hyphenatedToDate(date: string) {
   const month = Number(date.split('-')[1]) - 1;
   const day = Number(date.split('-')[2]);
   return new Date(year, month, day);
+}
+
+/** Invalid Date is truthy — never pass it to DayPicker's `month` / `selected`. */
+function parsePublicationDate(value?: string): Date | undefined {
+  if (!value) return undefined;
+  const parsed = hyphenatedToDate(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
 }
 
 export function PublicationDate({
@@ -30,16 +43,26 @@ export function PublicationDate({
 }) {
   const fetcher = useFetcher<{ error?: string }>();
 
-  const date = datePublished ? hyphenatedToDate(datePublished) : undefined;
-  const [selectedDate, setSelectedDate] = useState(date);
+  const committedDate = parsePublicationDate(datePublished);
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(committedDate);
   const [calendarOpen, setCalendarOpen] = useState(false);
+  const [visibleMonth, setVisibleMonth] = useState<Date>(() =>
+    startOfMonth(committedDate ?? new Date()),
+  );
+
+  // Sync draft state when the popover opens; reset to saved value each time.
+  useEffect(() => {
+    if (!calendarOpen) return;
+    setSelectedDate(parsePublicationDate(datePublished));
+    setVisibleMonth(startOfMonth(parsePublicationDate(datePublished) ?? new Date()));
+  }, [calendarOpen, datePublished]);
 
   return (
     <ui.Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
       <ui.PopoverTrigger asChild>
         <div
           className="text-right underline cursor-pointer"
-          title={`Publication Date${date ? ` ${datePublished}` : ''}`}
+          title={`Publication Date${committedDate ? ` ${datePublished}` : ''}`}
         >
           {datePublished ?? 'n/a'}
           {canUpdate && <SquarePen className="inline-block w-4 h-4 ml-[2px] mb-[2px]" />}
@@ -48,18 +71,23 @@ export function PublicationDate({
       <ui.PopoverContent className="w-auto p-0">
         <ui.Calendar
           mode="single"
+          captionLayout="dropdown-buttons"
+          {...publicationDateCalendarBounds()}
           selected={selectedDate}
           onSelect={setSelectedDate}
+          month={visibleMonth}
+          onMonthChange={setVisibleMonth}
           initialFocus
         />
-        <div className="flex p-2 space-x-2">
+        <div className="flex gap-1.5 px-2 pb-2 pt-1">
           <ui.Button
             className="flex-1"
+            size="sm"
             variant="outline"
             disabled={fetcher.state !== 'idle'}
             type="reset"
             onClick={() => {
-              setSelectedDate(date);
+              setSelectedDate(committedDate);
               setCalendarOpen(false);
             }}
           >
@@ -67,6 +95,7 @@ export function PublicationDate({
           </ui.Button>
           <ui.Button
             className="flex-1"
+            size="sm"
             disabled={!selectedDate || fetcher.state !== 'idle'}
             onClick={() => {
               if (!selectedDate) return;

--- a/ee/sites/src/routes/$siteName.submissions._index/SubmissionsDateFilter.tsx
+++ b/ee/sites/src/routes/$siteName.submissions._index/SubmissionsDateFilter.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { Calendar as CalendarIcon, ChevronDown, X } from 'lucide-react';
 import type { DateRange } from 'react-day-picker';
@@ -6,6 +6,7 @@ import { cn, ui } from '@curvenote/scms-core';
 import {
   LISTING_DATE_PRESETS,
   computeDatePresetRange,
+  listingPublishedCalendarBounds,
   matchPresetForRange,
   setListingParam,
   type ListingDatePresetId,
@@ -13,6 +14,23 @@ import {
 
 interface SubmissionsDateFilterProps {
   className?: string;
+}
+
+function isoToDate(iso: string): Date {
+  const [year, month, day] = iso.split('-').map(Number);
+  return new Date(year, (month ?? 1) - 1, day ?? 1);
+}
+
+function dateToIso(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function rangeFromUrl(from: string | undefined, to: string | undefined): DateRange | undefined {
+  if (!from) return undefined;
+  return { from: isoToDate(from), to: to ? isoToDate(to) : undefined };
 }
 
 /**
@@ -33,9 +51,20 @@ export function SubmissionsDateFilter({ className }: SubmissionsDateFilterProps)
   const to = searchParams.get('to') ?? undefined;
   const unpublishedOnly = searchParams.get('unpublishedOnly') === '1';
   const [open, setOpen] = useState(false);
+  /** In-popover range; URL updates only once both ends are chosen. */
+  const [draftRange, setDraftRange] = useState<DateRange | undefined>(undefined);
+  const [visibleMonth, setVisibleMonth] = useState<Date>(() => new Date());
 
+  const calendarBounds = listingPublishedCalendarBounds();
   const activePreset = matchPresetForRange(from, to, unpublishedOnly);
   const hasSelection = Boolean(from || to || unpublishedOnly);
+
+  useEffect(() => {
+    if (!open) return;
+    const committed = rangeFromUrl(from, to);
+    setDraftRange(committed);
+    setVisibleMonth(committed?.from ?? new Date());
+  }, [open, from, to]);
 
   /**
    * Writes a coherent date-mode state in one go. Range and `unpublishedOnly`
@@ -62,7 +91,8 @@ export function SubmissionsDateFilter({ className }: SubmissionsDateFilterProps)
       return;
     }
     if (preset === 'custom') {
-      // Don't close; let the user pick on the calendar.
+      setDraftRange(undefined);
+      setVisibleMonth(new Date());
       return;
     }
     if (preset === 'no_published_date') {
@@ -77,13 +107,17 @@ export function SubmissionsDateFilter({ className }: SubmissionsDateFilterProps)
 
   const handleCalendarSelect = (range: DateRange | undefined) => {
     if (!range || (!range.from && !range.to)) {
-      applyDateMode({});
+      setDraftRange(undefined);
       return;
     }
-    applyDateMode({
-      from: range.from ? dateToIso(range.from) : undefined,
-      to: range.to ? dateToIso(range.to) : range.from ? dateToIso(range.from) : undefined,
-    });
+    setDraftRange(range);
+    if (range.from && range.to) {
+      applyDateMode({
+        from: dateToIso(range.from),
+        to: dateToIso(range.to),
+      });
+      setOpen(false);
+    }
   };
 
   const handleClear = () => {
@@ -96,9 +130,6 @@ export function SubmissionsDateFilter({ className }: SubmissionsDateFilterProps)
   // user has picked "No Published Date" so the popover doesn't suggest a
   // range is in play.
   const showCalendar = activePreset !== 'no_published_date';
-  const calendarSelected: DateRange | undefined = from
-    ? { from: isoToDate(from), to: to ? isoToDate(to) : undefined }
-    : undefined;
 
   return (
     <ui.Popover open={open} onOpenChange={setOpen}>
@@ -177,10 +208,14 @@ export function SubmissionsDateFilter({ className }: SubmissionsDateFilterProps)
           {showCalendar ? (
             <ui.Calendar
               mode="range"
-              selected={calendarSelected}
+              captionLayout="dropdown-buttons"
+              {...calendarBounds}
+              selected={draftRange}
               onSelect={handleCalendarSelect}
               numberOfMonths={2}
-              defaultMonth={calendarSelected?.from}
+              month={visibleMonth}
+              onMonthChange={setVisibleMonth}
+              initialFocus
             />
           ) : (
             <div className="flex items-center px-4 py-6 max-w-xs text-xs text-muted-foreground">
@@ -227,16 +262,4 @@ function formatShortDate(iso: string): string {
     day: 'numeric',
     year: '2-digit',
   });
-}
-
-function isoToDate(iso: string): Date {
-  const [year, month, day] = iso.split('-').map(Number);
-  return new Date(year, (month ?? 1) - 1, day ?? 1);
-}
-
-function dateToIso(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  return `${y}-${m}-${d}`;
 }

--- a/ee/sites/src/routes/$siteName.submissions._index/listingParams.ts
+++ b/ee/sites/src/routes/$siteName.submissions._index/listingParams.ts
@@ -135,6 +135,11 @@ export function hasActiveListingFiltersInQuery(query: ListingQuery): boolean {
  * Date range
  * -------------------------------------------------------------------------- */
 
+export {
+  PUBLICATION_DATE_CALENDAR_FROM_YEAR as LISTING_PUBLISHED_CALENDAR_FROM_YEAR,
+  publicationDateCalendarBounds as listingPublishedCalendarBounds,
+} from '../../publicationDateCalendar.js';
+
 export type ListingDatePresetId =
   | 'anytime'
   | 'today'

--- a/packages/scms-core/src/components/ui/calendar.tsx
+++ b/packages/scms-core/src/components/ui/calendar.tsx
@@ -67,8 +67,7 @@ function Calendar({
   components: componentsProp,
   ...props
 }: CalendarProps) {
-  const captionUsesDropdown =
-    captionLayout === 'dropdown' || captionLayout === 'dropdown-buttons';
+  const captionUsesDropdown = captionLayout === 'dropdown' || captionLayout === 'dropdown-buttons';
   const multiMonth = (numberOfMonths ?? 1) > 1;
 
   return (
@@ -105,20 +104,25 @@ function Calendar({
         day_disabled: 'text-muted-foreground opacity-50',
         day_range_middle: 'aria-selected:bg-accent aria-selected:text-accent-foreground',
         day_hidden: 'invisible',
-        ...(captionUsesDropdown ? dropdownCaptionClassNames(multiMonth) : defaultCaptionClassNames()),
+        ...(captionUsesDropdown
+          ? dropdownCaptionClassNames(multiMonth)
+          : defaultCaptionClassNames()),
         ...classNames,
       }}
       components={{
         IconLeft: ({ className: chevronClassName, ...chevronProps }) => (
-          <ChevronLeft className={cn('h-4 w-4', chevronClassName)} {...chevronProps} />
+          <ChevronLeft className={cn('w-4 h-4', chevronClassName)} {...chevronProps} />
         ),
         IconRight: ({ className: chevronClassName, ...chevronProps }) => (
-          <ChevronRight className={cn('h-4 w-4', chevronClassName)} {...chevronProps} />
+          <ChevronRight className={cn('w-4 h-4', chevronClassName)} {...chevronProps} />
         ),
         ...(captionUsesDropdown
           ? {
               IconDropdown: ({ className: iconClassName, ...iconProps }) => (
-                <ChevronDown className={cn('size-3.5 shrink-0 opacity-50', iconClassName)} {...iconProps} />
+                <ChevronDown
+                  className={cn('size-3.5 shrink-0 opacity-50', iconClassName)}
+                  {...iconProps}
+                />
               ),
             }
           : {}),

--- a/packages/scms-core/src/components/ui/calendar.tsx
+++ b/packages/scms-core/src/components/ui/calendar.tsx
@@ -1,34 +1,90 @@
 import * as React from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import { DayPicker } from 'react-day-picker';
+import type { ClassNames } from 'react-day-picker';
 
 import { cn } from '../../utils/cn.js';
 import { buttonVariants } from './button.js';
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>;
 
-function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
+/** Shared shell for each month/year `<select>` (invisible select over a text label). */
+const dropdownFieldShell = 'relative inline-flex h-7 items-center';
+
+const dropdownCaptionLabel = cn(
+  'relative z-[1] inline-flex h-7 w-auto items-center gap-1 px-1 text-sm',
+  'pointer-events-none select-none',
+);
+
+/** Month nav chevrons: no persistent focus ring after mouse use. */
+const navButtonClass = cn(
+  buttonVariants({ variant: 'outline' }),
+  'h-7 w-7 bg-transparent p-0 opacity-80 hover:opacity-100',
+  'outline-none focus:outline-none focus-visible:ring-0 focus-visible:outline-none',
+);
+
+/**
+ * react-day-picker v8 dropdown captions: native `<select>` overlays a faux label.
+ * These classNames mirror the library layout but use our input/button tokens.
+ */
+function dropdownCaptionClassNames(multiMonth: boolean): Partial<ClassNames> {
+  return {
+    caption: cn('relative mb-2 block min-h-8 px-9 text-center', multiMonth && 'pt-0.5'),
+    caption_dropdowns: 'relative inline-flex items-center justify-center gap-1.5',
+    dropdown_month: dropdownFieldShell,
+    dropdown_year: dropdownFieldShell,
+    caption_label: dropdownCaptionLabel,
+    dropdown:
+      'absolute inset-0 z-[2] h-full w-full cursor-pointer appearance-none border-0 bg-transparent opacity-0',
+    dropdown_icon: 'size-3.5 shrink-0 opacity-50',
+    vhidden: 'sr-only',
+    nav: 'inline-flex items-center whitespace-nowrap',
+    nav_button: navButtonClass,
+    nav_button_previous: 'absolute top-1/2 left-0 z-[3] -translate-y-1/2',
+    nav_button_next: 'absolute top-1/2 right-0 z-[3] -translate-y-1/2',
+    caption_start: multiMonth ? 'relative' : undefined,
+    caption_end: multiMonth ? 'relative' : undefined,
+  };
+}
+
+function defaultCaptionClassNames(): Partial<ClassNames> {
+  return {
+    caption: 'relative flex items-center justify-center pt-1',
+    caption_label: 'text-sm font-medium',
+    nav: 'flex items-center space-x-1',
+    nav_button: cn(navButtonClass, 'opacity-50 hover:opacity-100'),
+    nav_button_previous: 'absolute left-1',
+    nav_button_next: 'absolute right-1',
+  };
+}
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  captionLayout,
+  numberOfMonths,
+  components: componentsProp,
+  ...props
+}: CalendarProps) {
+  const captionUsesDropdown =
+    captionLayout === 'dropdown' || captionLayout === 'dropdown-buttons';
+  const multiMonth = (numberOfMonths ?? 1) > 1;
+
   return (
     <DayPicker
-      // selected={new Date('2011-01-01')}
       showOutsideDays={showOutsideDays}
+      {...(captionLayout != null ? { captionLayout } : {})}
+      {...(numberOfMonths != null ? { numberOfMonths } : {})}
       className={cn('p-3', className)}
       classNames={{
-        months: 'flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0',
+        root: cn('m-0', multiMonth && 'rdp-multiple_months'),
+        months: 'flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:space-x-4',
         month: 'space-y-4',
-        caption: 'flex justify-center pt-1 relative items-center',
-        caption_label: 'text-sm font-medium',
-        nav: 'space-x-1 flex items-center',
-        nav_button: cn(
-          buttonVariants({ variant: 'outline' }),
-          'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100',
-        ),
-        nav_button_previous: 'absolute left-1',
-        nav_button_next: 'absolute right-1',
         table: 'w-full border-collapse space-y-1',
         head_row: 'flex',
-        head_cell: 'text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]',
-        row: 'flex w-full mt-2',
+        head_cell: 'w-8 rounded-md text-[0.8rem] font-normal text-muted-foreground',
+        row: 'mt-2 flex w-full',
         cell: cn(
           'relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected].day-range-end)]:rounded-r-md',
           props.mode === 'range'
@@ -49,21 +105,24 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         day_disabled: 'text-muted-foreground opacity-50',
         day_range_middle: 'aria-selected:bg-accent aria-selected:text-accent-foreground',
         day_hidden: 'invisible',
+        ...(captionUsesDropdown ? dropdownCaptionClassNames(multiMonth) : defaultCaptionClassNames()),
         ...classNames,
       }}
       components={{
-        // Chevron: ({ className: chevronClassName, ...chevronProps }) => {
-        //   if (chevronProps.orientation === 'left') {
-        //     return <ChevronLeft className={cn('h-4 w-4', chevronClassName)} {...chevronProps} />;
-        //   }
-        //   return <ChevronRight className={cn('h-4 w-4', chevronClassName)} {...chevronProps} />;
-        // },
         IconLeft: ({ className: chevronClassName, ...chevronProps }) => (
           <ChevronLeft className={cn('h-4 w-4', chevronClassName)} {...chevronProps} />
         ),
         IconRight: ({ className: chevronClassName, ...chevronProps }) => (
           <ChevronRight className={cn('h-4 w-4', chevronClassName)} {...chevronProps} />
         ),
+        ...(captionUsesDropdown
+          ? {
+              IconDropdown: ({ className: iconClassName, ...iconProps }) => (
+                <ChevronDown className={cn('size-3.5 shrink-0 opacity-50', iconClassName)} {...iconProps} />
+              ),
+            }
+          : {}),
+        ...componentsProp,
       }}
       {...props}
     />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only changes to date selection and URL filter timing; bounds align publication dates with “not in the future” without touching auth or persistence logic beyond existing submit paths.
> 
> **Overview**
> Improves publication-date pickers across submission detail and listing filters with **month/year dropdown captions**, shared **calendar bounds** (1990 through today, no future days), and safer date parsing.
> 
> The shared `ui.Calendar` now styles **react-day-picker** dropdown captions and multi-month layouts. Sites code adds `publicationDateCalendarBounds` and wires both `PublicationDate` and the submissions date filter to use it with controlled `month` / `visibleMonth` state.
> 
> **PublicationDate** resets draft selection when the popover opens, rejects invalid dates for DayPicker, and tightens the action row. **SubmissionsDateFilter** keeps a **draft range** until both ends are chosen before updating URL params, re-syncs from the URL when opened, and applies the same bounds and dropdown layout on the two-month range picker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc0304e6344877b9884893b8003ab24ebb060fb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->