### PR TITLE
🏷️ Expose subject on API

### DIFF
--- a/.changeset/site-work-subject-field.md
+++ b/.changeset/site-work-subject-field.md
@@ -3,4 +3,4 @@
 '@curvenote/scms-server': minor
 ---
 
-Add optional `subject` to `SiteWorkDTO`, populated from `WorkVersion.metadata['frontmatter.myst'].project.subject`. Exposed on all SiteWork API responses (works listing, DOI resolve, published work get, submission version get/list, previews). Subject is batch-fetched via a Postgres JSON-path query so the full metadata blob is not loaded into Node.
+Add optional `subject` to `SiteWorkDTO`, populated from `WorkVersion.metadata['frontmatter.myst'].project.subject`. Exposed on all SiteWork API responses (works listing, DOI resolve, published work get, submission version get/list, previews). Subject is batch-fetched via a Postgres JSON-path query so the full metadata blob is not loaded into Node. The public works listing (`GET /v1/sites/:siteName/works`) accepts a `subject` query param for case-insensitive exact filtering; pagination links preserve it.

--- a/.changeset/site-work-subject-field.md
+++ b/.changeset/site-work-subject-field.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/common': minor
+'@curvenote/scms-server': minor
+---
+
+Add optional `subject` to `SiteWorkDTO`, populated from `WorkVersion.metadata['frontmatter.myst'].project.subject`. Exposed on all SiteWork API responses (works listing, DOI resolve, published work get, submission version get/list, previews). Subject is batch-fetched via a Postgres JSON-path query so the full metadata blob is not loaded into Node.

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -159,6 +159,8 @@ export type SiteWorkDTO = Pick<SubmissionDTO, 'slug' | 'kind' | 'date_published'
   Omit<Work, 'date'> & {
     /** @deprecated - date_published is favored over date */
     date?: string;
+    /** MyST project subject from `metadata['frontmatter.myst'].project.subject`. */
+    subject?: string;
     submission_version_id: string;
     submission_id: string;
     /**

--- a/packages/scms-server/src/backend/index.ts
+++ b/packages/scms-server/src/backend/index.ts
@@ -28,6 +28,7 @@ export * from './submission-version-metadata.server.js';
 export * from './utils.server.js';
 export * from './domains.server.js';
 export * from './workDraftChecksMetadata.server.js';
+export * from './work-version-subject.server.js';
 
 export * from './etl/index.js';
 export * from './loaders/index.js';

--- a/packages/scms-server/src/backend/loaders/previews/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/previews/get.server.ts
@@ -32,6 +32,7 @@ import { formatSiteWorkDTO } from '../sites/submissions/published/get.server.js'
 import { SiteContext } from '../../context.site.server.js';
 import { formatSubmissionKindSummaryDTO } from '../sites/kinds/get.server.js';
 import { formatCollectionSummaryDTO } from '../sites/get.server.js';
+import { fetchWorkVersionSubjects } from '../../work-version-subject.server.js';
 
 export async function dbGetSubmissionVersion(id: string) {
   const prisma = await getPrismaClient();
@@ -49,14 +50,18 @@ export type ModifiedSubmissionVersionDTO = Omit<SubmissionVersionDTO, 'site_work
   site_work: ModifiedSiteWorkDTO;
 };
 
-function formatPreviewDTO(ctx: Context, dbo: PreviewDBO): ModifiedSubmissionVersionDTO {
+function formatPreviewDTO(
+  ctx: Context,
+  dbo: PreviewDBO,
+  opts?: { subject?: string },
+): ModifiedSubmissionVersionDTO {
   return {
     id: dbo.id,
     date_created: dbo.date_created,
     status: dbo.status,
     submission_id: dbo.submission.id,
     site_name: dbo.submission.site.name,
-    site_work: formatSiteWorkDTO(new SiteContext(ctx, dbo.submission.site), dbo),
+    site_work: formatSiteWorkDTO(new SiteContext(ctx, dbo.submission.site), dbo, opts),
     submitted_by: {
       id: dbo.submitted_by.id,
       name: dbo.submitted_by.display_name ?? '',
@@ -100,5 +105,6 @@ export default async function (
   )
     throw error401('bad submission scope');
 
-  return formatPreviewDTO(ctx, dbo);
+  const subjects = await fetchWorkVersionSubjects([dbo.work_version.id]);
+  return formatPreviewDTO(ctx, dbo, { subject: subjects.get(dbo.work_version.id) });
 }

--- a/packages/scms-server/src/backend/loaders/sites/doi.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/doi.server.ts
@@ -8,6 +8,7 @@ import type { ModifiedSiteWorkDTO } from './submissions/published/get.server.js'
 import type { SiteContext } from '../../context.site.server.js';
 import type { Prisma } from '@curvenote/scms-db';
 import { siteWorkDtoSelect } from '../../prisma.selects.server.js';
+import { fetchWorkVersionSubjects } from '../../work-version-subject.server.js';
 
 export type SiteDoiResolveOptions = {
   /** If set, pick the latest *published* submission version for this DOI whose `tags` contains this string */
@@ -106,7 +107,9 @@ export default async function (
         : 'Not Found - No work with that DOI exists in database',
     );
   }
-  const siteWork = formatSiteWorkDTO(ctx, sv);
+  const siteWork = formatSiteWorkDTO(ctx, sv, {
+    subject: (await fetchWorkVersionSubjects([sv.work_version.id])).get(sv.work_version.id),
+  });
 
   // One indexed query for the work's published versions, replacing a second
   // client round-trip to the submission `versions` listing.

--- a/packages/scms-server/src/backend/loaders/sites/submissions/published/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/published/get.server.ts
@@ -9,6 +9,7 @@ import { signPrivateUrls } from '../../../../sign.private.server.js';
 import { formatCollectionSummaryDTO } from '../../get.server.js';
 import { formatSubmissionKindSummaryDTO } from '../../kinds/get.server.js';
 import { createArticleUrl } from '../../../../domains.server.js';
+import { fetchWorkVersionSubjects } from '../../../../work-version-subject.server.js';
 
 export async function dbGetLatestPublishedSubmissionVersion(
   siteName: string,
@@ -73,7 +74,11 @@ export type ModifiedSiteWorkDTO = Omit<SiteWorkDTO, 'links' | 'cdn' | 'cdn_key'>
   cdn?: string;
   cdn_key?: string;
 };
-export function formatSiteWorkDTO(ctx: SiteContext, dbo: SiteWorkDtoInput): ModifiedSiteWorkDTO {
+export function formatSiteWorkDTO(
+  ctx: SiteContext,
+  dbo: SiteWorkDtoInput,
+  opts?: { subject?: string },
+): ModifiedSiteWorkDTO {
   const { cdn_key, cdn, title, description, canonical, authors, date_created } = dbo.work_version;
   const tags = concatSiteWorkTags(dbo.tags ?? [], dbo.work_version.tags ?? []);
   const submission_version_id = dbo.id;
@@ -122,6 +127,7 @@ export function formatSiteWorkDTO(ctx: SiteContext, dbo: SiteWorkDtoInput): Modi
     cdn_query: host?.query,
     title: title ?? '',
     description: description || undefined,
+    subject: opts?.subject,
     authors: authors.map((a) => ({ name: a })),
     canonical: canonical ? true : false,
     tags,
@@ -153,5 +159,8 @@ export function formatSiteWorkDTO(ctx: SiteContext, dbo: SiteWorkDtoInput): Modi
 export default async function (ctx: SiteContext, workIdOrSlug: string) {
   const dbo = await dbGetLatestPublishedSubmissionVersion(ctx.site.name, workIdOrSlug);
   if (!dbo) return null;
-  return formatSiteWorkDTO(ctx, dbo);
+  const subjects = await fetchWorkVersionSubjects([dbo.work_version.id]);
+  return formatSiteWorkDTO(ctx, dbo, {
+    subject: subjects.get(dbo.work_version.id),
+  });
 }

--- a/packages/scms-server/src/backend/loaders/sites/submissions/published/list.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/published/list.server.ts
@@ -14,6 +14,7 @@ import {
 import type { Prisma } from '@curvenote/scms-db';
 import type { ModifiedSiteWorkDTO } from './get.server.js';
 import { formatSiteWorkDTO } from './get.server.js';
+import { fetchWorkVersionSubjects } from '../../../../work-version-subject.server.js';
 
 /** NOTE we can not just count() here because of the distinct field
 // writing a raw query would be an option but that is complex for this query
@@ -166,7 +167,7 @@ export function formatSiteWorkDTOFromSubmissions(
   ctx: SiteContext,
   dbo: DBO,
   where?: { collection?: string; kind?: string; status?: string },
-  opts?: { page?: number; limit?: number },
+  opts?: { page?: number; limit?: number; subjects?: Map<string, string> },
 ): Omit<SiteWorkListingDTO, 'items'> & { items: ModifiedSiteWorkDTO[] } {
   const selfUrl = new URL(ctx.asApiUrl(`/sites/${ctx.site.name}/works`));
   if (where?.collection) selfUrl.searchParams.set('collection', where?.collection ?? '');
@@ -185,7 +186,7 @@ export function formatSiteWorkDTOFromSubmissions(
   return {
     items: dbo.items.map((v: DBO['items'][0]) => {
       // note: we know there is at least one version
-      return formatSiteWorkDTO(ctx, v);
+      return formatSiteWorkDTO(ctx, v, { subject: opts?.subjects?.get(v.work_version.id) });
     }),
     total: dbo.total,
     links,
@@ -200,5 +201,6 @@ export default async function (
 ) {
   const dbo = await dbListLatestPublishedSubmissions(ctx, extensions, where, opts);
   if (!dbo) throw error404();
-  return formatSiteWorkDTOFromSubmissions(ctx, dbo, where, opts);
+  const subjects = await fetchWorkVersionSubjects(dbo.items.map((row) => row.work_version.id));
+  return formatSiteWorkDTOFromSubmissions(ctx, dbo, where, { ...opts, subjects });
 }

--- a/packages/scms-server/src/backend/loaders/sites/submissions/versions/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/versions/get.server.ts
@@ -10,6 +10,7 @@ import type { ModifiedSiteWorkDTO } from '../published/get.server.js';
 import { formatSiteWorkDTO } from '../published/get.server.js';
 import { formatSubmissionKindSummaryDTO } from '../../kinds/get.server.js';
 import type { WorkflowTransition } from '@curvenote/scms-core';
+import { fetchWorkVersionSubjects } from '../../../../work-version-subject.server.js';
 
 export async function dbGetSubmissionVersion(
   where: Prisma.SubmissionVersionFindUniqueArgs['where'],
@@ -46,6 +47,7 @@ type DBO = Prisma.SubmissionVersionGetPayload<{
 export function formatSubmissionVersionDTO(
   ctx: SiteContext,
   version: DBO,
+  opts?: { subject?: string },
 ): Omit<SubmissionVersionDTO, 'site_work'> & { site_work: ModifiedSiteWorkDTO } & {
   transition?: WorkflowTransition;
 } {
@@ -73,7 +75,7 @@ export function formatSubmissionVersionDTO(
     },
     submission_id: version.submission.id,
     site_name: ctx.site.name,
-    site_work: formatSiteWorkDTO(ctx, { ...version, submission: version.submission }),
+    site_work: formatSiteWorkDTO(ctx, { ...version, submission: version.submission }, opts),
     kind: formatSubmissionKindSummaryDTO(version.submission.kind),
     collection: {
       ...version.submission.collection,
@@ -97,7 +99,10 @@ export function formatSubmissionVersionDTO(
 export default async function (ctx: SiteContext, submissionVersionId: string) {
   const dbo = await dbGetSubmissionVersion({ id: submissionVersionId });
   if (!dbo) throw error404();
-  return formatSubmissionVersionDTO(ctx, dbo);
+  const subjects = await fetchWorkVersionSubjects([dbo.work_version.id]);
+  return formatSubmissionVersionDTO(ctx, dbo, {
+    subject: subjects.get(dbo.work_version.id),
+  });
 }
 
 export async function getOnSubmission(
@@ -111,5 +116,8 @@ export async function getOnSubmission(
     submissionVersionId,
   );
   if (!dbo) throw error404();
-  return formatSubmissionVersionDTO(ctx, dbo);
+  const subjects = await fetchWorkVersionSubjects([dbo.work_version.id]);
+  return formatSubmissionVersionDTO(ctx, dbo, {
+    subject: subjects.get(dbo.work_version.id),
+  });
 }

--- a/packages/scms-server/src/backend/loaders/sites/submissions/versions/list.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/versions/list.server.ts
@@ -5,6 +5,7 @@ import type { SiteContext } from '../../../../context.site.server.js';
 import { error404, makePaginationLinks } from '@curvenote/scms-core';
 import { formatSubmissionVersionDTO } from './get.server.js';
 import type { ModifiedSubmissionVersionDTO } from '../../../previews/get.server.js';
+import { fetchWorkVersionSubjects } from '../../../../work-version-subject.server.js';
 
 async function dbCountSubmissionVersions(siteName: string, submissionId: string) {
   const prisma = await getPrismaClient();
@@ -64,7 +65,7 @@ export function formatSubmissionVersionListingDTO(
   ctx: SiteContext,
   submissionId: string,
   dbo: DBO,
-  opts?: { page?: number; limit?: number },
+  opts?: { page?: number; limit?: number; subjects?: Map<string, string> },
 ): Omit<SubmissionVersionListingDTO, 'items'> & { items: ModifiedSubmissionVersionDTO[] } {
   const selfUrl = new URL(
     ctx.asApiUrl(`/sites/${ctx.site.name}/submissions/${submissionId}/versions`),
@@ -82,7 +83,9 @@ export function formatSubmissionVersionListingDTO(
 
   return {
     items: dbo.items.map((v: DBO['items'][0]) => {
-      return formatSubmissionVersionDTO(ctx, v);
+      return formatSubmissionVersionDTO(ctx, v, {
+        subject: opts?.subjects?.get(v.work_version.id),
+      });
     }),
     total: dbo.total,
     links,
@@ -96,5 +99,6 @@ export default async function (
 ) {
   const dbo = await dbListSubmissionVersions(ctx, submissionId, opts);
   if (!dbo) throw error404();
-  return formatSubmissionVersionListingDTO(ctx, submissionId, dbo, opts);
+  const subjects = await fetchWorkVersionSubjects(dbo.items.map((row) => row.work_version.id));
+  return formatSubmissionVersionListingDTO(ctx, submissionId, dbo, { ...opts, subjects });
 }

--- a/packages/scms-server/src/backend/work-version-subject.server.test.ts
+++ b/packages/scms-server/src/backend/work-version-subject.server.test.ts
@@ -1,0 +1,34 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { describe, test, expect } from 'vitest';
+import { extractWorkVersionSubjectFromMetadata } from './work-version-subject.server.js';
+
+describe('extractWorkVersionSubjectFromMetadata', () => {
+  test('reads frontmatter.myst.project.subject', () => {
+    expect(
+      extractWorkVersionSubjectFromMetadata({
+        'frontmatter.myst': {
+          project: { subject: ' Neuroscience ' },
+        },
+      }),
+    ).toBe('Neuroscience');
+  });
+
+  test('returns undefined for missing or empty values', () => {
+    expect(extractWorkVersionSubjectFromMetadata(null)).toBeUndefined();
+    expect(extractWorkVersionSubjectFromMetadata({})).toBeUndefined();
+    expect(
+      extractWorkVersionSubjectFromMetadata({
+        'frontmatter.myst': { project: { subject: '   ' } },
+      }),
+    ).toBeUndefined();
+    expect(
+      extractWorkVersionSubjectFromMetadata({
+        myst: {
+          frontmatter: {
+            project: { subject: 'Neuroscience' },
+          },
+        },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/scms-server/src/backend/work-version-subject.server.ts
+++ b/packages/scms-server/src/backend/work-version-subject.server.ts
@@ -1,0 +1,48 @@
+import { Prisma } from '@curvenote/scms-db';
+import { getPrismaClient } from './prisma.server.js';
+
+/**
+ * Read `project.subject` from `metadata['frontmatter.myst'].project.subject`.
+ */
+export function extractWorkVersionSubjectFromMetadata(metadata: unknown): string | undefined {
+  if (!metadata || typeof metadata !== 'object') return undefined;
+  const myst = (metadata as Record<string, unknown>)['frontmatter.myst'];
+  if (!myst || typeof myst !== 'object') return undefined;
+
+  const project = (myst as Record<string, unknown>).project;
+  if (!project || typeof project !== 'object') return undefined;
+
+  const subject = (project as Record<string, unknown>).subject;
+  if (typeof subject !== 'string') return undefined;
+
+  const trimmed = subject.trim();
+  return trimmed || undefined;
+}
+
+/**
+ * Batch-fetch `project.subject` for work versions using Postgres JSON-path
+ * operators so only the scalar is read from the row, not the full metadata blob.
+ */
+export async function fetchWorkVersionSubjects(
+  workVersionIds: string[],
+  tx?: Prisma.TransactionClient,
+): Promise<Map<string, string>> {
+  const uniqueIds = [...new Set(workVersionIds.filter(Boolean))];
+  if (uniqueIds.length === 0) return new Map();
+
+  const prisma = await getPrismaClient();
+  const rows = await (tx ?? prisma).$queryRaw<{ id: string; subject: string | null }[]>`
+    SELECT
+      wv.id,
+      wv.metadata #>> '{frontmatter.myst,project,subject}' AS subject
+    FROM "WorkVersion" wv
+    WHERE wv.id IN (${Prisma.join(uniqueIds)})
+  `;
+
+  const subjects = new Map<string, string>();
+  for (const row of rows) {
+    const subject = row.subject?.trim();
+    if (subject) subjects.set(row.id, subject);
+  }
+  return subjects;
+}

--- a/packages/scms-server/src/backend/work-version-subject.server.ts
+++ b/packages/scms-server/src/backend/work-version-subject.server.ts
@@ -1,6 +1,9 @@
 import { Prisma } from '@curvenote/scms-db';
 import { getPrismaClient } from './prisma.server.js';
 
+/** Postgres `#>>` path for `metadata['frontmatter.myst'].project.subject`. */
+export const WORK_VERSION_SUBJECT_JSON_PATH = '{frontmatter.myst,project,subject}';
+
 /**
  * Read `project.subject` from `metadata['frontmatter.myst'].project.subject`.
  */
@@ -45,4 +48,35 @@ export async function fetchWorkVersionSubjects(
     if (subject) subjects.set(row.id, subject);
   }
   return subjects;
+}
+
+/**
+ * Resolve submission ids whose work metadata subject matches exactly (case- and
+ * whitespace-insensitive). Scoped to versions in the requested listing status,
+ * mirroring the public works listing semijoin.
+ */
+export async function fetchSubmissionIdsBySubject(
+  siteId: string,
+  subject: string,
+  status: string,
+  tx?: Prisma.TransactionClient,
+): Promise<string[]> {
+  const normalized = subject.trim();
+  if (!normalized) return [];
+
+  const prisma = await getPrismaClient();
+  const rows = await (tx ?? prisma).$queryRaw<{ id: string }[]>`
+    SELECT s.id
+    FROM "Submission" s
+    WHERE s.site_id = ${siteId}
+      AND EXISTS (
+        SELECT 1
+        FROM "SubmissionVersion" sv
+        JOIN "WorkVersion" wv ON wv.id = sv.work_version_id
+        WHERE sv.submission_id = s.id
+          AND sv.status = ${status}
+          AND LOWER(TRIM(wv.metadata #>> '{frontmatter.myst,project,subject}')) = LOWER(${normalized})
+      )
+  `;
+  return rows.map((row) => row.id);
 }

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
@@ -1,6 +1,7 @@
 import {
   getPrismaClient,
   fetchWorkVersionSubjects,
+  fetchSubmissionIdsBySubject,
   type SiteContext,
 } from '@curvenote/scms-server';
 import {
@@ -49,6 +50,22 @@ type ListingExtras = {
  */
 function escapeIlikePattern(q: string): string {
   return q.replace(/\\/g, '\\\\');
+}
+
+/** Narrow a listing to submissions present in every supplied id set. */
+function intersectSubmissionIds(...idSets: Array<string[] | undefined>): string[] | undefined {
+  const present = idSets.filter((ids): ids is string[] => ids != null);
+  if (present.length === 0) return undefined;
+  let acc = new Set(present[0]);
+  for (const ids of present.slice(1)) {
+    const next = new Set<string>();
+    for (const id of ids) {
+      if (acc.has(id)) next.add(id);
+    }
+    acc = next;
+    if (acc.size === 0) return [];
+  }
+  return [...acc];
 }
 
 /**
@@ -233,6 +250,7 @@ export async function dbListLatestPublishedSubmissions(
     kind?: string;
     status?: string;
     q?: string;
+    subject?: string;
     from?: string;
     to?: string;
   },
@@ -248,17 +266,22 @@ export async function dbListLatestPublishedSubmissions(
     );
   }
 
-  // Search narrows to a pre-resolved id set via raw SQL (covers the authors
-  // text[] substring match Prisma can't express); the select/count then run
-  // through the shared Prisma filter. An empty match short-circuits.
+  // Search and subject filters narrow to pre-resolved id sets via raw SQL; the
+  // select/count then run through the shared Prisma filter. An empty intersection
+  // short-circuits.
   let searchIds: string[] | undefined;
   if (where?.q) {
     searchIds = await dbSearchSubmissionIds(ctx.site.id, where.q);
-    if (searchIds.length === 0) {
-      return { items: [], total: 0 };
-    }
   }
-  const extras: ListingExtras = { from: where?.from, to: where?.to, ids: searchIds };
+  let subjectIds: string[] | undefined;
+  if (where?.subject) {
+    subjectIds = await fetchSubmissionIdsBySubject(ctx.site.id, where.subject, status);
+  }
+  const filteredIds = intersectSubmissionIds(searchIds, subjectIds);
+  if (filteredIds?.length === 0) {
+    return { items: [], total: 0 };
+  }
+  const extras: ListingExtras = { from: where?.from, to: where?.to, ids: filteredIds };
   const queryOpts = { ...opts, extras };
 
   const workflows = getWorkflows(ctx.$config, registerExtensionWorkflows(extensions));
@@ -324,6 +347,7 @@ export async function listPublishedWorks(
     kind?: string;
     status?: string;
     q?: string;
+    subject?: string;
     from?: string;
     to?: string;
   },

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
@@ -1,4 +1,8 @@
-import { getPrismaClient, type SiteContext } from '@curvenote/scms-server';
+import {
+  getPrismaClient,
+  fetchWorkVersionSubjects,
+  type SiteContext,
+} from '@curvenote/scms-server';
 import {
   error404,
   httpError,
@@ -327,5 +331,6 @@ export async function listPublishedWorks(
 ) {
   const dbo = await dbListLatestPublishedSubmissions(ctx, extensions, where, opts);
   if (!dbo) throw error404();
-  return formatSiteWorkDTOFromSubmissions(ctx, dbo, where, opts);
+  const subjects = await fetchWorkVersionSubjects(dbo.items.map((row) => row.work_version.id));
+  return formatSiteWorkDTOFromSubmissions(ctx, dbo, where, { ...opts, subjects });
 }

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/format.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/format.server.ts
@@ -101,7 +101,11 @@ function formatCollectionSummaryDTO(
   };
 }
 
-export function formatSiteWorkDTO(ctx: SiteContext, dbo: RowDBO): ModifiedSiteWorkDTO {
+export function formatSiteWorkDTO(
+  ctx: SiteContext,
+  dbo: RowDBO,
+  opts?: { subject?: string },
+): ModifiedSiteWorkDTO {
   const { cdn_key, cdn, title, description, canonical, authors, date_created } = dbo.work_version;
   const tags = concatSiteWorkTags(dbo.tags ?? [], dbo.work_version.tags ?? []);
   const submission_version_id = dbo.id;
@@ -150,6 +154,7 @@ export function formatSiteWorkDTO(ctx: SiteContext, dbo: RowDBO): ModifiedSiteWo
     cdn_query: host?.query,
     title: title ?? '',
     description: description || undefined,
+    subject: opts?.subject,
     authors: authors.map((a) => ({ name: a })),
     canonical: canonical ? true : false,
     tags,
@@ -189,7 +194,12 @@ export function formatSiteWorkDTOFromSubmissions(
     from?: string;
     to?: string;
   },
-  opts?: { page?: number; limit?: number; sort?: 'published_desc' | 'published_asc' },
+  opts?: {
+    page?: number;
+    limit?: number;
+    sort?: 'published_desc' | 'published_asc';
+    subjects?: Map<string, string>;
+  },
 ): Omit<SiteWorkListingDTO, 'items'> & { items: ModifiedSiteWorkDTO[] } {
   const selfUrl = new URL(ctx.asApiUrl(`/sites/${ctx.site.name}/works`));
   if (where?.collection) selfUrl.searchParams.set('collection', where?.collection ?? '');
@@ -211,7 +221,9 @@ export function formatSiteWorkDTOFromSubmissions(
   );
 
   return {
-    items: dbo.items.map((v) => formatSiteWorkDTO(ctx, v)),
+    items: dbo.items.map((v) =>
+      formatSiteWorkDTO(ctx, v, { subject: opts?.subjects?.get(v.work_version.id) }),
+    ),
     total: dbo.total,
     links,
   };

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/format.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/format.server.ts
@@ -191,6 +191,7 @@ export function formatSiteWorkDTOFromSubmissions(
     kind?: string;
     status?: string;
     q?: string;
+    subject?: string;
     from?: string;
     to?: string;
   },
@@ -206,6 +207,7 @@ export function formatSiteWorkDTOFromSubmissions(
   if (where?.kind) selfUrl.searchParams.set('kind', where?.kind ?? '');
   if (where?.status) selfUrl.searchParams.set('status', where?.status ?? '');
   if (where?.q) selfUrl.searchParams.set('q', where.q);
+  if (where?.subject) selfUrl.searchParams.set('subject', where.subject);
   if (where?.from) selfUrl.searchParams.set('from', where.from);
   if (where?.to) selfUrl.searchParams.set('to', where.to);
   // Only emit a non-default sort so default listings keep clean, cache-friendly URLs.

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/route.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/route.tsx
@@ -65,6 +65,12 @@ const ParamsSchema = z.object({
     const trimmed = v.trim();
     return trimmed.length >= WORKS_SEARCH_MIN_LENGTH ? trimmed : undefined;
   }, z.string().min(WORKS_SEARCH_MIN_LENGTH).max(200).optional()),
+  /** Case-insensitive exact match on MyST `project.subject` (whitespace-trimmed). */
+  subject: z.preprocess((v) => {
+    if (typeof v !== 'string') return undefined;
+    const trimmed = v.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }, z.string().min(1).max(40).optional()),
   /** Publication-date sort direction; defaults to newest first. */
   sort: z.enum(['published_desc', 'published_asc']).default('published_desc'),
   /** Inclusive ISO `yyyy-mm-dd` lower bound on `date_published`. */
@@ -92,6 +98,7 @@ export async function loader(args: Route.LoaderArgs) {
     kind: params.get('kind') ?? undefined,
     status: params.get('status') ?? undefined,
     q: params.get('q') ?? undefined,
+    subject: params.get('subject') ?? undefined,
     sort: params.get('sort') ?? undefined,
     from: params.get('from') ?? undefined,
     to: params.get('to') ?? undefined,

--- a/platform/scms/tests/integration/workflow/site-doi-resolve.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-doi-resolve.spec.ts
@@ -136,6 +136,27 @@ describe('site doi resolve — delivered package', () => {
     expect(dto.versions[0].tags).toEqual(['v2']);
   });
 
+  test('versions array includes published versions without v{n} tags and excludes in-review', async () => {
+    const seed = await seedPublishedWorkWithDoi(testData, {
+      datePublished: '2024-01-01',
+      svTags: ['preprint'],
+    });
+    const tagged = await addPublishedVersion(testData, seed, {
+      datePublished: '2024-06-01',
+      svTags: ['v2'],
+    });
+    await addInReviewVersion(testData, seed, { datePublished: '2024-07-01', svTags: ['v3'] });
+
+    const dto = await sites.doi(testData.context, seed.rawDoi);
+
+    expect(dto.versions.map((v) => v.submission_version_id)).toEqual([tagged.svId, seed.svId]);
+    expect(dto.versions.find((v) => v.submission_version_id === seed.svId)).toMatchObject({
+      version: undefined,
+      tags: ['preprint'],
+    });
+    expect(dto.versions.find((v) => v.submission_version_id === tagged.svId)?.version).toBe('v2');
+  });
+
   test('tag path resolves the tagged version; an absent tag is a 404', async () => {
     const seed = await seedPublishedWorkWithDoi(testData, { svTags: ['hhmi'] });
 
@@ -381,6 +402,47 @@ async function addPublishedVersion(
       date_modified: now,
       date_published: opts.datePublished,
       status: 'PUBLISHED',
+      tags: opts.svTags ?? [],
+      submission: { connect: { id: seed.submissionId } },
+      work_version: { connect: { id: workVersionId } },
+      submitted_by: { connect: { id: testData.userId } },
+    },
+  });
+  return { svId, workVersionId };
+}
+
+/** Adds an in-review submission version (must not appear in DOI `versions`). */
+async function addInReviewVersion(
+  testData: TestData,
+  seed: DoiSeed,
+  opts: { datePublished: string; svTags?: string[] },
+): Promise<{ svId: string; workVersionId: string }> {
+  const prisma = await getPrismaClient();
+  const now = new Date().toISOString();
+  const workVersionId = uuidv7();
+  const svId = uuidv7();
+  await prisma.workVersion.create({
+    data: {
+      id: workVersionId,
+      date_created: now,
+      date_modified: now,
+      title: seed.title,
+      doi: seed.normDoi,
+      authors: seed.authors,
+      canonical: true,
+      tags: [],
+      cdn: 'https://test-cdn.com',
+      cdn_key: `cdn-key-${workVersionId}`,
+      work: { connect: { id: seed.workId } },
+    },
+  });
+  await prisma.submissionVersion.create({
+    data: {
+      id: svId,
+      date_created: now,
+      date_modified: now,
+      date_published: opts.datePublished,
+      status: 'IN_REVIEW',
       tags: opts.svTags ?? [],
       submission: { connect: { id: seed.submissionId } },
       work_version: { connect: { id: workVersionId } },

--- a/platform/scms/tests/integration/workflow/site-doi-resolve.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-doi-resolve.spec.ts
@@ -32,6 +32,7 @@ const ITEM_KEYS = [
   'cdn_query',
   'title',
   'description',
+  'subject',
   'authors',
   'canonical',
   'tags',

--- a/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
@@ -309,6 +309,61 @@ describe('site works listing — search / sort / date filters', () => {
     expect(dto.items).toHaveLength(0);
   });
 
+  test('subject filters to an exact case-insensitive metadata match', async () => {
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { subject: 'neuroscience' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(1);
+    expect(dto.items[0].id).toBe(seeds[0].workId);
+    expect(dto.items[0].subject).toBe('Neuroscience');
+  });
+
+  test('subject with no matches returns an empty listing', async () => {
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { subject: 'no-such-subject' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(0);
+    expect(dto.items).toHaveLength(0);
+  });
+
+  test('subject combines with q by intersection', async () => {
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { subject: 'Genomics', q: 'work 05' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(1);
+    expect(dto.items[0].id).toBe(seeds[5].workId);
+  });
+
+  test('subject and q with disjoint matches returns an empty listing', async () => {
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { subject: 'Neuroscience', q: 'work 05' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(0);
+    expect(dto.items).toHaveLength(0);
+  });
+
+  test('pagination links preserve subject', async () => {
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { subject: 'Genomics' },
+      { page: 0, limit: 10 },
+    );
+    expect(dto.links.self).toContain('subject=Genomics');
+  });
+
   test('sort published_asc reverses the default ordering', async () => {
     const dto = await listPublishedWorks(
       testData.context,
@@ -394,7 +449,7 @@ async function seedPublishedWorks(testData: TestData, count: number): Promise<Se
       title: `Benchmark work ${i.toString().padStart(2, '0')}`,
       description: `Description for work ${i}`,
       authors: [`Author ${i}A`, `Author ${i}B`],
-      subject: i === 0 ? 'Neuroscience' : undefined,
+      subject: i === 0 ? 'Neuroscience' : i === 5 ? 'Genomics' : undefined,
       workDoi: `10.9999/bench-${slug}-${testData.siteId}`,
       workKey: `key-${slug}-${testData.siteId}`,
       workVersionTags: [`tag-${i}`],

--- a/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
@@ -43,6 +43,7 @@ const ITEM_KEYS = [
   'cdn_query',
   'title',
   'description',
+  'subject',
   'authors',
   'canonical',
   'tags',
@@ -78,6 +79,7 @@ interface SeedWork {
   title: string;
   description: string;
   authors: string[];
+  subject?: string;
   workDoi: string;
   workKey: string;
   workVersionTags: string[];
@@ -212,6 +214,7 @@ describe('site works listing — delivered package (limit=10)', () => {
     expect(item.slug).toBe(`${newest.slug}-${testData.siteId}`);
     expect(item.canonical).toBe(newest.canonical);
     expect(item.tags).toEqual(concatSiteWorkTags([], newest.workVersionTags));
+    expect(item.subject).toBe(newest.subject);
     expect(item.cdn).toBe('https://test-cdn.com');
     expect(item.cdn_key).toBe(`cdn-key-${newest.slug}`);
     expect(item.date).toBe(newest.datePublished);
@@ -391,6 +394,7 @@ async function seedPublishedWorks(testData: TestData, count: number): Promise<Se
       title: `Benchmark work ${i.toString().padStart(2, '0')}`,
       description: `Description for work ${i}`,
       authors: [`Author ${i}A`, `Author ${i}B`],
+      subject: i === 0 ? 'Neuroscience' : undefined,
       workDoi: `10.9999/bench-${slug}-${testData.siteId}`,
       workKey: `key-${slug}-${testData.siteId}`,
       workVersionTags: [`tag-${i}`],
@@ -423,6 +427,14 @@ async function seedPublishedWorks(testData: TestData, count: number): Promise<Se
         tags: seed.workVersionTags,
         cdn: 'https://test-cdn.com',
         cdn_key: `cdn-key-${seed.slug}`,
+        metadata:
+          seed.subject != null
+            ? {
+                'frontmatter.myst': {
+                  project: { subject: seed.subject },
+                },
+              }
+            : undefined,
         work: { connect: { id: seed.workId } },
       },
     });

--- a/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
@@ -119,6 +119,50 @@ describe('site works listing — delivered package (limit=10)', () => {
     for (const item of dto.items) expect(seededIds.has(item.id)).toBe(true);
   });
 
+  test('lists the latest published version even when it has no v{n} tags', async () => {
+    const prisma = await getPrismaClient();
+    const seed = seeds[0];
+    const now = new Date().toISOString();
+    const newerWorkVersionId = uuidv7();
+    const newerSvId = uuidv7();
+
+    await prisma.workVersion.create({
+      data: {
+        id: newerWorkVersionId,
+        date_created: now,
+        date_modified: now,
+        title: `${seed.title} (untagged)`,
+        doi: seed.workDoi,
+        authors: seed.authors,
+        canonical: true,
+        tags: [],
+        cdn: 'https://test-cdn.com',
+        cdn_key: `cdn-key-untagged-${seed.workId}`,
+        work: { connect: { id: seed.workId } },
+      },
+    });
+    await prisma.submissionVersion.create({
+      data: {
+        id: newerSvId,
+        date_created: now,
+        date_modified: now,
+        date_published: '2025-06-01',
+        status: 'PUBLISHED',
+        tags: ['preprint'],
+        submission: { connect: { id: seed.submissionId } },
+        work_version: { connect: { id: newerWorkVersionId } },
+        submitted_by: { connect: { id: testData.userId } },
+      },
+    });
+
+    const dto = await listPublishedWorks(testData.context, [], {}, { page: 0, limit: 500 });
+    const item = dto.items.find((i) => i.id === seed.workId);
+    expect(item).toBeTruthy();
+    expect(item!.version_id).toBe(newerWorkVersionId);
+    expect(item!.tags).toEqual(['preprint']);
+    expect(item!.versions).toBeUndefined();
+  });
+
   test('orders by date_published descending', async () => {
     const dto = await listPublishedWorks(testData.context, [], {}, { page: 0, limit: PAGE_LIMIT });
     const expectedOrder = [...seeds]


### PR DESCRIPTION
* Added to SiteWork
* available for filtering

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a public query filter and raw SQL over JSON metadata on listing paths; changes are additive but touch high-traffic works APIs and listing intersection logic with search.
> 
> **Overview**
> Adds an optional **`subject`** on **`SiteWorkDTO`**, sourced from MyST frontmatter at `metadata['frontmatter.myst'].project.subject` (trimmed). Values are loaded in **batch** via Postgres JSON-path (`#>>`) on `WorkVersion.metadata`, so formatters do not pull the full metadata blob into Node.
> 
> **Site work responses** that embed a site work now include `subject` when present: public works listing, published work get, DOI resolve, submission version get/list, and previews. Listing/detail formatters take an optional pre-fetched subject and thread it through existing `formatSiteWorkDTO` paths.
> 
> **Public works listing** (`GET /v1/sites/:siteName/works`) gains a **`subject`** query parameter for **case-insensitive exact** match (after trim). It narrows submissions with raw SQL (`fetchSubmissionIdsBySubject`), **intersects** with text search (`q`) when both are set, short-circuits empty results, and keeps **`subject` on pagination links**.
> 
> Shared helpers live in **`work-version-subject.server`** (exported from scms-server). Integration tests cover DTO shape, subject filter/combine-with-`q`, and related listing/DOI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6304f48f5b345f144030bfd79cb8894e3c3c65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->