### PR TITLE
🔒 Cap pg pool at 1 conn for serverless

### DIFF
--- a/packages/scms-db/src/index.ts
+++ b/packages/scms-db/src/index.ts
@@ -66,11 +66,13 @@ function makeClient(connectionString?: string, dbCACertificate?: string): Prisma
     );
   }
 
-  // Create a connection pool for the adapter
+  // One connection per process — matches Supabase/PgBouncer transaction pooler limits on serverless.
   const pool = new Pool({
     connectionString: dbUrl,
     ssl: dbCACertificate ? { ca: dbCACertificate } : undefined,
-    max: process.env.NODE_ENV !== 'production' ? 1 : undefined,
+    max: 1,
+    idleTimeoutMillis: 20_000,
+    connectionTimeoutMillis: 10_000,
   });
 
   const adapter = new PrismaPg(pool);


### PR DESCRIPTION
node-pg ignores connection_limit in the URL; enforce max 1 per process with idle and connect timeouts for Supabase transaction pooler.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection pooling behavior for all environments including production; mis-tuning could increase latency or connection errors under load, but the change targets known serverless pooler limits.
> 
> **Overview**
> Forces the Prisma `pg` `Pool` to **one connection per process** in all environments (`max: 1`), instead of only capping dev while leaving production `max` unset (which could open many connections per serverless instance).
> 
> Adds **`idleTimeoutMillis` (20s)** and **`connectionTimeoutMillis` (10s)** so idle backends are released and connect attempts fail fast—aligned with Supabase/PgBouncer transaction pooling where URL `connection_limit` is not honored by node-pg.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 693dd1ec8e6cf5ec60a178a608d0d3e1b9d9f024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->