### PR TITLE
🏎️ subject query performance

### DIFF
--- a/.changeset/subject-filter-index.md
+++ b/.changeset/subject-filter-index.md
@@ -1,0 +1,10 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms-db': patch
+'@curvenote/scms': patch
+---
+
+Speed up exact subject filtering on the public works listing (`GET /v1/sites/:siteName/works?subject=...`).
+
+- **Index:** add `work_version_subject_normalized(metadata)` expression index on `WorkVersion` for case- and whitespace-insensitive equality on `metadata['frontmatter.myst'].subject`.
+- **Query:** rewrite `fetchSubmissionIdsBySubject` to start from matching work versions and join back through `SubmissionVersion` (status) to `Submission` (site), instead of scanning every submission on the site with an `EXISTS` subquery that evaluates JSON extraction per row.

--- a/packages/scms-server/src/backend/work-version-subject.server.test.ts
+++ b/packages/scms-server/src/backend/work-version-subject.server.test.ts
@@ -2,12 +2,19 @@
 import { describe, test, expect } from 'vitest';
 import {
   WORK_VERSION_SUBJECT_JSON_PATH,
+  WORK_VERSION_SUBJECT_NORMALIZED_FN,
   extractWorkVersionSubjectFromMetadata,
 } from './work-version-subject.server.js';
 
 describe('WORK_VERSION_SUBJECT_JSON_PATH', () => {
   test('is a quoted SQL text-array literal for Prisma.raw()', () => {
     expect(WORK_VERSION_SUBJECT_JSON_PATH).toBe("'{frontmatter.myst,subject}'");
+  });
+});
+
+describe('WORK_VERSION_SUBJECT_NORMALIZED_FN', () => {
+  test('matches the Postgres function backing WorkVersion_subject_normalized_idx', () => {
+    expect(WORK_VERSION_SUBJECT_NORMALIZED_FN).toBe('work_version_subject_normalized');
   });
 });
 

--- a/packages/scms-server/src/backend/work-version-subject.server.ts
+++ b/packages/scms-server/src/backend/work-version-subject.server.ts
@@ -5,6 +5,13 @@ import { getPrismaClient } from './prisma.server.js';
 export const WORK_VERSION_SUBJECT_JSON_PATH = "'{frontmatter.myst,subject}'";
 
 /**
+ * Postgres normalizer for subject equality filters. Must match
+ * `work_version_subject_normalized()` and `WorkVersion_subject_normalized_idx`
+ * (migration `20260609120000_add_work_version_subject_normalized_index`).
+ */
+export const WORK_VERSION_SUBJECT_NORMALIZED_FN = 'work_version_subject_normalized';
+
+/**
  * Read `subject` from `metadata['frontmatter.myst'].subject`.
  */
 export function extractWorkVersionSubjectFromMetadata(metadata: unknown): string | undefined {
@@ -51,6 +58,10 @@ export async function fetchWorkVersionSubjects(
  * Resolve submission ids whose work metadata subject matches exactly (case- and
  * whitespace-insensitive). Scoped to versions in the requested listing status,
  * mirroring the public works listing semijoin.
+ *
+ * Starts from `WorkVersion` rows matching the subject (index-backed via
+ * `WorkVersion_subject_normalized_idx`) and joins back to submissions on the
+ * site rather than scanning every submission with an EXISTS subquery.
  */
 export async function fetchSubmissionIdsBySubject(
   siteId: string,
@@ -63,17 +74,15 @@ export async function fetchSubmissionIdsBySubject(
 
   const prisma = await getPrismaClient();
   const rows = await (tx ?? prisma).$queryRaw<{ id: string }[]>`
-    SELECT s.id
-    FROM "Submission" s
-    WHERE s.site_id = ${siteId}
-      AND EXISTS (
-        SELECT 1
-        FROM "SubmissionVersion" sv
-        JOIN "WorkVersion" wv ON wv.id = sv.work_version_id
-        WHERE sv.submission_id = s.id
-          AND sv.status = ${status}
-          AND LOWER(TRIM(wv.metadata #>> ${Prisma.raw(WORK_VERSION_SUBJECT_JSON_PATH)})) = LOWER(${normalized})
-      )
+    SELECT DISTINCT s.id
+    FROM "WorkVersion" wv
+    INNER JOIN "SubmissionVersion" sv
+      ON sv.work_version_id = wv.id
+     AND sv.status = ${status}
+    INNER JOIN "Submission" s
+      ON s.id = sv.submission_id
+     AND s.site_id = ${siteId}
+    WHERE ${Prisma.raw(WORK_VERSION_SUBJECT_NORMALIZED_FN)}(wv.metadata) = LOWER(${normalized})
   `;
   return rows.map((row) => row.id);
 }

--- a/prisma/schema/migrations/20260609120000_add_work_version_subject_normalized_index/migration.sql
+++ b/prisma/schema/migrations/20260609120000_add_work_version_subject_normalized_index/migration.sql
@@ -1,0 +1,28 @@
+-- Expression index powering exact subject filter on the public works listing
+-- (`fetchSubmissionIdsBySubject` in packages/scms-server).
+--
+-- The filter is case- and whitespace-insensitive equality on
+-- `WorkVersion.metadata['frontmatter.myst'].subject`. Without an index the
+-- query walks every submission on the site and evaluates JSON extraction per
+-- version row. The listing query is rewritten to start from matching
+-- `WorkVersion` rows (usually a tiny set) and join back through
+-- `SubmissionVersion` (status) to `Submission` (site_id).
+--
+-- The normalizer MUST match the WHERE clause exactly for the planner to use
+-- the index — same contract as `immutable_array_to_string` for trgm search.
+--
+-- Cannot be expressed in schema.prisma (expression index + helper function);
+-- same pattern as `20260526223800_add_submission_search_trgm_indexes`.
+
+CREATE OR REPLACE FUNCTION work_version_subject_normalized(metadata jsonb)
+  RETURNS text
+  LANGUAGE sql
+  IMMUTABLE
+  PARALLEL SAFE
+AS $$
+  SELECT NULLIF(LOWER(TRIM(metadata #>> '{frontmatter.myst,subject}')), '')
+$$;
+
+CREATE INDEX IF NOT EXISTS "WorkVersion_subject_normalized_idx"
+  ON "WorkVersion" (work_version_subject_normalized(metadata))
+  WHERE metadata IS NOT NULL;

--- a/prisma/schema/work.prisma
+++ b/prisma/schema/work.prisma
@@ -64,6 +64,11 @@ model WorkVersion {
   /// Equality lookup for DOI resolution (`GET /v1/sites/:siteName/doi/...`).
   /// The `WorkVersion_doi_trgm_idx` GIN index (migration 20260526223800) only
   /// serves `LIKE`/search; a btree is required for `doi = ?`.
+  ///
+  /// Exact subject filter on the public works listing uses
+  /// `WorkVersion_subject_normalized_idx` (migration
+  /// `20260609120000_add_work_version_subject_normalized_index`) over
+  /// `work_version_subject_normalized(metadata)` — not expressible in Prisma.
   @@index([doi])
 }
 


### PR DESCRIPTION
a speed up for minimal changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploys a DB migration and ties application raw SQL to the index expression; wrong drift would break or skip the index, but filter semantics stay the same read-only path.
> 
> **Overview**
> Speeds up **`?subject=`** filtering on the public works listing by making subject equality indexable and flipping the lookup direction.
> 
> A new migration adds immutable Postgres helper **`work_version_subject_normalized(metadata)`** and partial expression index **`WorkVersion_subject_normalized_idx`** on normalized `metadata['frontmatter.myst'].subject` (case- and whitespace-insensitive). **`fetchSubmissionIdsBySubject`** now starts from matching **`WorkVersion`** rows via that function, joins **`SubmissionVersion`** (status) and **`Submission`** (site), instead of scanning every site submission behind an **`EXISTS`** subquery with per-row JSON extraction. **`WORK_VERSION_SUBJECT_NORMALIZED_FN`** is exported (with a test) so the raw SQL stays aligned with the index definition; **`work.prisma`** documents the index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb03381739dff9fede74db4aa284aa8832c05dfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->