### PR TITLE
✨ Improvements to the sites UI

### DIFF
--- a/.changeset/puny-coins-rescue.md
+++ b/.changeset/puny-coins-rescue.md
@@ -1,0 +1,8 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms-core': patch
+'@curvenote/scms': patch
+'@curvenote/scms-sites-ext': patch
+---
+
+Sites UI improvements

--- a/ee/sites/src/routes/$siteName.submissions-classic/db.server.ts
+++ b/ee/sites/src/routes/$siteName.submissions-classic/db.server.ts
@@ -1,8 +1,13 @@
-import type { SiteContext } from '@curvenote/scms-server';
-import { createPreviewToken, getPrismaClient, jobs } from '@curvenote/scms-server';
+import {
+  createPreviewToken,
+  getConfiguredWorkflow,
+  getPrismaClient,
+  jobs,
+  type SiteContext,
+} from '@curvenote/scms-server';
 import type { Prisma } from '@curvenote/scms-db';
 import { JobStatus } from '@curvenote/scms-db';
-import { getWorkflow, KnownJobTypes } from '@curvenote/scms-core';
+import { KnownJobTypes } from '@curvenote/scms-core';
 import { pickListingActiveVersionId } from './listing.utils.server.js';
 import { dbLoadListingVersionSnapshots } from './listing.versions.server.js';
 import {
@@ -145,7 +150,7 @@ async function dbBuildAugmentedListingItems(
       const activeWork = activeId ? workByVersionId.get(activeId) : undefined;
       const item = formatSubmissionListingItem(ctx, row, activeWork);
       if (!item) return null;
-      const workflow = getWorkflow(ctx.$config, [], row.collection.workflow);
+      const workflow = getConfiguredWorkflow(ctx, row.collection.workflow);
       return {
         ...item,
         workflow,

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.spec.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.spec.ts
@@ -8,14 +8,7 @@ vi.mock('@curvenote/scms-server', async (importOriginal) => {
   return {
     ...actual,
     getPrismaClient: vi.fn(),
-  };
-});
-
-vi.mock('@curvenote/scms-core', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@curvenote/scms-core')>();
-  return {
-    ...actual,
-    getWorkflow: vi.fn(() => ({
+    getConfiguredWorkflow: vi.fn(() => ({
       states: {
         PUBLISHED: { label: 'Published' },
         IN_REVIEW: { label: 'In review' },

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.ts
@@ -1,6 +1,4 @@
-import type { SiteContext } from '@curvenote/scms-server';
-import { getPrismaClient } from '@curvenote/scms-server';
-import { getWorkflow } from '@curvenote/scms-core';
+import { getConfiguredWorkflow, getPrismaClient, type SiteContext } from '@curvenote/scms-server';
 import { firstVersionTag } from '../$siteName.submissions._index/index.versions.server.js';
 
 export type VersionTimelineEntry = {
@@ -53,7 +51,7 @@ export async function dbLoadSubmissionVersionsTimeline(
     return null;
   }
 
-  const workflow = getWorkflow(ctx.$config, [], submission.collection.workflow);
+  const workflow = getConfiguredWorkflow(ctx, submission.collection.workflow);
 
   return submission.versions.map((row) => ({
     id: row.id,

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/loader.server.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/loader.server.ts
@@ -1,7 +1,9 @@
 import type { Context, Workflow } from '@curvenote/scms-core';
-import { getWorkflow } from '@curvenote/scms-core';
-import type { SiteContext } from '@curvenote/scms-server';
-import { createPreviewToken } from '@curvenote/scms-server';
+import {
+  createPreviewToken,
+  getConfiguredWorkflow,
+  type SiteContext,
+} from '@curvenote/scms-server';
 import {
   dbGetSiteAppData,
   dbListMagicLinksForSubmission,
@@ -79,7 +81,7 @@ export async function loadSubmissionDetailPage(
     return null;
   }
 
-  const workflow = getWorkflow(ctx.$config, [], submission.collection.workflow);
+  const workflow = getConfiguredWorkflow(ctx, submission.collection.workflow);
 
   let activeVersionIndex = submissionVersions.findIndex(
     (version) => version.id === submission.active_version_id,

--- a/ee/sites/src/routes/$siteName.submissions._index/ListingMultiSelectChip.tsx
+++ b/ee/sites/src/routes/$siteName.submissions._index/ListingMultiSelectChip.tsx
@@ -29,6 +29,11 @@ interface ListingMultiSelectChipProps {
   searchPlaceholder?: string;
   /** Empty-state copy when no options match the search query (only when `searchable`). */
   noResultsLabel?: string;
+  /**
+   * Value shown when nothing is selected (e.g. `"All"`). When set, the trigger
+   * reads `{label}: {defaultValueLabel}` and an option to clear is offered.
+   */
+  defaultValueLabel?: string;
   options: ListingMultiSelectOption[];
   className?: string;
 }
@@ -47,6 +52,7 @@ export function ListingMultiSelectChip({
   searchable = true,
   searchPlaceholder = 'Search...',
   noResultsLabel = 'No matches.',
+  defaultValueLabel,
   options,
   className,
 }: ListingMultiSelectChipProps) {
@@ -69,8 +75,10 @@ export function ListingMultiSelectChip({
     });
   };
 
-  const summary = formatSelectionSummary(label, options, selected);
+  const summary = formatSelectionSummary(label, options, selected, defaultValueLabel);
   const hasSelection = selected.length > 0;
+  const ariaLabel =
+    summary.kind === 'label-only' ? summary.text : `${summary.prefix}: ${summary.value}`;
 
   return (
     <ui.Popover open={open} onOpenChange={setOpen}>
@@ -84,9 +92,15 @@ export function ListingMultiSelectChip({
               'border-primary/40 bg-primary/5 dark:border-primary/40 dark:bg-primary/10',
             className,
           )}
-          aria-label={summary}
+          aria-label={ariaLabel}
         >
-          <span>{summary}</span>
+          {summary.kind === 'label-only' ? (
+            <span>{summary.text}</span>
+          ) : (
+            <span>
+              {summary.prefix}: <span className="font-medium">{summary.value}</span>
+            </span>
+          )}
           {hasSelection ? (
             <span
               role="button"
@@ -119,6 +133,18 @@ export function ListingMultiSelectChip({
           <ui.CommandList>
             {searchable ? <ui.CommandEmpty>{noResultsLabel}</ui.CommandEmpty> : null}
             <ui.CommandGroup>
+              {defaultValueLabel ? (
+                <ui.CommandItem value={`${defaultValueLabel} all`} onSelect={handleClear}>
+                  <Check
+                    className={cn(
+                      'size-3.5 shrink-0',
+                      selected.length === 0 ? 'opacity-100' : 'opacity-0',
+                    )}
+                    aria-hidden
+                  />
+                  <span className="flex-1 truncate">{defaultValueLabel}</span>
+                </ui.CommandItem>
+              ) : null}
               {options.map((option) => {
                 const isSelected = selectedSet.has(option.id);
                 return (
@@ -147,11 +173,21 @@ function formatSelectionSummary(
   label: string,
   options: ListingMultiSelectOption[],
   selectedIds: readonly string[],
-): string {
-  if (selectedIds.length === 0) return label;
+  defaultValueLabel?: string,
+): { kind: 'label-only'; text: string } | { kind: 'label-value'; prefix: string; value: string } {
+  if (selectedIds.length === 0) {
+    if (defaultValueLabel) {
+      return { kind: 'label-value', prefix: label, value: defaultValueLabel };
+    }
+    return { kind: 'label-only', text: label };
+  }
   if (selectedIds.length === 1) {
     const match = options.find((option) => option.id === selectedIds[0]);
-    return match ? `${label}: ${match.name}` : `${label}: 1`;
+    return {
+      kind: 'label-value',
+      prefix: label,
+      value: match ? match.name : '1',
+    };
   }
-  return `${label}: ${selectedIds.length}`;
+  return { kind: 'label-value', prefix: label, value: String(selectedIds.length) };
 }

--- a/ee/sites/src/routes/$siteName.submissions._index/SubmissionsListingToolbar.tsx
+++ b/ee/sites/src/routes/$siteName.submissions._index/SubmissionsListingToolbar.tsx
@@ -33,8 +33,8 @@ interface SubmissionsListingToolbarProps {
  * the toolbar itself only composes them and renders the result summary.
  *
  * The (i) help icon next to the search field documents the ILIKE-backed
- * matching behaviour (including the `%` and `_` wildcards). Sort lives at
- * the right end of the filter row so it sits beside the chips it conceptually
+ * matching behaviour (including the `%` and `_` wildcards). Search commits on
+ * Enter or blur — see `SubmissionsSearchInput`. Sort lives at the right end of the filter row so it sits beside the chips it conceptually
  * belongs to, rather than competing with the search input for top-row space.
  */
 export function SubmissionsListingToolbar({

--- a/ee/sites/src/routes/$siteName.submissions._index/SubmissionsPagination.tsx
+++ b/ee/sites/src/routes/$siteName.submissions._index/SubmissionsPagination.tsx
@@ -104,7 +104,7 @@ function ItemsPerPageSelect({
         Show
       </ui.Label>
       <ui.Select
-        value={perPage.toString()}
+        value={String(perPage)}
         onValueChange={(value) => {
           const newPerPage = Number(value);
           const newPage = pageForPerPageChange(page, perPage, newPerPage, total);
@@ -113,8 +113,12 @@ function ItemsPerPageSelect({
           });
         }}
       >
-        <ui.SelectTrigger id={selectId} size="sm" className="h-8 min-w-[4.75rem] text-xs">
-          <ui.SelectValue />
+        <ui.SelectTrigger
+          id={selectId}
+          size="sm"
+          className="h-8 min-w-[4.75rem] text-xs text-foreground"
+        >
+          <ui.SelectValue placeholder={String(perPage)}>{perPage}</ui.SelectValue>
         </ui.SelectTrigger>
         <ui.SelectContent>
           {SUBMISSIONS_PER_PAGE_OPTIONS.map((option) => (

--- a/ee/sites/src/routes/$siteName.submissions._index/SubmissionsSearchInput.tsx
+++ b/ee/sites/src/routes/$siteName.submissions._index/SubmissionsSearchInput.tsx
@@ -1,153 +1,137 @@
 import { useEffect, useId, useRef, useState, useTransition } from 'react';
 import { useSearchParams } from 'react-router';
-import { Loader2, Search, X } from 'lucide-react';
-import { cn, ui } from '@curvenote/scms-core';
+import { CornerDownLeft, Loader2, Search, X } from 'lucide-react';
+import { cn } from '@curvenote/scms-core';
 import { LISTING_SEARCH_MIN_LENGTH, setListingParam } from './listingParams.js';
-
-const SEARCH_DEBOUNCE_MS = 500;
 
 interface SubmissionsSearchInputProps {
   className?: string;
 }
 
+/** Trimmed value actually written to the URL, or '' when below the min length. */
+function toEffective(value: string): string {
+  return value.trim().length >= LISTING_SEARCH_MIN_LENGTH ? value.trim() : '';
+}
+
 /**
- * URL-bound debounced search box for the submissions listing.
+ * URL-bound search box for the submissions listing, dispatched on Enter or blur.
  *
- * `q` in the URL is the source of truth. Local state mirrors it so the input
- * feels responsive while the navigation that updates `?q=` happens in a
- * transition (kept out of the typing thread).
+ * `q` in the URL is the source of truth. Local state mirrors it so typing feels
+ * responsive, but nothing is pushed to the URL while typing. The search fires
+ * when the user presses Enter or leaves the field (blur), which keeps history
+ * clean and cuts loader hits to one per intentional query. Blur also commits a
+ * cleared box, so deleting the text and clicking away strips `q`. A subtle
+ * ↵ Enter affordance appears on the right while the input is "dirty" (differs
+ * from the active search).
  *
- * `?q=` is only pushed once the trimmed input reaches `LISTING_SEARCH_MIN_LENGTH`
- * (3) — anything shorter is treated as no search and the URL has the param
- * stripped, so the loader takes the fast (no-join) path. The input still shows
- * whatever the user has typed; only the URL/search side is gated.
- *
- * Page is reset by `setListingParam` whenever the search changes — the user
- * is always taken back to page 1 on a new search.
+ * Below `LISTING_SEARCH_MIN_LENGTH` (3) the URL carries no `q` (the route schema
+ * enforces the same floor) so the loader takes the fast no-search path.
  */
 export function SubmissionsSearchInput({ className }: SubmissionsSearchInputProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const inputId = useId();
-  const initialValue = searchParams.get('q') ?? '';
-  const [value, setValue] = useState(initialValue);
+  const submitted = searchParams.get('q') ?? '';
+  const [value, setValue] = useState(submitted);
   const [isPending, startTransition] = useTransition();
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastPushedRef = useRef(initialValue);
+  const lastSyncedRef = useRef(submitted);
 
-  // Resync local state when the URL changes from outside (e.g. "Clear
-  // filters" action, browser back/forward). Avoid clobbering an in-flight
-  // edit the user has typed but not yet flushed.
   useEffect(() => {
     const urlValue = searchParams.get('q') ?? '';
-    if (urlValue !== lastPushedRef.current) {
-      lastPushedRef.current = urlValue;
+    if (urlValue !== lastSyncedRef.current) {
+      lastSyncedRef.current = urlValue;
       setValue(urlValue);
     }
   }, [searchParams]);
 
-  // Cleanup any pending debounce on unmount.
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, []);
-
   const pushToUrl = (next: string) => {
-    // Below the trigram-friendly minimum the URL carries no `q` — the route
-    // schema enforces the same rule, but doing it here keeps `?q=` out of
-    // shareable links until the search is actually meaningful.
-    const effective = next.trim().length >= LISTING_SEARCH_MIN_LENGTH ? next : '';
-    lastPushedRef.current = effective;
+    const effective = toEffective(next);
+    lastSyncedRef.current = effective;
     startTransition(() => {
-      setSearchParams(
-        (prev) => setListingParam(prev, 'q', effective.length ? effective : undefined),
-        {
-          replace: true,
-          preventScrollReset: true,
-        },
-      );
+      setSearchParams((prev) => setListingParam(prev, 'q', effective || undefined), {
+        replace: false,
+        preventScrollReset: true,
+      });
     });
   };
 
-  const scheduleDebouncedPush = (next: string) => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      pushToUrl(next);
-    }, SEARCH_DEBOUNCE_MS);
-  };
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const next = event.target.value;
-    setValue(next);
-    scheduleDebouncedPush(next);
-  };
-
   const handleClear = () => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
     setValue('');
     pushToUrl('');
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Escape' && value.length > 0) {
-      event.preventDefault();
-      handleClear();
-    }
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      if (debounceRef.current) clearTimeout(debounceRef.current);
+  const handleBlur = () => {
+    if (toEffective(value) !== lastSyncedRef.current) {
       pushToUrl(value);
     }
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      pushToUrl(value);
+    } else if (event.key === 'Escape' && value.length > 0) {
+      event.preventDefault();
+      handleClear();
+    }
+  };
+
   const showClear = value.length > 0;
+  const isDirty = value.trim() !== submitted && value.trim().length >= LISTING_SEARCH_MIN_LENGTH;
 
   return (
-    <ui.InputWithAdornments
+    <div
       className={cn(
-        'border-0 bg-stone-100 shadow-none focus-within:ring-1 dark:bg-stone-900/60',
+        'relative flex items-center rounded-md bg-stone-100 focus-within:ring-1 focus-within:ring-ring dark:bg-stone-900/60',
         className,
       )}
-      leadingAdornment={
-        isPending ? (
-          <Loader2 className="size-4 animate-spin text-muted-foreground" aria-hidden />
-        ) : (
-          <Search className="size-4 text-muted-foreground" aria-hidden />
-        )
-      }
-      trailingAdornment={
-        showClear ? (
-          <button
-            type="button"
-            onClick={handleClear}
-            aria-label="Clear search"
-            className="mr-1 inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-stone-200 hover:text-foreground dark:hover:bg-stone-800"
-          >
-            <X className="size-3.5" />
-          </button>
-        ) : null
-      }
     >
-      <ui.Input
+      <span className="pointer-events-none absolute left-3 flex items-center text-muted-foreground">
+        {isPending ? (
+          <Loader2 className="size-4 animate-spin" aria-hidden />
+        ) : (
+          <Search className="size-4" aria-hidden />
+        )}
+      </span>
+      <input
         id={inputId}
-        // `type="text"` (not `type="search"`) so the browser doesn't render its
-        // own native clear `×` button alongside the custom one in
-        // `trailingAdornment`. Functionally equivalent for our purposes.
         type="text"
         role="searchbox"
         value={value}
-        onChange={handleChange}
+        onChange={(event) => setValue(event.target.value)}
         onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
         maxLength={200}
-        placeholder="Search submissions..."
+        placeholder="Search by title, author, or DOI..."
         aria-label="Search submissions"
         autoComplete="off"
         spellCheck={false}
         className={cn(
-          'h-9 border-0 bg-transparent pl-9 shadow-none focus-visible:ring-0 dark:bg-transparent',
-          showClear && 'pr-9',
+          'h-9 w-full rounded-md border-0 bg-transparent pl-9 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-hidden',
+          showClear ? 'pr-24' : 'pr-3',
         )}
       />
-    </ui.InputWithAdornments>
+      <div className="absolute right-2 flex items-center gap-1">
+        {isDirty ? (
+          <span
+            className="pointer-events-none hidden items-center gap-1 rounded border border-stone-300 bg-white px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground sm:inline-flex dark:border-stone-700 dark:bg-stone-800"
+            aria-hidden
+          >
+            <CornerDownLeft className="size-3" />
+            Enter
+          </span>
+        ) : null}
+        {showClear ? (
+          <button
+            type="button"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={handleClear}
+            aria-label="Clear search"
+            className="inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-stone-200 hover:text-foreground dark:hover:bg-stone-800"
+          >
+            <X className="size-3.5" />
+          </button>
+        ) : null}
+      </div>
+    </div>
   );
 }

--- a/ee/sites/src/routes/$siteName.submissions._index/SubmissionsStatusFilter.tsx
+++ b/ee/sites/src/routes/$siteName.submissions._index/SubmissionsStatusFilter.tsx
@@ -25,6 +25,7 @@ export function SubmissionsStatusFilter({ className }: SubmissionsStatusFilterPr
     <ListingMultiSelectChip
       paramKey="statuses"
       label="Status"
+      defaultValueLabel="All"
       searchable={false}
       options={[...LISTING_STATUS_OPTIONS]}
       className={className}

--- a/ee/sites/src/routes/$siteName.submissions._index/format.server.ts
+++ b/ee/sites/src/routes/$siteName.submissions._index/format.server.ts
@@ -1,6 +1,6 @@
-import { coerceToObject, getWorkflow } from '@curvenote/scms-core';
+import { coerceToObject } from '@curvenote/scms-core';
 import { doi as doiUtils } from 'doi-utils';
-import type { SiteContext } from '@curvenote/scms-server';
+import { getConfiguredWorkflow, type SiteContext } from '@curvenote/scms-server';
 import type { IndexListingRow } from './db.server.js';
 import type { SubmissionsIndexItem } from './types.js';
 
@@ -24,8 +24,7 @@ export function formatSubmissionsIndexItems(
     const kindContent = coerceToObject(row.kind.content);
     const collectionContent = coerceToObject(row.collection.content);
     const status = newestVersion?.status ?? 'UNKNOWN';
-    const workflow = getWorkflow(ctx.$config, [], row.collection.workflow);
-
+    const workflow = getConfiguredWorkflow(ctx, row.collection.workflow);
     return {
       id: row.id,
       title: work?.title ?? '',

--- a/ee/sites/src/routes/$siteName.submissions._index/route.tsx
+++ b/ee/sites/src/routes/$siteName.submissions._index/route.tsx
@@ -85,7 +85,7 @@ const csvStatusIds = z.preprocess(
  * Canonical URL contract for the submissions index listing.
  *
  *   page, perPage  — pagination
- *   q              — debounced search text (matches title / authors / DOI)
+ *   q              — search text (matches title / authors / DOI); committed on Enter or blur
  *   sort           — one of LISTING_SORTS; disabled values silently coerce
  *                    to the default until the denormalisation slice lands
  *   kindIds        — CSV of SubmissionKind ids (multi-select chip)

--- a/ee/sites/src/routes/$siteName.submissions/route.tsx
+++ b/ee/sites/src/routes/$siteName.submissions/route.tsx
@@ -1,7 +1,7 @@
 import type { ActionFunctionArgs } from 'react-router';
 import { data, Outlet } from 'react-router';
-import { sites, withAppSiteContext } from '@curvenote/scms-server';
-import { getValidTransition, getWorkflow, TrackEvent, scopes } from '@curvenote/scms-core';
+import { getConfiguredWorkflow, sites, withAppSiteContext } from '@curvenote/scms-server';
+import { getValidTransition, TrackEvent, scopes } from '@curvenote/scms-core';
 import type { WorkflowTransition } from '@curvenote/scms-core';
 
 // Helper function to get specific transition event names
@@ -66,7 +66,7 @@ export const action = async (args: ActionFunctionArgs) => {
 
     // Get the workflow for the current status
     const workflowName = submissionVersion.submission.collection.workflow;
-    const workflow = getWorkflow(ctx.$config, [], workflowName);
+    const workflow = getConfiguredWorkflow(ctx, workflowName);
     if (!workflow) {
       return data(
         {

--- a/packages/scms-core/src/components/ui/MermaidDiagram.tsx
+++ b/packages/scms-core/src/components/ui/MermaidDiagram.tsx
@@ -1,8 +1,34 @@
 import { useHydrated } from '../../hooks/useHydrated.js';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Maximize2, Minimize2, RotateCcw, ZoomIn, ZoomOut } from 'lucide-react';
+import { cn } from '../../utils/cn.js';
+import { Button } from './button.js';
 
 interface MermaidDiagramProps {
   children: string;
+  /** When true, show a control to expand the diagram to the app viewport. */
+  showFullscreenControl?: boolean;
+}
+
+const MIN_ZOOM = 0.25;
+const MAX_ZOOM = 3;
+const ZOOM_STEP = 0.15;
+
+function clampZoom(value: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value));
+}
+
+function zoomToPoint(
+  oldZoom: number,
+  oldPan: { x: number; y: number },
+  newZoom: number,
+  point: { x: number; y: number },
+): { x: number; y: number } {
+  return {
+    x: point.x - ((point.x - oldPan.x) / oldZoom) * newZoom,
+    y: point.y - ((point.y - oldPan.y) / oldZoom) * newZoom,
+  };
 }
 
 // Global queue to ensure only one diagram renders at a time
@@ -28,12 +54,84 @@ const processQueue = async () => {
   isRendering = false;
 };
 
-export function MermaidDiagram({ children }: MermaidDiagramProps) {
+export function MermaidDiagram({ children, showFullscreenControl = true }: MermaidDiagramProps) {
   const isHydrated = useHydrated();
+  const frameRef = useRef<HTMLDivElement>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const panSessionRef = useRef<{
+    originX: number;
+    originY: number;
+    panX: number;
+    panY: number;
+  } | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isViewportExpanded, setIsViewportExpanded] = useState(false);
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [isPanning, setIsPanning] = useState(false);
+  const panRef = useRef(pan);
+  panRef.current = pan;
+  const zoomRef = useRef(zoom);
+  zoomRef.current = zoom;
   const diagramIdRef = useRef<string>(`mermaid-${Math.random().toString(36).substr(2, 9)}`);
+
+  const resetView = useCallback(() => {
+    setZoom(1);
+    setPan({ x: 0, y: 0 });
+  }, []);
+
+  useEffect(() => {
+    resetView();
+  }, [children, resetView]);
+
+  useEffect(() => {
+    if (!isViewportExpanded) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsViewportExpanded(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isViewportExpanded]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || isLoading) return;
+
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      const rect = viewport.getBoundingClientRect();
+      const cursor = {
+        x: event.clientX - rect.left,
+        y: event.clientY - rect.top,
+      };
+      const oldZoom = zoomRef.current;
+      const oldPan = panRef.current;
+      const factor = event.deltaY > 0 ? 1 - ZOOM_STEP : 1 + ZOOM_STEP;
+      const newZoom = clampZoom(oldZoom * factor);
+      if (newZoom === oldZoom) return;
+
+      const newPan = zoomToPoint(oldZoom, oldPan, newZoom, cursor);
+      zoomRef.current = newZoom;
+      panRef.current = newPan;
+      setZoom(newZoom);
+      setPan(newPan);
+    };
+
+    viewport.addEventListener('wheel', handleWheel, { passive: false });
+    return () => viewport.removeEventListener('wheel', handleWheel);
+  }, [isLoading, isViewportExpanded]);
 
   useEffect(() => {
     if (!isHydrated || !containerRef.current) return;
@@ -43,26 +141,20 @@ export function MermaidDiagram({ children }: MermaidDiagramProps) {
         setIsLoading(true);
         setError(null);
 
-        // Dynamically import mermaid to avoid SSR issues
         const mermaidModule = await import('mermaid');
         const mermaid = mermaidModule.default;
 
-        // Clear the container
         if (containerRef.current) {
           containerRef.current.innerHTML = '';
         }
 
-        // Create a unique container for this diagram
         const diagramContainer = document.createElement('div');
         diagramContainer.id = diagramIdRef.current;
         diagramContainer.className = 'mermaid';
         diagramContainer.textContent = children;
 
-        if (containerRef.current) {
-          containerRef.current.appendChild(diagramContainer);
-        }
+        containerRef.current?.appendChild(diagramContainer);
 
-        // Initialize Mermaid
         mermaid.initialize({
           startOnLoad: false,
           theme: 'default',
@@ -70,7 +162,6 @@ export function MermaidDiagram({ children }: MermaidDiagramProps) {
           fontFamily: 'inherit',
         });
 
-        // Render the diagram
         await mermaid.run({
           nodes: [diagramContainer],
         });
@@ -83,10 +174,43 @@ export function MermaidDiagram({ children }: MermaidDiagramProps) {
       }
     };
 
-    // Add to queue and process
     renderQueue.push(renderDiagram);
     processQueue();
   }, [children, isHydrated]);
+
+  const toggleViewportExpanded = () => {
+    setIsViewportExpanded((expanded) => !expanded);
+  };
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0 || isLoading) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setIsPanning(true);
+    panSessionRef.current = {
+      originX: event.clientX,
+      originY: event.clientY,
+      panX: panRef.current.x,
+      panY: panRef.current.y,
+    };
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const session = panSessionRef.current;
+    if (!session) return;
+
+    setPan({
+      x: session.panX + event.clientX - session.originX,
+      y: session.panY + event.clientY - session.originY,
+    });
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (panSessionRef.current) {
+      panSessionRef.current = null;
+      setIsPanning(false);
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
 
   if (!isHydrated) {
     return (
@@ -109,18 +233,114 @@ export function MermaidDiagram({ children }: MermaidDiagramProps) {
     );
   }
 
-  return (
-    <div className="p-4 overflow-hidden bg-white border border-gray-200 rounded dark:bg-gray-800 dark:border-gray-700">
-      {isLoading && (
+  const zoomLabel = `${Math.round(zoom * 100)}%`;
+
+  const diagramFrame = (
+    <div
+      ref={frameRef}
+      className={cn(
+        'relative overflow-hidden bg-white border border-gray-200 dark:bg-gray-800 dark:border-gray-700',
+        isViewportExpanded
+          ? 'fixed inset-0 z-50 flex flex-col rounded-none border-0 p-4 shadow-none'
+          : 'rounded',
+      )}
+    >
+      <div className="absolute top-2 right-2 z-10 flex items-center gap-1">
+        <div className="flex items-center overflow-hidden rounded-sm border border-stone-200 bg-white/90 shadow-xs dark:border-stone-700 dark:bg-gray-900/90">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="rounded-none"
+            onClick={() => setZoom((current) => clampZoom(current - ZOOM_STEP))}
+            aria-label="Zoom out"
+            title="Zoom out"
+            disabled={zoom <= MIN_ZOOM}
+          >
+            <ZoomOut aria-hidden />
+          </Button>
+          <span className="min-w-12 border-x border-stone-200 px-2 text-center text-xs font-medium tabular-nums text-muted-foreground dark:border-stone-700">
+            {zoomLabel}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="rounded-none"
+            onClick={() => setZoom((current) => clampZoom(current + ZOOM_STEP))}
+            aria-label="Zoom in"
+            title="Zoom in"
+            disabled={zoom >= MAX_ZOOM}
+          >
+            <ZoomIn aria-hidden />
+          </Button>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          className="bg-white/90 dark:bg-gray-900/90"
+          onClick={resetView}
+          aria-label="Reset zoom and pan"
+          title="Reset view"
+        >
+          <RotateCcw aria-hidden />
+        </Button>
+        {showFullscreenControl ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            className="bg-white/90 dark:bg-gray-900/90"
+            onClick={toggleViewportExpanded}
+            aria-label={isViewportExpanded ? 'Exit expanded view' : 'Expand to viewport'}
+            title={isViewportExpanded ? 'Exit expanded view' : 'Expand to viewport'}
+          >
+            {isViewportExpanded ? <Minimize2 aria-hidden /> : <Maximize2 aria-hidden />}
+          </Button>
+        ) : null}
+      </div>
+
+      {isLoading ? (
         <div className="flex items-center justify-center p-4">
           <div className="text-sm text-gray-500 dark:text-gray-400">Rendering diagram...</div>
         </div>
-      )}
+      ) : null}
+
       <div
-        ref={containerRef}
-        className="mermaid-container"
-        style={{ minHeight: isLoading ? '100px' : 'auto' }}
-      />
+        ref={viewportRef}
+        className={cn(
+          'touch-none select-none overflow-hidden',
+          isViewportExpanded ? 'min-h-0 flex-1' : 'min-h-[280px]',
+          isLoading ? 'pointer-events-none' : isPanning ? 'cursor-grabbing' : 'cursor-grab',
+        )}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        aria-label="Workflow diagram. Scroll to zoom, drag to pan."
+      >
+        <div
+          className="inline-block min-w-full p-4 pt-12"
+          style={{
+            transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+            transformOrigin: '0 0',
+          }}
+        >
+          <div ref={containerRef} className="mermaid-container" />
+        </div>
+      </div>
     </div>
   );
+
+  if (isViewportExpanded) {
+    return (
+      <>
+        <div className="min-h-[280px] rounded border border-transparent" aria-hidden />
+        {createPortal(diagramFrame, document.body)}
+      </>
+    );
+  }
+
+  return diagramFrame;
 }

--- a/packages/scms-server/src/extensions/registry.server.ts
+++ b/packages/scms-server/src/extensions/registry.server.ts
@@ -1,0 +1,15 @@
+import type { ClientExtension } from '@curvenote/scms-core';
+
+let appExtensions: ClientExtension[] = [];
+
+/**
+ * Registers the platform extension list once at app bootstrap (see platform/scms/app/root.tsx).
+ * Enables server code outside platform routes (e.g. ee/sites loaders) to resolve extension workflows.
+ */
+export function setAppExtensions(extensions: ClientExtension[]): void {
+  appExtensions = extensions;
+}
+
+export function getAppExtensions(): ClientExtension[] {
+  return appExtensions;
+}

--- a/packages/scms-server/src/workflow/index.ts
+++ b/packages/scms-server/src/workflow/index.ts
@@ -1,1 +1,2 @@
 export * from './utils.server.js';
+export * from '../extensions/registry.server.js';

--- a/packages/scms-server/src/workflow/utils.server.ts
+++ b/packages/scms-server/src/workflow/utils.server.ts
@@ -1,7 +1,15 @@
 import type { Workflow, ClientExtension } from '@curvenote/scms-core';
-import { getWorkflows, registerExtensionWorkflows } from '@curvenote/scms-core';
+import { getWorkflow, getWorkflows, registerExtensionWorkflows } from '@curvenote/scms-core';
 import { getPrismaClient } from '../backend/prisma.server.js';
 import type { SiteContext } from '../backend/context.site.server.js';
+import { getAppExtensions } from '../extensions/registry.server.js';
+
+/**
+ * Resolves a workflow using extension definitions registered at app bootstrap.
+ */
+export function getConfiguredWorkflow(ctx: SiteContext, workflowName: string): Workflow {
+  return getWorkflow(ctx.$config, registerExtensionWorkflows(getAppExtensions()), workflowName);
+}
 
 /**
  * Given the submission ID, we need to determine the workflow in use based on the collection.

--- a/platform/scms/app/root.tsx
+++ b/platform/scms/app/root.tsx
@@ -7,6 +7,7 @@ import {
   formatMyUserDTO,
   buildClientNavigation,
   loadAndValidateSigninSignupConfig,
+  setAppExtensions,
 } from '@curvenote/scms-server';
 import {
   ui,
@@ -115,6 +116,7 @@ export const loader = async (args: Route.LoaderArgs) => {
   const ctx = await withContext(args);
 
   registerExtensionsForNavigation(clientExtensions);
+  setAppExtensions(extensions);
 
   // Validate that all expected workflows are registered (pass extensions for proper missing detection)
   const extensionWorkflows = registerExtensionWorkflows(extensions);


### PR DESCRIPTION
small ones but including better search UX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `getConfiguredWorkflow` depends on `setAppExtensions` running in the root loader before ee/sites server code; if that ordering fails, status labels or transitions could resolve wrong workflows. Submission transition actions use the new helper, so workflow resolution is on a critical path.
> 
> **Overview**
> Sites submissions listing and related surfaces get UX polish, while server-side workflow resolution is centralized so extension-defined workflows work outside platform routes.
> 
> **Submissions listing:** Search no longer debounces into the URL on every keystroke—it commits on **Enter** or **blur** (with an Enter hint when the query is “dirty”), updated placeholder copy, and history entries that aren’t `replace`d. The status filter shows **Status: All** when nothing is selected and adds a clear “All” row in the popover via `defaultValueLabel` on the shared multi-select chip. Pagination’s per-page select gets an explicit displayed value to fix empty trigger text.
> 
> **Workflows:** `getConfiguredWorkflow` on `@curvenote/scms-server` replaces direct `getWorkflow(ctx.$config, [], …)` across ee/sites loaders and the submission status transition action. Extensions are registered once at bootstrap (`setAppExtensions` in root loader) and read from a small server registry so labels and transitions include extension workflows.
> 
> **Mermaid diagrams:** `MermaidDiagram` adds wheel zoom, drag pan, reset, optional viewport expand (portal + Escape), and zoom controls—mainly for workflow diagrams in the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa6ccfb92faf25b274496cf1c0a1cf452fd869e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->