### PR TITLE
🏎️ perf opt & additional index

### DIFF
--- a/.changeset/doi-resolve-hot-path.md
+++ b/.changeset/doi-resolve-hot-path.md
@@ -1,0 +1,10 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms-db': patch
+'@curvenote/scms': patch
+---
+
+Speed up site DOI resolution under load (`GET /v1/sites/:siteName/doi/:first/:second`).
+
+- **Query:** start from btree-backed `WorkVersion.doi` / `Work.doi` equality, join to published `SubmissionVersion` rows scoped by `site_id`, then hydrate the DTO by primary key — avoids Prisma `OR` duplicating `WorkVersion` joins and rooting the plan at `SubmissionVersion`.
+- **Index:** partial `(work_version_id, date_created DESC) WHERE status = 'PUBLISHED'` via `CREATE INDEX CONCURRENTLY` for the latest-published probe after DOI lookup.

--- a/.changeset/work-version-work-id-index.md
+++ b/.changeset/work-version-work-id-index.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-db': patch
+---
+
+Add btree index on `WorkVersion.work_id` (migration `20260610160000_add_work_version_work_id_index`, `CREATE INDEX CONCURRENTLY`) for work-scoped version lookups and Work → versions joins on the large `WorkVersion` table.

--- a/docs/planning/site-doi-resolve-performance.md
+++ b/docs/planning/site-doi-resolve-performance.md
@@ -24,6 +24,7 @@ provably behaviour-preserving:
 | 3   | **Correctness:** the no-tag path is now site-scoped                                                            | a DOI published only on _another_ site no longer resolves                                                |
 | 4   | Narrow `siteWorkDtoSelect` for this flow                                                                       | drops the `submitted_by` → `User` join and the SubmissionVersion bookkeeping columns the DTO never reads |
 | 5   | Edge caching on the route (success + 404)                                                                      | DOI→work mappings and junk-DOI scans are absorbed by the CDN instead of the origin/DB                    |
+| 6   | DOI-index-first raw SQL + partial published-version index (`20260610150000`)                                   | avoids Prisma `OR` duplicate `WorkVersion` joins; scopes by `site_id` not `Site.name`                    |
 
 ### 1. Indexes
 
@@ -107,6 +108,25 @@ to be faster.
 > e2e needs a populated fixture DB. The change is lint-clean and mirrors the
 > established pattern in `published.tsx` and the thumbnail/social routes; the
 > package-level integration spec is route-independent and still green.
+
+### 7. DOI-index-first query (load-test hot path)
+
+Prisma `findFirst` with `OR` on `work_version.doi` vs `work_version.work.doi` rooted
+the plan at `SubmissionVersion` and emitted duplicate `WorkVersion` joins — under
+load-test traffic the query maxed CPU even with btree DOI indexes.
+
+`fetchPublishedSubmissionVersionIdByDoi` now:
+
+1. Unions work-version ids from `WorkVersion.doi = ?` and `Work.doi = ?` (both
+   btree-backed).
+2. Joins to `SubmissionVersion` (`status = PUBLISHED`, optional `tags @>`) and
+   `Submission` (`site_id = ?` — no `Site` join).
+3. `ORDER BY date_created DESC LIMIT 1`.
+4. Hydrates the row with `findUnique` + `siteWorkDtoSelect`.
+
+Migration
+[`20260610150000_add_doi_resolve_hot_path_index`](../../prisma/schema/migrations/20260610150000_add_doi_resolve_hot_path_index/migration.sql)
+adds partial `(work_version_id, date_created DESC) WHERE status = 'PUBLISHED'`.
 
 ## Remaining / optional work
 

--- a/packages/scms-server/src/backend/loaders/sites/doi.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/doi.server.ts
@@ -1,4 +1,5 @@
 import { doi } from 'doi-utils';
+import { Prisma } from '@curvenote/scms-db';
 import { getPrismaClient } from '../../prisma.server.js';
 import { error404 } from '@curvenote/scms-core';
 import {
@@ -6,49 +7,83 @@ import {
   type PublishedSiteWorkDTO,
 } from './submissions/published/get.server.js';
 import type { SiteContext } from '../../context.site.server.js';
-import type { Prisma } from '@curvenote/scms-db';
 import { siteWorkDtoSelect } from '../../prisma.selects.server.js';
+
 export type SiteDoiResolveOptions = {
   /** If set, pick the latest *published* submission version for this DOI whose `tags` contains this string */
   tag?: string;
 };
 
 /**
- * Filter for the latest *published* submission version of a DOI on this site.
+ * Resolve the id of the latest *published* submission version for a DOI on a site.
  *
- * Rooting at `SubmissionVersion` (rather than `WorkVersion`) makes the tag and
- * no-tag paths a single query and lets the `date_created DESC` + LIMIT 1
- * short-circuit at the first match. The DOI is matched against either the
- * version's own `doi` or the parent work's `doi` — both now backed by btree
- * indexes (migration `20260529130000`) so the equality lookup no longer
- * sequential-scans.
+ * Starts from btree-backed DOI equality on `WorkVersion` / `Work` (migration
+ * `20260529130000`), unions the matching work-version ids, then joins to
+ * `SubmissionVersion` filtered by `status = PUBLISHED` and `Submission.site_id`.
+ * This avoids Prisma's `OR` on nested relations, which duplicates `WorkVersion`
+ * joins and roots the plan at `SubmissionVersion` so Postgres cannot short-circuit
+ * at the DOI index under load.
  *
- * Crucially this is always scoped to `siteName`. The previous no-tag path
- * (`WorkVersion`-rooted) omitted the site filter and could resolve a DOI that
- * was only published on a *different* site; the tag path already scoped
- * correctly, and the regression spec pins this down.
+ * Optional `tag` uses the GIN index on `SubmissionVersion.tags` (`@>`).
+ * Latest match uses `date_created DESC LIMIT 1`, backed by
+ * `SubmissionVersion_published_work_version_date_created_idx` (migration
+ * `20260610150000`).
  */
-function buildPublishedByDoiWhere(
-  siteName: string,
+async function fetchPublishedSubmissionVersionIdByDoi(
+  siteId: string,
   doiNormalized: string,
   tag?: string,
-): Prisma.SubmissionVersionWhereInput {
-  return {
-    status: 'PUBLISHED',
-    submission: { site: { name: siteName } },
-    ...(tag ? { tags: { has: tag } } : {}),
-    OR: [
-      { work_version: { doi: doiNormalized } },
-      { work_version: { work: { doi: doiNormalized } } },
-    ],
-  };
+): Promise<string | null> {
+  const prisma = await getPrismaClient();
+
+  const doiWorkVersions = Prisma.sql`
+    SELECT wv.id AS work_version_id
+    FROM "WorkVersion" wv
+    WHERE wv.doi = ${doiNormalized}
+    UNION
+    SELECT wv.id
+    FROM "Work" w
+    INNER JOIN "WorkVersion" wv ON wv.work_id = w.id
+    WHERE w.doi = ${doiNormalized}
+  `;
+
+  const rows = tag
+    ? await prisma.$queryRaw<{ id: string }[]>`
+        SELECT sv.id
+        FROM (${doiWorkVersions}) doi_wv
+        INNER JOIN "SubmissionVersion" sv
+          ON sv.work_version_id = doi_wv.work_version_id
+         AND sv.status = 'PUBLISHED'
+         AND sv.tags @> ARRAY[${tag}]::varchar[]
+        INNER JOIN "Submission" s
+          ON s.id = sv.submission_id
+         AND s.site_id = ${siteId}
+        ORDER BY sv.date_created DESC
+        LIMIT 1
+      `
+    : await prisma.$queryRaw<{ id: string }[]>`
+        SELECT sv.id
+        FROM (${doiWorkVersions}) doi_wv
+        INNER JOIN "SubmissionVersion" sv
+          ON sv.work_version_id = doi_wv.work_version_id
+         AND sv.status = 'PUBLISHED'
+        INNER JOIN "Submission" s
+          ON s.id = sv.submission_id
+         AND s.site_id = ${siteId}
+        ORDER BY sv.date_created DESC
+        LIMIT 1
+      `;
+
+  return rows[0]?.id ?? null;
 }
 
-async function dbGetPublishedSiteWorkByDoi(siteName: string, doiNormalized: string, tag?: string) {
+async function dbGetPublishedSiteWorkByDoi(siteId: string, doiNormalized: string, tag?: string) {
+  const id = await fetchPublishedSubmissionVersionIdByDoi(siteId, doiNormalized, tag);
+  if (!id) return null;
+
   const prisma = await getPrismaClient();
-  return prisma.submissionVersion.findFirst({
-    where: buildPublishedByDoiWhere(siteName, doiNormalized, tag),
-    orderBy: { date_created: 'desc' },
+  return prisma.submissionVersion.findUnique({
+    where: { id },
     select: siteWorkDtoSelect,
   });
 }
@@ -64,7 +99,7 @@ export default async function (
   if (!doiNormalized) throw error404('Not Found - Invalid DOI');
 
   const tag = opts?.tag?.trim();
-  const sv = await dbGetPublishedSiteWorkByDoi(ctx.site.name, doiNormalized, tag);
+  const sv = await dbGetPublishedSiteWorkByDoi(ctx.site.id, doiNormalized, tag);
   if (!sv) {
     throw error404(
       tag

--- a/prisma/schema/migrations/20260610150000_add_doi_resolve_hot_path_index/migration.sql
+++ b/prisma/schema/migrations/20260610150000_add_doi_resolve_hot_path_index/migration.sql
@@ -1,0 +1,13 @@
+-- prisma-migrate-disable-next-transaction
+-- Partial index for DOI resolution (`sites.doi` in
+-- `packages/scms-server/src/backend/loaders/sites/doi.server.ts`).
+--
+-- After DOI btree lookup yields work_version_id(s), the hot path probes
+-- published submission versions in `date_created DESC` order. A partial index on
+-- `status = 'PUBLISHED'` keeps the btree small and matches the join predicate.
+
+SET statement_timeout = 0;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "SubmissionVersion_published_work_version_date_created_idx"
+  ON "SubmissionVersion" (work_version_id, date_created DESC)
+  WHERE status = 'PUBLISHED';

--- a/prisma/schema/migrations/20260610160000_add_work_version_work_id_index/migration.sql
+++ b/prisma/schema/migrations/20260610160000_add_work_version_work_id_index/migration.sql
@@ -1,0 +1,11 @@
+-- prisma-migrate-disable-next-transaction
+-- Supabase advisor: WorkVersion.work_id FK with no implicit Postgres index.
+-- Large table — work-scoped version lookups and Work → versions joins were
+-- sequential-scanning (work pages, DOI resolution, listings, work teardown).
+--
+-- CONCURRENTLY on large production tables; IF NOT EXISTS for safe retries.
+
+SET statement_timeout = 0;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "WorkVersion_work_id_idx"
+  ON "WorkVersion" (work_id);

--- a/prisma/schema/work.prisma
+++ b/prisma/schema/work.prisma
@@ -80,6 +80,11 @@ model WorkVersion {
   /// `WorkVersion_authors_trgm_idx` (expression on `authors`) and
   /// `WorkVersion_subject_normalized_idx` / `WorkVersion_affiliations_trgm_idx`
   /// remain raw-SQL-only — not expressible in Prisma.
+  ///
+  /// Backs Work → versions joins and work-scoped version lookups (`work_id` FK
+  /// has no implicit Postgres index). Large table; used by work pages, DOI
+  /// resolution, listings, and work teardown `workVersion.deleteMany`.
+  @@index([work_id])
   @@index([doi])
   @@index([doi(ops: raw("gin_trgm_ops"))], type: Gin, map: "WorkVersion_doi_trgm_idx")
   @@index([title(ops: raw("gin_trgm_ops"))], type: Gin, map: "WorkVersion_title_trgm_idx")


### PR DESCRIPTION
* first step in dealing with poor query performance on `v1/sites/<site>/doi/*`
* added recommended index from supabase advisor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a high-traffic read path to hand-written SQL and alters site filtering from name to id; behavior is intended to match existing integration tests but query-plan risk remains until load-tested in production.
> 
> **Overview**
> **Site DOI resolution** (`GET /v1/sites/:siteName/doi/...`) is reworked for load: the loader no longer uses Prisma `findFirst` with nested `OR` on work vs work-version DOI (which duplicated joins and rooted at `SubmissionVersion`). It now runs **parameterized raw SQL** that unions btree-backed `WorkVersion.doi` and `Work.doi` matches, joins published `SubmissionVersion` rows filtered by **`site_id`** (not site name), picks latest with `ORDER BY date_created DESC LIMIT 1`, then **hydrates** the DTO via `findUnique` + `siteWorkDtoSelect`.
> 
> Two **concurrent migrations** add indexes: a **partial** `(work_version_id, date_created DESC) WHERE status = 'PUBLISHED'` on `SubmissionVersion` for the post-DOI probe, and a btree on **`WorkVersion.work_id`** (schema `@@index` + migration) for work-scoped joins. Planning docs and changesets document the hot path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f0c6f1db9ca4c81ae0822910fcc4b549d547b2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->