### PR TITLE
🏫 Add affiliations to search

### DIFF
--- a/.changeset/affiliation-search-works-listing.md
+++ b/.changeset/affiliation-search-works-listing.md
@@ -7,7 +7,7 @@
 Extend free-text search on the public works listing (`GET /v1/sites/:siteName/works?q=...`) to match affiliation names from `WorkVersion.metadata['frontmatter.myst'].affiliations`.
 
 - **Index:** add `work_version_affiliations_search_text(metadata)` GIN trigram index on `WorkVersion`, extracting each affiliation's `name` (with `institution` fallback).
-- **Query:** add an `OR` branch to `dbSearchSubmissionIds` alongside existing title, author, and DOI predicates.
-- **Tests:** integration coverage for Harvard/Wyss-style affiliation metadata; unit tests for the extractor.
+- **Query:** add an `OR` branch to `dbSearchSubmissionIds` alongside existing title, author, and DOI predicates; omit the affiliation branch when every query token is a common boilerplate stopword (university, department, school, etc.).
+- **Tests:** integration coverage for Harvard/Wyss-style affiliation metadata; unit tests for the extractor and stopword gate.
 
 ---

--- a/.changeset/affiliation-search-works-listing.md
+++ b/.changeset/affiliation-search-works-listing.md
@@ -1,0 +1,13 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms-db': patch
+'@curvenote/scms': patch
+---
+
+Extend free-text search on the public works listing (`GET /v1/sites/:siteName/works?q=...`) to match affiliation names from `WorkVersion.metadata['frontmatter.myst'].affiliations`.
+
+- **Index:** add `work_version_affiliations_search_text(metadata)` GIN trigram index on `WorkVersion`, extracting each affiliation's `name` (with `institution` fallback).
+- **Query:** add an `OR` branch to `dbSearchSubmissionIds` alongside existing title, author, and DOI predicates.
+- **Tests:** integration coverage for Harvard/Wyss-style affiliation metadata; unit tests for the extractor.
+
+---

--- a/packages/scms-server/src/backend/index.ts
+++ b/packages/scms-server/src/backend/index.ts
@@ -29,6 +29,7 @@ export * from './utils.server.js';
 export * from './domains.server.js';
 export * from './workDraftChecksMetadata.server.js';
 export * from './work-version-subject.server.js';
+export * from './work-version-affiliations.server.js';
 
 export * from './etl/index.js';
 export * from './loaders/index.js';

--- a/packages/scms-server/src/backend/work-version-affiliations.server.test.ts
+++ b/packages/scms-server/src/backend/work-version-affiliations.server.test.ts
@@ -3,11 +3,29 @@ import { describe, expect, test } from 'vitest';
 import {
   WORK_VERSION_AFFILIATIONS_SEARCH_TEXT_FN,
   extractWorkVersionAffiliationsSearchTextFromMetadata,
+  isAffiliationSearchEnabled,
 } from './work-version-affiliations.server.js';
 
 describe('work-version-affiliations', () => {
   test('exports the Postgres function name', () => {
     expect(WORK_VERSION_AFFILIATIONS_SEARCH_TEXT_FN).toBe('work_version_affiliations_search_text');
+  });
+
+  describe('isAffiliationSearchEnabled', () => {
+    test('is true when at least one token is not a stopword', () => {
+      expect(isAffiliationSearchEnabled('Harvard Medical School')).toBe(true);
+      expect(isAffiliationSearchEnabled('Wyss Institute')).toBe(true);
+    });
+
+    test('is false for stopword-only queries', () => {
+      expect(isAffiliationSearchEnabled('University')).toBe(false);
+      expect(isAffiliationSearchEnabled('University Department')).toBe(false);
+      expect(isAffiliationSearchEnabled('medical school')).toBe(false);
+    });
+
+    test('is false when every token is shorter than the minimum length', () => {
+      expect(isAffiliationSearchEnabled('ab cd')).toBe(false);
+    });
   });
 
   test('concatenates affiliation names from frontmatter.myst', () => {

--- a/packages/scms-server/src/backend/work-version-affiliations.server.test.ts
+++ b/packages/scms-server/src/backend/work-version-affiliations.server.test.ts
@@ -1,0 +1,33 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { describe, expect, test } from 'vitest';
+import {
+  WORK_VERSION_AFFILIATIONS_SEARCH_TEXT_FN,
+  extractWorkVersionAffiliationsSearchTextFromMetadata,
+} from './work-version-affiliations.server.js';
+
+describe('work-version-affiliations', () => {
+  test('exports the Postgres function name', () => {
+    expect(WORK_VERSION_AFFILIATIONS_SEARCH_TEXT_FN).toBe('work_version_affiliations_search_text');
+  });
+
+  test('concatenates affiliation text fields', () => {
+    expect(
+      extractWorkVersionAffiliationsSearchTextFromMetadata({
+        'frontmatter.myst': {
+          affiliations: [
+            { name: 'Curvenote Labs', city: 'Halifax', country: 'Canada' },
+            { institution: 'MIT', department: 'CS', state: 'MA' },
+          ],
+        },
+      }),
+    ).toBe('Curvenote Labs Halifax Canada MIT CS MA');
+  });
+
+  test('returns empty string when affiliations are absent', () => {
+    expect(extractWorkVersionAffiliationsSearchTextFromMetadata(undefined)).toBe('');
+    expect(extractWorkVersionAffiliationsSearchTextFromMetadata({})).toBe('');
+    expect(extractWorkVersionAffiliationsSearchTextFromMetadata({ 'frontmatter.myst': {} })).toBe(
+      '',
+    );
+  });
+});

--- a/packages/scms-server/src/backend/work-version-affiliations.server.test.ts
+++ b/packages/scms-server/src/backend/work-version-affiliations.server.test.ts
@@ -23,6 +23,12 @@ describe('work-version-affiliations', () => {
       expect(isAffiliationSearchEnabled('medical school')).toBe(false);
     });
 
+    test('is false for punctuated stopword-only queries', () => {
+      expect(isAffiliationSearchEnabled('University,')).toBe(false);
+      expect(isAffiliationSearchEnabled('school.')).toBe(false);
+      expect(isAffiliationSearchEnabled('Department;')).toBe(false);
+    });
+
     test('is false when every token is shorter than the minimum length', () => {
       expect(isAffiliationSearchEnabled('ab cd')).toBe(false);
     });

--- a/packages/scms-server/src/backend/work-version-affiliations.server.test.ts
+++ b/packages/scms-server/src/backend/work-version-affiliations.server.test.ts
@@ -10,17 +10,32 @@ describe('work-version-affiliations', () => {
     expect(WORK_VERSION_AFFILIATIONS_SEARCH_TEXT_FN).toBe('work_version_affiliations_search_text');
   });
 
-  test('concatenates affiliation text fields', () => {
+  test('concatenates affiliation names from frontmatter.myst', () => {
     expect(
       extractWorkVersionAffiliationsSearchTextFromMetadata({
         'frontmatter.myst': {
           affiliations: [
-            { name: 'Curvenote Labs', city: 'Halifax', country: 'Canada' },
-            { institution: 'MIT', department: 'CS', state: 'MA' },
+            { id: 'a1', name: 'Systems Biology Department, Harvard Medical School' },
+            {
+              id: 'a2',
+              name: 'Wyss Institute for Biologically Inspired Engineering, Harvard University',
+            },
           ],
         },
       }),
-    ).toBe('Curvenote Labs Halifax Canada MIT CS MA');
+    ).toBe(
+      'Systems Biology Department, Harvard Medical School Wyss Institute for Biologically Inspired Engineering, Harvard University',
+    );
+  });
+
+  test('falls back to institution when name is absent', () => {
+    expect(
+      extractWorkVersionAffiliationsSearchTextFromMetadata({
+        'frontmatter.myst': {
+          affiliations: [{ id: 'a1', institution: 'MIT' }],
+        },
+      }),
+    ).toBe('MIT');
   });
 
   test('returns empty string when affiliations are absent', () => {

--- a/packages/scms-server/src/backend/work-version-affiliations.server.ts
+++ b/packages/scms-server/src/backend/work-version-affiliations.server.ts
@@ -6,6 +6,53 @@
  */
 export const WORK_VERSION_AFFILIATIONS_SEARCH_TEXT_FN = 'work_version_affiliations_search_text';
 
+/**
+ * Boilerplate affiliation tokens excluded from the affiliation search branch of
+ * `q`. Title / author / DOI matching is unaffected. Enable the branch only when
+ * at least one query token is not on this list.
+ */
+export const AFFILIATION_SEARCH_STOP_TERMS = new Set([
+  'centre',
+  'center',
+  'college',
+  'department',
+  'faculty',
+  'hospital',
+  'institute',
+  'institution',
+  'laboratory',
+  'lab',
+  'medical',
+  'research',
+  'school',
+  'sciences',
+  'science',
+  'university',
+]);
+
+/** Minimum token length required to treat a word as affiliation-significant. */
+export const AFFILIATION_SEARCH_MIN_TOKEN_LENGTH = 3;
+
+function tokenizeAffiliationSearchQuery(q: string): string[] {
+  return q
+    .trim()
+    .split(/\s+/)
+    .map((token) => token.toLowerCase())
+    .filter(Boolean);
+}
+
+/**
+ * Whether the affiliation ILIKE branch should run for this `q`. Returns false
+ * when every token is a stopword or shorter than {@link AFFILIATION_SEARCH_MIN_TOKEN_LENGTH}.
+ */
+export function isAffiliationSearchEnabled(q: string): boolean {
+  return tokenizeAffiliationSearchQuery(q).some(
+    (token) =>
+      token.length >= AFFILIATION_SEARCH_MIN_TOKEN_LENGTH &&
+      !AFFILIATION_SEARCH_STOP_TERMS.has(token),
+  );
+}
+
 function affiliationObjectToSearchFragment(aff: Record<string, unknown>): string | undefined {
   const name = typeof aff.name === 'string' ? aff.name.trim() : '';
   if (name) return name;

--- a/packages/scms-server/src/backend/work-version-affiliations.server.ts
+++ b/packages/scms-server/src/backend/work-version-affiliations.server.ts
@@ -6,24 +6,12 @@
  */
 export const WORK_VERSION_AFFILIATIONS_SEARCH_TEXT_FN = 'work_version_affiliations_search_text';
 
-const AFFILIATION_TEXT_FIELDS = [
-  'name',
-  'institution',
-  'department',
-  'city',
-  'state',
-  'country',
-] as const;
+function affiliationObjectToSearchFragment(aff: Record<string, unknown>): string | undefined {
+  const name = typeof aff.name === 'string' ? aff.name.trim() : '';
+  if (name) return name;
 
-function affiliationObjectToSearchFragment(aff: Record<string, unknown>): string {
-  const parts: string[] = [];
-  for (const field of AFFILIATION_TEXT_FIELDS) {
-    const value = aff[field];
-    if (typeof value !== 'string') continue;
-    const trimmed = value.trim();
-    if (trimmed) parts.push(trimmed);
-  }
-  return parts.join(' ').trim();
+  const institution = typeof aff.institution === 'string' ? aff.institution.trim() : '';
+  return institution || undefined;
 }
 
 /**

--- a/packages/scms-server/src/backend/work-version-affiliations.server.ts
+++ b/packages/scms-server/src/backend/work-version-affiliations.server.ts
@@ -33,12 +33,13 @@ export const AFFILIATION_SEARCH_STOP_TERMS = new Set([
 /** Minimum token length required to treat a word as affiliation-significant. */
 export const AFFILIATION_SEARCH_MIN_TOKEN_LENGTH = 3;
 
+/** Strip punctuation so stopword checks treat `University,` like `University`. */
+function normalizeAffiliationSearchToken(token: string): string {
+  return token.toLowerCase().replace(/[^\p{L}\p{N}]/gu, '');
+}
+
 function tokenizeAffiliationSearchQuery(q: string): string[] {
-  return q
-    .trim()
-    .split(/\s+/)
-    .map((token) => token.toLowerCase())
-    .filter(Boolean);
+  return q.trim().split(/\s+/).map(normalizeAffiliationSearchToken).filter(Boolean);
 }
 
 /**

--- a/packages/scms-server/src/backend/work-version-affiliations.server.ts
+++ b/packages/scms-server/src/backend/work-version-affiliations.server.ts
@@ -1,0 +1,48 @@
+/**
+ * Postgres affiliation search extractor for the public works listing text
+ * search. Must match `work_version_affiliations_search_text()` and
+ * `WorkVersion_affiliations_trgm_idx` (migration
+ * `20260610120000_add_work_version_affiliations_trgm_index`).
+ */
+export const WORK_VERSION_AFFILIATIONS_SEARCH_TEXT_FN = 'work_version_affiliations_search_text';
+
+const AFFILIATION_TEXT_FIELDS = [
+  'name',
+  'institution',
+  'department',
+  'city',
+  'state',
+  'country',
+] as const;
+
+function affiliationObjectToSearchFragment(aff: Record<string, unknown>): string {
+  const parts: string[] = [];
+  for (const field of AFFILIATION_TEXT_FIELDS) {
+    const value = aff[field];
+    if (typeof value !== 'string') continue;
+    const trimmed = value.trim();
+    if (trimmed) parts.push(trimmed);
+  }
+  return parts.join(' ').trim();
+}
+
+/**
+ * Read searchable affiliation text from `metadata['frontmatter.myst'].affiliations`.
+ * Mirrors the Postgres `work_version_affiliations_search_text` function.
+ */
+export function extractWorkVersionAffiliationsSearchTextFromMetadata(metadata: unknown): string {
+  if (!metadata || typeof metadata !== 'object') return '';
+  const myst = (metadata as Record<string, unknown>)['frontmatter.myst'];
+  if (!myst || typeof myst !== 'object') return '';
+
+  const affiliations = (myst as Record<string, unknown>).affiliations;
+  if (!Array.isArray(affiliations)) return '';
+
+  const fragments: string[] = [];
+  for (const aff of affiliations) {
+    if (!aff || typeof aff !== 'object' || Array.isArray(aff)) continue;
+    const fragment = affiliationObjectToSearchFragment(aff as Record<string, unknown>);
+    if (fragment) fragments.push(fragment);
+  }
+  return fragments.join(' ').trim();
+}

--- a/packages/scms-server/src/backend/work-version-subject.server.ts
+++ b/packages/scms-server/src/backend/work-version-subject.server.ts
@@ -62,6 +62,9 @@ export async function fetchWorkVersionSubjects(
  * Starts from `WorkVersion` rows matching the subject (index-backed via
  * `WorkVersion_subject_normalized_idx`) and joins back to submissions on the
  * site rather than scanning every submission with an EXISTS subquery.
+ *
+ * `wv.metadata IS NOT NULL` is required so the planner can use the partial
+ * index (`WHERE metadata IS NOT NULL` on `WorkVersion_subject_normalized_idx`).
  */
 export async function fetchSubmissionIdsBySubject(
   siteId: string,
@@ -82,7 +85,8 @@ export async function fetchSubmissionIdsBySubject(
     INNER JOIN "Submission" s
       ON s.id = sv.submission_id
      AND s.site_id = ${siteId}
-    WHERE ${Prisma.raw(WORK_VERSION_SUBJECT_NORMALIZED_FN)}(wv.metadata) = LOWER(${normalized})
+    WHERE wv.metadata IS NOT NULL
+      AND ${Prisma.raw(WORK_VERSION_SUBJECT_NORMALIZED_FN)}(wv.metadata) = LOWER(${normalized})
   `;
   return rows.map((row) => row.id);
 }

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
@@ -142,7 +142,7 @@ function buildListingWhere(
 /**
  * Resolve the submission ids matching a free-text query via a single raw SQL
  * EXISTS subquery that ILIKE-substrings work versions' title / authors / DOI,
- * affiliation metadata, and the underlying work's DOI. The pg_trgm GIN indexes
+ * affiliation names from `metadata['frontmatter.myst'].affiliations`, and the underlying work's DOI. The pg_trgm GIN indexes
  * from `20260526223800_add_submission_search_trgm_indexes` and
  * `20260610120000_add_work_version_affiliations_trgm_index` serve these
  * predicates.

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
@@ -2,6 +2,7 @@ import {
   getPrismaClient,
   fetchWorkVersionSubjects,
   fetchSubmissionIdsBySubject,
+  isAffiliationSearchEnabled,
   WORK_VERSION_AFFILIATIONS_SEARCH_TEXT_FN,
   type SiteContext,
 } from '@curvenote/scms-server';
@@ -142,7 +143,8 @@ function buildListingWhere(
 /**
  * Resolve the submission ids matching a free-text query via a single raw SQL
  * EXISTS subquery that ILIKE-substrings work versions' title / authors / DOI,
- * affiliation names from `metadata['frontmatter.myst'].affiliations`, and the underlying work's DOI. The pg_trgm GIN indexes
+ * affiliation names from `metadata['frontmatter.myst'].affiliations` (when
+ * {@link isAffiliationSearchEnabled} allows), and the underlying work's DOI. The pg_trgm GIN indexes
  * from `20260526223800_add_submission_search_trgm_indexes` and
  * `20260610120000_add_work_version_affiliations_trgm_index` serve these
  * predicates.
@@ -158,6 +160,17 @@ async function dbSearchSubmissionIds(
 ): Promise<string[]> {
   const prisma = await getPrismaClient();
   const pattern = `%${escapeIlikePattern(q)}%`;
+  const matchPredicates: Prisma.Sql[] = [
+    Prisma.sql`wv.title ILIKE ${pattern}`,
+    Prisma.sql`wv.doi ILIKE ${pattern}`,
+    Prisma.sql`w.doi ILIKE ${pattern}`,
+    Prisma.sql`immutable_array_to_string(wv.authors, ' ') ILIKE ${pattern}`,
+  ];
+  if (isAffiliationSearchEnabled(q)) {
+    matchPredicates.push(
+      Prisma.sql`${Prisma.raw(WORK_VERSION_AFFILIATIONS_SEARCH_TEXT_FN)}(wv.metadata) ILIKE ${pattern}`,
+    );
+  }
   const rows = await (tx ?? prisma).$queryRaw<{ id: string }[]>`
     SELECT s.id FROM "Submission" s
     WHERE s.site_id = ${siteId}
@@ -167,13 +180,7 @@ async function dbSearchSubmissionIds(
         JOIN "WorkVersion" wv ON wv.id = sv.work_version_id
         LEFT JOIN "Work" w ON w.id = wv.work_id
         WHERE sv.submission_id = s.id
-          AND (
-            wv.title ILIKE ${pattern}
-            OR wv.doi ILIKE ${pattern}
-            OR w.doi ILIKE ${pattern}
-            OR immutable_array_to_string(wv.authors, ' ') ILIKE ${pattern}
-            OR ${Prisma.raw(WORK_VERSION_AFFILIATIONS_SEARCH_TEXT_FN)}(wv.metadata) ILIKE ${pattern}
-          )
+          AND (${Prisma.join(matchPredicates, ' OR ')})
       )
   `;
   return rows.map((r) => r.id);

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
@@ -2,6 +2,7 @@ import {
   getPrismaClient,
   fetchWorkVersionSubjects,
   fetchSubmissionIdsBySubject,
+  WORK_VERSION_AFFILIATIONS_SEARCH_TEXT_FN,
   type SiteContext,
 } from '@curvenote/scms-server';
 import {
@@ -12,7 +13,7 @@ import {
   registerExtensionWorkflows,
   type ClientExtension,
 } from '@curvenote/scms-core';
-import type { Prisma } from '@curvenote/scms-db';
+import { Prisma } from '@curvenote/scms-db';
 import { formatSiteWorkDTOFromSubmissions, siteWorkListingSelect } from './format.server';
 import type { ListDBO, RowDBO } from './format.server';
 
@@ -140,12 +141,15 @@ function buildListingWhere(
 
 /**
  * Resolve the submission ids matching a free-text query via a single raw SQL
- * EXISTS subquery that ILIKE-substrings the newest work versions' title /
- * authors / DOI and the underlying work's DOI. The pg_trgm GIN indexes from
- * `20260526223800_add_submission_search_trgm_indexes` serve these predicates.
+ * EXISTS subquery that ILIKE-substrings work versions' title / authors / DOI,
+ * affiliation metadata, and the underlying work's DOI. The pg_trgm GIN indexes
+ * from `20260526223800_add_submission_search_trgm_indexes` and
+ * `20260610120000_add_work_version_affiliations_trgm_index` serve these
+ * predicates.
  *
- * `immutable_array_to_string(authors, ' ')` MUST match the expression index
- * exactly for the planner to use it.
+ * `immutable_array_to_string(authors, ' ')` and
+ * `work_version_affiliations_search_text(metadata)` MUST match their
+ * expression indexes exactly for the planner to use them.
  */
 async function dbSearchSubmissionIds(
   siteId: string,
@@ -168,6 +172,7 @@ async function dbSearchSubmissionIds(
             OR wv.doi ILIKE ${pattern}
             OR w.doi ILIKE ${pattern}
             OR immutable_array_to_string(wv.authors, ' ') ILIKE ${pattern}
+            OR ${Prisma.raw(WORK_VERSION_AFFILIATIONS_SEARCH_TEXT_FN)}(wv.metadata) ILIKE ${pattern}
           )
       )
   `;

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/route.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/route.tsx
@@ -59,7 +59,7 @@ const ParamsSchema = z.object({
   collection: z.string().min(1).max(64).optional(),
   kind: z.string().min(1).max(64).optional(), // TODO kind name should be url-safe
   status: z.union([z.literal('published'), z.literal('in-review')]).optional(),
-  /** Case-insensitive substring search across title / authors / DOI. */
+  /** Case-insensitive substring search across title / authors / DOI / affiliations. */
   q: z.preprocess((v) => {
     if (typeof v !== 'string') return undefined;
     const trimmed = v.trim();

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/route.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/route.tsx
@@ -59,7 +59,7 @@ const ParamsSchema = z.object({
   collection: z.string().min(1).max(64).optional(),
   kind: z.string().min(1).max(64).optional(), // TODO kind name should be url-safe
   status: z.union([z.literal('published'), z.literal('in-review')]).optional(),
-  /** Case-insensitive substring search across title / authors / DOI / affiliations. */
+  /** Case-insensitive substring search across title / authors / DOI / affiliations (affiliation branch skips common boilerplate tokens). */
   q: z.preprocess((v) => {
     if (typeof v !== 'string') return undefined;
     const trimmed = v.trim();

--- a/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
@@ -342,6 +342,52 @@ describe('site works listing — search / sort / date filters', () => {
     expect(dto.items[0].id).toBe(seeds[7].workId);
   });
 
+  test('q matches an affiliation name from work version metadata', async () => {
+    const prisma = await getPrismaClient();
+    await prisma.workVersion.update({
+      where: { id: seeds[3].workVersionId },
+      data: {
+        metadata: {
+          'frontmatter.myst': {
+            affiliations: [{ id: 'curvenote', name: 'Curvenote Labs', city: 'Halifax' }],
+          },
+        },
+      },
+    });
+
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'Curvenote Labs' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(1);
+    expect(dto.items[0].id).toBe(seeds[3].workId);
+  });
+
+  test('q matches an affiliation city substring', async () => {
+    const prisma = await getPrismaClient();
+    await prisma.workVersion.update({
+      where: { id: seeds[8].workVersionId },
+      data: {
+        metadata: {
+          'frontmatter.myst': {
+            affiliations: [{ institution: 'MIT', department: 'CS', city: 'Cambridge' }],
+          },
+        },
+      },
+    });
+
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'Cambridge' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(1);
+    expect(dto.items[0].id).toBe(seeds[8].workId);
+  });
+
   test('q with no matches returns an empty listing', async () => {
     const dto = await listPublishedWorks(
       testData.context,

--- a/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
@@ -349,7 +349,13 @@ describe('site works listing — search / sort / date filters', () => {
       data: {
         metadata: {
           'frontmatter.myst': {
-            affiliations: [{ id: 'curvenote', name: 'Curvenote Labs', city: 'Halifax' }],
+            affiliations: [
+              { id: 'a1', name: 'Systems Biology Department, Harvard Medical School' },
+              {
+                id: 'a2',
+                name: 'Wyss Institute for Biologically Inspired Engineering, Harvard University',
+              },
+            ],
           },
         },
       },
@@ -358,21 +364,21 @@ describe('site works listing — search / sort / date filters', () => {
     const dto = await listPublishedWorks(
       testData.context,
       [],
-      { q: 'Curvenote Labs' },
+      { q: 'Harvard Medical School' },
       { page: 0, limit: 500 },
     );
     expect(dto.total).toBe(1);
     expect(dto.items[0].id).toBe(seeds[3].workId);
   });
 
-  test('q matches an affiliation city substring', async () => {
+  test('q matches a second affiliation name on the same work', async () => {
     const prisma = await getPrismaClient();
     await prisma.workVersion.update({
       where: { id: seeds[8].workVersionId },
       data: {
         metadata: {
           'frontmatter.myst': {
-            affiliations: [{ institution: 'MIT', department: 'CS', city: 'Cambridge' }],
+            affiliations: [{ id: 'a1', name: 'Wyss Institute for Biologically Inspired Engineering' }],
           },
         },
       },
@@ -381,7 +387,7 @@ describe('site works listing — search / sort / date filters', () => {
     const dto = await listPublishedWorks(
       testData.context,
       [],
-      { q: 'Cambridge' },
+      { q: 'Wyss Institute' },
       { page: 0, limit: 500 },
     );
     expect(dto.total).toBe(1);

--- a/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
@@ -394,6 +394,51 @@ describe('site works listing — search / sort / date filters', () => {
     expect(dto.items[0].id).toBe(seeds[8].workId);
   });
 
+  test('q skips affiliation-only matches for stopword-only queries', async () => {
+    const prisma = await getPrismaClient();
+    await prisma.workVersion.update({
+      where: { id: seeds[4].workVersionId },
+      data: {
+        metadata: {
+          'frontmatter.myst': {
+            affiliations: [{ id: 'a1', name: 'Example University Research Center' }],
+          },
+        },
+      },
+    });
+
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'University' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(0);
+  });
+
+  test('q still matches a distinctive affiliation token when stopwords are present', async () => {
+    const prisma = await getPrismaClient();
+    await prisma.workVersion.update({
+      where: { id: seeds[4].workVersionId },
+      data: {
+        metadata: {
+          'frontmatter.myst': {
+            affiliations: [{ id: 'a1', name: 'Example University Research Center' }],
+          },
+        },
+      },
+    });
+
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'Example' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(1);
+    expect(dto.items[0].id).toBe(seeds[4].workId);
+  });
+
   test('q with no matches returns an empty listing', async () => {
     const dto = await listPublishedWorks(
       testData.context,

--- a/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
@@ -378,7 +378,9 @@ describe('site works listing — search / sort / date filters', () => {
       data: {
         metadata: {
           'frontmatter.myst': {
-            affiliations: [{ id: 'a1', name: 'Wyss Institute for Biologically Inspired Engineering' }],
+            affiliations: [
+              { id: 'a1', name: 'Wyss Institute for Biologically Inspired Engineering' },
+            ],
           },
         },
       },

--- a/platform/scms/tests/integration/workflow/work-version-subject.spec.ts
+++ b/platform/scms/tests/integration/workflow/work-version-subject.spec.ts
@@ -1,0 +1,198 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { describe, test, expect, beforeEach } from 'vitest';
+import type { SiteRole } from '@curvenote/scms-db';
+import { fetchSubmissionIdsBySubject, getPrismaClient } from '@curvenote/scms-server';
+import { uuidv7 } from 'uuidv7';
+import { createTestData, type TestData } from '../helpers/mocks';
+
+function subjectMetadata(subject: string) {
+  return {
+    'frontmatter.myst': { subject },
+  };
+}
+
+async function seedSubmissionWithSubject(
+  testData: TestData,
+  opts: {
+    subject: string;
+    siteId?: string;
+    status?: string;
+  },
+): Promise<{ submissionId: string; workVersionId: string }> {
+  const prisma = await getPrismaClient();
+  const now = new Date().toISOString();
+  const siteId = opts.siteId ?? testData.siteId;
+  const status = opts.status ?? 'PUBLISHED';
+  const workId = uuidv7();
+  const workVersionId = uuidv7();
+  const submissionId = uuidv7();
+
+  await prisma.work.create({
+    data: {
+      id: workId,
+      date_created: now,
+      date_modified: now,
+      created_by: { connect: { id: testData.userId } },
+    },
+  });
+  await prisma.workVersion.create({
+    data: {
+      id: workVersionId,
+      date_created: now,
+      date_modified: now,
+      title: `Subject seed ${submissionId}`,
+      authors: [],
+      metadata: subjectMetadata(opts.subject),
+      work: { connect: { id: workId } },
+    },
+  });
+  await prisma.submission.create({
+    data: {
+      id: submissionId,
+      date_created: now,
+      date_modified: now,
+      site: { connect: { id: siteId } },
+      work: { connect: { id: workId } },
+      kind: { connect: { id: testData.kindId } },
+      collection: { connect: { id: testData.collectionId } },
+      submitted_by: { connect: { id: testData.userId } },
+    },
+  });
+  await prisma.submissionVersion.create({
+    data: {
+      id: uuidv7(),
+      date_created: now,
+      date_modified: now,
+      status,
+      submission: { connect: { id: submissionId } },
+      work_version: { connect: { id: workVersionId } },
+      submitted_by: { connect: { id: testData.userId } },
+    },
+  });
+
+  return { submissionId, workVersionId };
+}
+
+describe('fetchSubmissionIdsBySubject', () => {
+  let testData: TestData;
+
+  beforeEach(async () => {
+    testData = await createTestData('ADMIN' as SiteRole);
+  });
+
+  test('matches subject case- and whitespace-insensitively', async () => {
+    const { submissionId } = await seedSubmissionWithSubject(testData, {
+      subject: '  Neuroscience ',
+    });
+
+    const ids = await fetchSubmissionIdsBySubject(testData.siteId, 'neuroscience', 'PUBLISHED');
+    expect(ids).toEqual([submissionId]);
+  });
+
+  test('returns each submission once when multiple published versions match', async () => {
+    const prisma = await getPrismaClient();
+    const now = new Date().toISOString();
+    const workId = uuidv7();
+    const submissionId = uuidv7();
+    const firstWorkVersionId = uuidv7();
+    const secondWorkVersionId = uuidv7();
+
+    await prisma.work.create({
+      data: {
+        id: workId,
+        date_created: now,
+        date_modified: now,
+        created_by: { connect: { id: testData.userId } },
+      },
+    });
+    for (const workVersionId of [firstWorkVersionId, secondWorkVersionId]) {
+      await prisma.workVersion.create({
+        data: {
+          id: workVersionId,
+          date_created: now,
+          date_modified: now,
+          title: `Version ${workVersionId}`,
+          authors: [],
+          metadata: subjectMetadata('Genomics'),
+          work: { connect: { id: workId } },
+        },
+      });
+    }
+    await prisma.submission.create({
+      data: {
+        id: submissionId,
+        date_created: now,
+        date_modified: now,
+        site: { connect: { id: testData.siteId } },
+        work: { connect: { id: workId } },
+        kind: { connect: { id: testData.kindId } },
+        collection: { connect: { id: testData.collectionId } },
+        submitted_by: { connect: { id: testData.userId } },
+      },
+    });
+    for (const workVersionId of [firstWorkVersionId, secondWorkVersionId]) {
+      await prisma.submissionVersion.create({
+        data: {
+          id: uuidv7(),
+          date_created: now,
+          date_modified: now,
+          status: 'PUBLISHED',
+          submission: { connect: { id: submissionId } },
+          work_version: { connect: { id: workVersionId } },
+          submitted_by: { connect: { id: testData.userId } },
+        },
+      });
+    }
+
+    const ids = await fetchSubmissionIdsBySubject(testData.siteId, 'genomics', 'PUBLISHED');
+    expect(ids).toEqual([submissionId]);
+  });
+
+  test('scopes to the requested submission version status', async () => {
+    const published = await seedSubmissionWithSubject(testData, {
+      subject: 'Microbiology',
+      status: 'PUBLISHED',
+    });
+    await seedSubmissionWithSubject(testData, {
+      subject: 'Microbiology',
+      status: 'DRAFT',
+    });
+
+    const ids = await fetchSubmissionIdsBySubject(testData.siteId, 'microbiology', 'PUBLISHED');
+    expect(ids).toEqual([published.submissionId]);
+  });
+
+  test('scopes to the requested site', async () => {
+    const prisma = await getPrismaClient();
+    const now = new Date().toISOString();
+    const otherSiteId = uuidv7();
+    await prisma.site.create({
+      data: {
+        id: otherSiteId,
+        name: `other-site-${otherSiteId}`,
+        title: 'Other Site',
+        private: false,
+        date_created: now,
+        date_modified: now,
+        metadata: {},
+        external: false,
+        restricted: true,
+        default_workflow: 'SIMPLE',
+        slug_strategy: 'NONE',
+      },
+    });
+
+    const onSite = await seedSubmissionWithSubject(testData, { subject: 'Oncology' });
+    await seedSubmissionWithSubject(testData, { subject: 'Oncology', siteId: otherSiteId });
+
+    const ids = await fetchSubmissionIdsBySubject(testData.siteId, 'oncology', 'PUBLISHED');
+    expect(ids).toEqual([onSite.submissionId]);
+  });
+
+  test('returns an empty list when no subject matches', async () => {
+    await seedSubmissionWithSubject(testData, { subject: 'Cardiology' });
+
+    const ids = await fetchSubmissionIdsBySubject(testData.siteId, 'no-such-subject', 'PUBLISHED');
+    expect(ids).toEqual([]);
+  });
+});

--- a/prisma/schema/migrations/20260609120000_add_work_version_subject_normalized_index/migration.sql
+++ b/prisma/schema/migrations/20260609120000_add_work_version_subject_normalized_index/migration.sql
@@ -8,8 +8,10 @@
 -- `WorkVersion` rows (usually a tiny set) and join back through
 -- `SubmissionVersion` (status) to `Submission` (site_id).
 --
--- The normalizer MUST match the WHERE clause exactly for the planner to use
--- the index — same contract as `immutable_array_to_string` for trgm search.
+-- The normalizer and partial-index predicate MUST match the WHERE clause
+-- exactly for the planner to use the index — same contract as
+-- `immutable_array_to_string` for trgm search. The query adds
+-- `wv.metadata IS NOT NULL` alongside the normalizer equality check.
 --
 -- Cannot be expressed in schema.prisma (expression index + helper function);
 -- same pattern as `20260526223800_add_submission_search_trgm_indexes`.

--- a/prisma/schema/migrations/20260610120000_add_work_version_affiliations_trgm_index/migration.sql
+++ b/prisma/schema/migrations/20260610120000_add_work_version_affiliations_trgm_index/migration.sql
@@ -2,9 +2,9 @@
 -- listing (`dbSearchSubmissionIds` in v1.sites.$siteName.works/db.server.ts).
 --
 -- Affiliations live at `WorkVersion.metadata['frontmatter.myst'].affiliations` as
--- an array of objects (name, institution, department, city, state, country).
--- The immutable extractor concatenates those fields per affiliation so ILIKE
--- predicates can be served via pg_trgm, matching the authors search contract.
+-- an array of objects keyed by local ids (e.g. "a1") with a human-readable `name`.
+-- Author entries reference those ids in their own `affiliations` arrays; search
+-- targets the resolved affiliation `name` (MyST `institution` when `name` absent).
 
 CREATE OR REPLACE FUNCTION work_version_affiliations_search_text(metadata jsonb)
   RETURNS text
@@ -15,14 +15,10 @@ AS $$
   SELECT COALESCE(
     (
       SELECT string_agg(
-        trim(both ' ' from concat_ws(' ',
+        COALESCE(
           NULLIF(trim(aff->>'name'), ''),
-          NULLIF(trim(aff->>'institution'), ''),
-          NULLIF(trim(aff->>'department'), ''),
-          NULLIF(trim(aff->>'city'), ''),
-          NULLIF(trim(aff->>'state'), ''),
-          NULLIF(trim(aff->>'country'), '')
-        )),
+          NULLIF(trim(aff->>'institution'), '')
+        ),
         ' '
       )
       FROM jsonb_array_elements(

--- a/prisma/schema/migrations/20260610120000_add_work_version_affiliations_trgm_index/migration.sql
+++ b/prisma/schema/migrations/20260610120000_add_work_version_affiliations_trgm_index/migration.sql
@@ -1,0 +1,43 @@
+-- Trigram GIN index powering affiliation substring search on the public works
+-- listing (`dbSearchSubmissionIds` in v1.sites.$siteName.works/db.server.ts).
+--
+-- Affiliations live at `WorkVersion.metadata['frontmatter.myst'].affiliations` as
+-- an array of objects (name, institution, department, city, state, country).
+-- The immutable extractor concatenates those fields per affiliation so ILIKE
+-- predicates can be served via pg_trgm, matching the authors search contract.
+
+CREATE OR REPLACE FUNCTION work_version_affiliations_search_text(metadata jsonb)
+  RETURNS text
+  LANGUAGE sql
+  IMMUTABLE
+  PARALLEL SAFE
+AS $$
+  SELECT COALESCE(
+    (
+      SELECT string_agg(
+        trim(both ' ' from concat_ws(' ',
+          NULLIF(trim(aff->>'name'), ''),
+          NULLIF(trim(aff->>'institution'), ''),
+          NULLIF(trim(aff->>'department'), ''),
+          NULLIF(trim(aff->>'city'), ''),
+          NULLIF(trim(aff->>'state'), ''),
+          NULLIF(trim(aff->>'country'), '')
+        )),
+        ' '
+      )
+      FROM jsonb_array_elements(
+        CASE
+          WHEN jsonb_typeof(metadata #> '{frontmatter.myst,affiliations}') = 'array'
+          THEN metadata #> '{frontmatter.myst,affiliations}'
+          ELSE '[]'::jsonb
+        END
+      ) AS aff
+      WHERE jsonb_typeof(aff) = 'object'
+    ),
+    ''
+  )
+$$;
+
+CREATE INDEX IF NOT EXISTS "WorkVersion_affiliations_trgm_idx"
+  ON "WorkVersion" USING GIN ((work_version_affiliations_search_text(metadata)) gin_trgm_ops)
+  WHERE metadata IS NOT NULL;


### PR DESCRIPTION
Affiliations now in full text search with some, blacklisted term removal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches public listing search SQL and adds a DB migration/index; behavior change is scoped to optional `q` with stopword guards, but query plans and search results can shift after deploy.
> 
> **Overview**
> Extends **`GET /v1/sites/:siteName/works?q=...`** so free-text search can match **MyST affiliation names** in `WorkVersion.metadata['frontmatter.myst'].affiliations` (using each entry’s `name`, or `institution` when `name` is missing), in addition to title, authors, and DOI.
> 
> A new Postgres helper **`work_version_affiliations_search_text(metadata)`** and **GIN trigram index** on `WorkVersion` back the affiliation `ILIKE` branch in `dbSearchSubmissionIds`. Shared logic in **`work-version-affiliations.server`** mirrors the SQL extractor and **skips the affiliation branch** when every query token is a boilerplate stopword (e.g. university, department) or too short—title/author/DOI matching is unchanged.
> 
> **`fetchSubmissionIdsBySubject`** now requires **`wv.metadata IS NOT NULL`** so the subject partial index can be used. API docs and integration/unit tests cover affiliation hits, stopword behavior, and subject filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f1d5b1c0c7bd5f8516afb3110c8efc586dca3ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->