### PR TITLE
🏎️ optimizing published article api route

### DIFF
--- a/.changeset/thirty-sides-serve.md
+++ b/.changeset/thirty-sides-serve.md
@@ -1,0 +1,7 @@
+---
+'@curvenote/scms-server': patch
+'@curvenote/scms': patch
+'@curvenote/scms-sites-ext': patch
+---
+
+Optimizing query on main published article API route

--- a/docs/planning/site-published-resolve-performance.md
+++ b/docs/planning/site-published-resolve-performance.md
@@ -1,0 +1,110 @@
+# Follow-up Plan: Site Published Work Resolution Performance
+
+## Endpoint
+
+`GET /v1/sites/:siteName/works/:workIdOrSlug/published` — resolves a work id or
+slug to the latest published submission version on a site, returning the site-work
+DTO plus an embedded `versions` array.
+
+- Route: [`v1.sites.$siteName.works.$workIdOrSlug.published/route.tsx`](../../platform/scms/app/routes/api/v1.sites.$siteName.works.$workIdOrSlug.published/route.tsx)
+- Loader: [`sites/submissions/published/get.server.ts`](../../packages/scms-server/src/backend/loaders/sites/submissions/published/get.server.ts)
+- Shared resolver: [`sites/submissions/published/resolve.server.ts`](../../packages/scms-server/src/backend/loaders/sites/submissions/published/resolve.server.ts)
+
+Theme article pages call this on every render via
+[`apps/theme/lib/loaders.server.ts`](../../../next-theme/apps/theme/lib/loaders.server.ts)
+(`getPublishedWork`). Thumbnail and social routes reuse the same resolver for the
+published hot path.
+
+Golden-payload regression tests lock the delivered DTO and site-scoping contract:
+[`tests/integration/workflow/site-doi-resolve.spec.ts`](../../platform/scms/tests/integration/workflow/site-doi-resolve.spec.ts).
+
+## What has landed
+
+| #   | Change                                                                                              | Effect                                                                                          |
+| --- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| 1   | Shared `resolve.server.ts` with index-native raw SQL (work id vs slug branches)                     | Avoids Prisma `OR`, duplicate joins, and `Site.name` filter                                     |
+| 2   | Hydrate via `findUnique` + `siteWorkDtoSelect` (published/social) or `publishedThumbnailSelect`     | Drops `submitted_by` User join and unused SubmissionVersion columns on hot paths                |
+| 3   | **Correctness:** resolve scoped by `Submission.site_id`                                             | A work published only on another site returns null (404 at route)                               |
+| 4   | `dbGetPublishedVersionsForSubmission` uses `site_id` + `submission_id` instead of `Site.name` join  | Cheaper versions array query                                                                    |
+| 5   | Partial index `SubmissionVersion_published_submission_date_created_idx` (`20260612150000`)          | Backs `ORDER BY date_created DESC` for published versions on a submission                       |
+| 6   | Route moved to folder layout under `works/`                                                         | Matches nested `works/route.tsx` registration pattern                                           |
+| 7   | Edge caching unchanged on route (`SEMI_STATIC_BURST_PROTECTION` / `NOT_FOUND_PUBLIC_BURST`)         | DOI and published share stable CDN semantics for success + junk 404s                            |
+
+### 1. Resolver paths
+
+**Work id** (`looksLikeUUID`):
+
+```sql
+WorkVersion.work_id = ?
+  → SubmissionVersion (status = PUBLISHED)
+  → Submission (site_id = ?)
+ORDER BY sv.date_created DESC LIMIT 1
+```
+
+Uses `WorkVersion_work_id_idx` and
+`SubmissionVersion_published_work_version_date_created_idx` (migration
+`20260610150000`, shared with DOI resolve).
+
+**Slug**:
+
+```sql
+Slug (slug, site_id)
+  → Submission (site_id = ?)
+  → SubmissionVersion (status = PUBLISHED)
+ORDER BY sv.date_created DESC LIMIT 1
+```
+
+Uses `Slug @@unique([slug, site_id])`.
+
+### 2. Shared vs divergent callers
+
+| Caller              | Phase 1 (resolve)              | Phase 2 (hydrate select)        |
+| ------------------- | ------------------------------ | ------------------------------- |
+| `published.get`     | `fetchPublishedSubmissionVersionId` | `siteWorkDtoSelect`        |
+| `thumbnail` (pub)   | same                           | `publishedThumbnailSelect`      |
+| `social` (pub)      | same                           | `siteWorkDtoSelect`             |
+| `thumbnail` (draft) | legacy Prisma path             | `submissionVersionForSiteWorkSelect` (cold path) |
+
+DOI resolve keeps its own resolver in `doi.server.ts` but shares formatters
+(`formatPublishedSiteWorkWithVersions`, `siteWorkDtoSelect`).
+
+### 3. Versions partial index
+
+Migration
+[`20260612150000_add_published_versions_hot_path_index`](../../prisma/schema/migrations/20260612150000_add_published_versions_hot_path_index/migration.sql):
+
+```sql
+CREATE INDEX CONCURRENTLY … ON "SubmissionVersion" (submission_id, date_created DESC)
+  WHERE status = 'PUBLISHED';
+```
+
+## Remaining / optional work
+
+### A. Narrow the shared site-work formatter further
+
+Same as DOI plan — low payoff unless profiling shows relation bloat.
+
+### B. Runtime cache (LRU / Vercel Runtime Cache)
+
+Edge cache already covers public sites. Per-request `React.cache()` dedup helps
+only when multiple loaders hit published in one request (thumbnail + social on
+same page are separate HTTP calls).
+
+### C. Thumbnail unpublished fallback
+
+Still uses legacy `findFirst` + `Site.name` + broad select. Optimize only if
+preview traffic shows up in advisor.
+
+### D. Hostname lookup (`GET /v1/sites?hostname=`)
+
+Separate theme hot path — see theme SCMS optimization backlog.
+
+## Verification
+
+```bash
+npm run lint
+npm run test:integration -- platform/scms/tests/integration/workflow/site-doi-resolve.spec.ts
+```
+
+Apply migration in staging/production before expecting index-backed plans in
+Supabase Query Performance Advisor.

--- a/ee/sites/src/routes/$siteName.submissions._index/SubmissionsDateFilter.tsx
+++ b/ee/sites/src/routes/$siteName.submissions._index/SubmissionsDateFilter.tsx
@@ -51,7 +51,7 @@ export function SubmissionsDateFilter({ className }: SubmissionsDateFilterProps)
   const to = searchParams.get('to') ?? undefined;
   const unpublishedOnly = searchParams.get('unpublishedOnly') === '1';
   const [open, setOpen] = useState(false);
-  /** In-popover range; URL updates only once both ends are chosen. */
+  /** In-popover range while the user is picking; URL syncs on complete range or popover close. */
   const [draftRange, setDraftRange] = useState<DateRange | undefined>(undefined);
   const [visibleMonth, setVisibleMonth] = useState<Date>(() => new Date());
 
@@ -105,17 +105,28 @@ export function SubmissionsDateFilter({ className }: SubmissionsDateFilterProps)
     setOpen(false);
   };
 
+  const applyDraftRange = (range: DateRange) => {
+    const fromIso = dateToIso(range.from!);
+    const toIso = range.to ? dateToIso(range.to) : fromIso;
+    applyDateMode({ from: fromIso, to: toIso });
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && draftRange?.from && !draftRange.to) {
+      applyDraftRange(draftRange);
+    }
+    setOpen(nextOpen);
+  };
+
   const handleCalendarSelect = (range: DateRange | undefined) => {
     if (!range || (!range.from && !range.to)) {
       setDraftRange(undefined);
+      applyDateMode({});
       return;
     }
     setDraftRange(range);
     if (range.from && range.to) {
-      applyDateMode({
-        from: dateToIso(range.from),
-        to: dateToIso(range.to),
-      });
+      applyDraftRange(range);
       setOpen(false);
     }
   };
@@ -132,7 +143,7 @@ export function SubmissionsDateFilter({ className }: SubmissionsDateFilterProps)
   const showCalendar = activePreset !== 'no_published_date';
 
   return (
-    <ui.Popover open={open} onOpenChange={setOpen}>
+    <ui.Popover open={open} onOpenChange={handleOpenChange}>
       <ui.PopoverTrigger asChild>
         <ui.Button
           variant="action"

--- a/packages/scms-server/src/backend/loaders/sites/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/get.server.ts
@@ -69,7 +69,13 @@ export async function dbGetUserSiteRoles(userId: string, siteId: string) {
   return siteUsers;
 }
 
-export function formatCollectionSummaryDTO(dbo: Collection): CollectionSummaryDTO {
+/** Fields read by {@link formatCollectionSummaryDTO}. */
+export type CollectionSummaryInput = Pick<
+  Collection,
+  'id' | 'name' | 'slug' | 'workflow' | 'content' | 'open'
+>;
+
+export function formatCollectionSummaryDTO(dbo: CollectionSummaryInput): CollectionSummaryDTO {
   return {
     id: dbo.id,
     name: dbo.name,

--- a/packages/scms-server/src/backend/loaders/sites/kinds/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/kinds/get.server.ts
@@ -11,7 +11,12 @@ export async function dbGetKind(ctx: SiteContext, where: Prisma.SubmissionKindWh
 
 export type DBO = Exclude<Awaited<ReturnType<typeof dbGetKind>>, null>;
 
-export function formatSubmissionKindSummaryDTO(dbo: DBO): SubmissionKindSummaryDTO {
+/** Fields read by {@link formatSubmissionKindSummaryDTO}. */
+export type SubmissionKindSummaryInput = Pick<DBO, 'id' | 'name' | 'content' | 'default'>;
+
+export function formatSubmissionKindSummaryDTO(
+  dbo: SubmissionKindSummaryInput,
+): SubmissionKindSummaryDTO {
   return {
     id: dbo.id,
     name: dbo.name,

--- a/packages/scms-server/src/backend/loaders/sites/submissions/published/get.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/published/get.server.ts
@@ -2,50 +2,21 @@ import type { SiteContext } from '../../../../context.site.server.js';
 import type { HostSpec, SiteWorkDTO, SiteWorkVersionDTO } from '@curvenote/common';
 import { formatDate, concatSiteWorkTags, pickVersionTag } from '@curvenote/common';
 import { getPrismaClient } from '../../../../prisma.server.js';
-import type { siteWorkDtoSelect } from '../../../../prisma.selects.server.js';
-import { submissionVersionForSiteWorkSelect } from '../../../../prisma.selects.server.js';
 import type { Prisma } from '@curvenote/scms-db';
+import type {
+  siteWorkDtoSelect,
+  submissionVersionForSiteWorkSelect,
+} from '../../../../prisma.selects.server.js';
 import { signPrivateUrls } from '../../../../sign.private.server.js';
 import { formatCollectionSummaryDTO } from '../../get.server.js';
 import { formatSubmissionKindSummaryDTO } from '../../kinds/get.server.js';
 import { createArticleUrl } from '../../../../domains.server.js';
 import { fetchWorkVersionSubjects } from '../../../../work-version-subject.server.js';
+import { dbGetPublishedSiteWorkDto } from './resolve.server.js';
 
-export async function dbGetLatestPublishedSubmissionVersion(
-  siteName: string,
-  workIdOrSlug: string,
-) {
-  const prisma = await getPrismaClient();
-  return prisma.submissionVersion.findFirst({
-    where: {
-      status: 'PUBLISHED',
-      submission: {
-        site: {
-          name: siteName,
-        },
-      },
-      OR: [
-        {
-          work_version: {
-            work_id: workIdOrSlug,
-          },
-        },
-        {
-          submission: {
-            slugs: {
-              some: {
-                slug: workIdOrSlug,
-              },
-            },
-          },
-        },
-      ],
-    },
-    orderBy: {
-      date_created: 'desc',
-    },
-    select: submissionVersionForSiteWorkSelect,
-  });
+/** @deprecated Prefer `dbGetPublishedSiteWorkDto(siteId, …)` — kept for callers expecting the old name. */
+export async function dbGetLatestPublishedSubmissionVersion(siteId: string, workIdOrSlug: string) {
+  return dbGetPublishedSiteWorkDto(siteId, workIdOrSlug);
 }
 
 export type DBO = Prisma.SubmissionVersionGetPayload<{
@@ -82,12 +53,13 @@ export type PublishedSiteWorkDTO = ModifiedSiteWorkDTO & { versions: SiteWorkVer
  * `versions` summary array so clients can render version navigation without a second
  * request to `links.versions`.
  */
-export async function dbGetPublishedVersionsForSubmission(siteName: string, submissionId: string) {
+export async function dbGetPublishedVersionsForSubmission(siteId: string, submissionId: string) {
   const prisma = await getPrismaClient();
   return prisma.submissionVersion.findMany({
     where: {
       status: 'PUBLISHED',
-      submission: { id: submissionId, site: { name: siteName } },
+      submission_id: submissionId,
+      submission: { site_id: siteId },
     },
     orderBy: { date_created: 'desc' },
     select: {
@@ -119,7 +91,7 @@ export async function formatPublishedSiteWorkWithVersions(
     subject: subjects.get(dbo.work_version.id),
   });
   const versionRows = await dbGetPublishedVersionsForSubmission(
-    ctx.site.name,
+    ctx.site.id,
     siteWork.submission_id,
   );
   return { ...siteWork, versions: formatSiteWorkVersions(versionRows) };
@@ -210,7 +182,7 @@ export default async function (
   ctx: SiteContext,
   workIdOrSlug: string,
 ): Promise<PublishedSiteWorkDTO | null> {
-  const dbo = await dbGetLatestPublishedSubmissionVersion(ctx.site.name, workIdOrSlug);
+  const dbo = await dbGetPublishedSiteWorkDto(ctx.site.id, workIdOrSlug);
   if (!dbo) return null;
   return formatPublishedSiteWorkWithVersions(ctx, dbo);
 }

--- a/packages/scms-server/src/backend/loaders/sites/submissions/published/resolve.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/published/resolve.server.ts
@@ -1,0 +1,93 @@
+import { looksLikeUUID } from '@curvenote/scms-core';
+import type { Prisma as PrismaTypes } from '@curvenote/scms-db';
+import { getPrismaClient } from '../../../../prisma.server.js';
+import { publishedThumbnailSelect, siteWorkDtoSelect } from '../../../../prisma.selects.server.js';
+
+/**
+ * Resolve the id of the latest *published* submission version for a work id or
+ * slug on a site.
+ *
+ * Uses separate index-native paths (work id vs slug) instead of Prisma `OR`, and
+ * scopes by `Submission.site_id` rather than joining `Site` by name. Latest match
+ * uses `date_created DESC LIMIT 1`, backed by
+ * `SubmissionVersion_published_work_version_date_created_idx` (work-id path) and
+ * `Slug(slug, site_id)` (slug path).
+ */
+async function fetchPublishedSubmissionVersionIdByWorkId(
+  siteId: string,
+  workId: string,
+): Promise<string | null> {
+  const prisma = await getPrismaClient();
+  const rows = await prisma.$queryRaw<{ id: string }[]>`
+    SELECT sv.id
+    FROM "WorkVersion" wv
+    INNER JOIN "SubmissionVersion" sv
+      ON sv.work_version_id = wv.id
+     AND sv.status = 'PUBLISHED'
+    INNER JOIN "Submission" s
+      ON s.id = sv.submission_id
+     AND s.site_id = ${siteId}
+    WHERE wv.work_id = ${workId}
+    ORDER BY sv.date_created DESC
+    LIMIT 1
+  `;
+  return rows[0]?.id ?? null;
+}
+
+async function fetchPublishedSubmissionVersionIdBySlug(
+  siteId: string,
+  slug: string,
+): Promise<string | null> {
+  const prisma = await getPrismaClient();
+  const rows = await prisma.$queryRaw<{ id: string }[]>`
+    SELECT sv.id
+    FROM "Slug" slug
+    INNER JOIN "Submission" s
+      ON s.id = slug.submission_id
+     AND s.site_id = ${siteId}
+    INNER JOIN "SubmissionVersion" sv
+      ON sv.submission_id = s.id
+     AND sv.status = 'PUBLISHED'
+    WHERE slug.slug = ${slug}
+      AND slug.site_id = ${siteId}
+    ORDER BY sv.date_created DESC
+    LIMIT 1
+  `;
+  return rows[0]?.id ?? null;
+}
+
+export async function fetchPublishedSubmissionVersionId(
+  siteId: string,
+  workIdOrSlug: string,
+): Promise<string | null> {
+  if (looksLikeUUID(workIdOrSlug)) {
+    return fetchPublishedSubmissionVersionIdByWorkId(siteId, workIdOrSlug);
+  }
+  return fetchPublishedSubmissionVersionIdBySlug(siteId, workIdOrSlug);
+}
+
+export async function hydratePublishedSubmissionVersion<
+  S extends PrismaTypes.SubmissionVersionSelect,
+>(id: string, select: S) {
+  const prisma = await getPrismaClient();
+  return prisma.submissionVersion.findUnique({
+    where: { id },
+    select,
+  });
+}
+
+export async function dbGetPublishedSiteWorkDto(siteId: string, workIdOrSlug: string) {
+  const id = await fetchPublishedSubmissionVersionId(siteId, workIdOrSlug);
+  if (!id) return null;
+  return hydratePublishedSubmissionVersion(id, siteWorkDtoSelect);
+}
+
+export async function dbGetPublishedThumbnailRow(siteId: string, workIdOrSlug: string) {
+  const id = await fetchPublishedSubmissionVersionId(siteId, workIdOrSlug);
+  if (!id) return null;
+  return hydratePublishedSubmissionVersion(id, publishedThumbnailSelect);
+}
+
+export type PublishedThumbnailRow = PrismaTypes.SubmissionVersionGetPayload<{
+  select: typeof publishedThumbnailSelect;
+}>;

--- a/packages/scms-server/src/backend/loaders/sites/works/social.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/works/social.server.ts
@@ -1,8 +1,6 @@
 import type { SiteContext } from '../../../context.site.server.js';
-import {
-  formatSiteWorkDTO,
-  dbGetLatestPublishedSubmissionVersion,
-} from '../submissions/published/get.server.js';
+import { formatSiteWorkDTO } from '../submissions/published/get.server.js';
+import { dbGetPublishedSiteWorkDto } from '../submissions/published/resolve.server.js';
 import { withApiBaseUrl } from '@curvenote/scms-core';
 
 const OG_API = 'https://og.curvenote.com/';
@@ -30,7 +28,7 @@ export default async function (ctx: SiteContext, workIdOrSlug: string, versionId
   console.log('🎑 - Generating social image for', workIdOrSlug, versionId);
 
   // TODO get a specific work version when versionId is provided
-  const dbo = await dbGetLatestPublishedSubmissionVersion(ctx.site.name, workIdOrSlug);
+  const dbo = await dbGetPublishedSiteWorkDto(ctx.site.id, workIdOrSlug);
   if (!dbo) return;
 
   if (!dbo.work_version.cdn || !dbo.work_version.cdn_key) return;

--- a/packages/scms-server/src/backend/loaders/sites/works/thumbnail.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/works/thumbnail.server.ts
@@ -1,8 +1,8 @@
 import type { SiteContext } from '../../../context.site.server.js';
 import {
-  dbGetLatestPublishedSubmissionVersion,
-  type DBO as PublishedDBO,
-} from '../submissions/published/get.server.js';
+  dbGetPublishedThumbnailRow,
+  type PublishedThumbnailRow,
+} from '../submissions/published/resolve.server.js';
 import { error401, error404 } from '@curvenote/scms-core';
 import { getPrismaClient } from '../../../prisma.server.js';
 import { submissionVersionForSiteWorkSelect } from '../../../prisma.selects.server.js';
@@ -41,7 +41,12 @@ async function dbGetLatestSubmissionVersion(siteName: string, workIdOrSlug: stri
   });
 }
 
-type DBO = Exclude<Awaited<ReturnType<typeof dbGetLatestSubmissionVersion>>, null>;
+type UnpublishedThumbnailRow = Exclude<
+  Awaited<ReturnType<typeof dbGetLatestSubmissionVersion>>,
+  null
+>;
+
+type ThumbnailRow = PublishedThumbnailRow | UnpublishedThumbnailRow;
 
 export default async function loadSiteWorkThumbnail(
   ctx: SiteContext,
@@ -49,10 +54,7 @@ export default async function loadSiteWorkThumbnail(
   query?: string,
 ) {
   // TODO get a specific work version when versionId is provided
-  let dbo: DBO | PublishedDBO | null = await dbGetLatestPublishedSubmissionVersion(
-    ctx.site.name,
-    workIdOrSlug,
-  );
+  let dbo: ThumbnailRow | null = await dbGetPublishedThumbnailRow(ctx.site.id, workIdOrSlug);
   if (!dbo) {
     // there is no published version of this work
     // if the user is authorized, or we have a preview signature - then we can show them the thumbnail

--- a/packages/scms-server/src/backend/prisma.selects.server.ts
+++ b/packages/scms-server/src/backend/prisma.selects.server.ts
@@ -93,6 +93,12 @@ export const siteWorkDtoSelect = {
   submission: { select: siteWorkSubmissionSelect },
 } satisfies Prisma.SubmissionVersionSelect;
 
+/** Published thumbnail/social hot path — CDN fields only. */
+export const publishedThumbnailSelect = {
+  id: true,
+  work_version: { select: { id: true, work_id: true, cdn: true, cdn_key: true } },
+} satisfies Prisma.SubmissionVersionSelect;
+
 /**
  * Submission version rows formatted as SiteWorkDTO / SubmissionVersionDTO
  * (excludes submission-version metadata JSON).

--- a/packages/scms-server/src/backend/prisma.selects.server.ts
+++ b/packages/scms-server/src/backend/prisma.selects.server.ts
@@ -32,6 +32,21 @@ export const cdnWorkVersionSelect = {
   cdn_key: true,
 } satisfies Prisma.WorkVersionSelect;
 
+/**
+ * Submission relation fields read by `formatSiteWorkDTO` (excludes site graph and
+ * large kind/collection columns such as `checks` and unused scalars).
+ */
+export const siteWorkSubmissionSelect = {
+  id: true,
+  date_published: true,
+  kind: { select: { id: true, name: true, content: true, default: true } },
+  collection: {
+    select: { id: true, name: true, slug: true, workflow: true, content: true, open: true },
+  },
+  slugs: { where: { primary: true }, select: { slug: true, primary: true }, take: 1 },
+  work: { select: { doi: true, key: true } },
+} satisfies Prisma.SubmissionSelect;
+
 /** Activity feed refs — avoid full version payloads. */
 export const activitySubmissionVersionRefSelect = {
   id: true,
@@ -75,16 +90,7 @@ export const siteWorkDtoSelect = {
   id: true,
   tags: true,
   work_version: { select: siteWorkWorkVersionSelect },
-  submission: {
-    select: {
-      id: true,
-      date_published: true,
-      kind: true,
-      collection: true,
-      slugs: true,
-      work: true,
-    },
-  },
+  submission: { select: siteWorkSubmissionSelect },
 } satisfies Prisma.SubmissionVersionSelect;
 
 /**
@@ -102,14 +108,5 @@ export const submissionVersionForSiteWorkSelect = {
   tags: true,
   submitted_by: { select: { id: true, display_name: true } },
   work_version: { select: siteWorkWorkVersionSelect },
-  submission: {
-    select: {
-      id: true,
-      date_published: true,
-      kind: true,
-      collection: true,
-      slugs: true,
-      work: true,
-    },
-  },
+  submission: { select: siteWorkSubmissionSelect },
 } satisfies Prisma.SubmissionVersionSelect;

--- a/platform/scms/app/routes.ts
+++ b/platform/scms/app/routes.ts
@@ -254,7 +254,7 @@ export default [
           ),
           route(
             ':workIdOrSlug/published',
-            'routes/api/v1.sites.$siteName.works.$workIdOrSlug.published.tsx',
+            'routes/api/v1.sites.$siteName.works.$workIdOrSlug.published/route.tsx',
           ),
           route(
             ':workIdOrSlug/thumbnail',

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works.$workIdOrSlug.published/route.tsx
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works.$workIdOrSlug.published/route.tsx
@@ -1,4 +1,4 @@
-import type { Route } from './+types/v1.sites.$siteName.works.$workIdOrSlug.published';
+import type { Route } from './+types/route';
 import { httpError, MESSAGE_404 } from '@curvenote/scms-core';
 import { withSecureSiteContext, sites } from '@curvenote/scms-server';
 import {

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
@@ -148,9 +148,11 @@ function buildListingWhere(
  * Roots at `WorkVersion` via a UNION of single-predicate branches so each arm
  * can use its pg_trgm GIN index (`20260526223800`,
  * `20260610120000_add_work_version_affiliations_trgm_index`), then joins back
- * through `SubmissionVersion` to `Submission` scoped by `site_id`. The previous
- * correlated `EXISTS (… WHERE sv.submission_id = s.id …)` looped once per
- * submission on large sites (e.g. biorxiv) and dominated CPU under search load.
+ * through `SubmissionVersion` to `Submission` scoped by `site_id`. Only
+ * submission versions in the listing's requested `status` are considered (same
+ * as {@link fetchSubmissionIdsBySubject} and {@link buildListingWhere}), which
+ * avoids join fan-out on draft/unpublished history and keeps search aligned with
+ * the version shown in results.
  *
  * `immutable_array_to_string(authors, ' ')` and
  * `work_version_affiliations_search_text(metadata)` MUST match their expression
@@ -158,6 +160,7 @@ function buildListingWhere(
  */
 async function dbSearchSubmissionIds(
   siteId: string,
+  status: string,
   q: string,
   tx?: Prisma.TransactionClient,
 ): Promise<string[]> {
@@ -187,7 +190,9 @@ async function dbSearchSubmissionIds(
   const rows = await (tx ?? prisma).$queryRaw<{ id: string }[]>`
     SELECT DISTINCT s.id
     FROM (${matchingWorkVersions}) matching_wv
-    INNER JOIN "SubmissionVersion" sv ON sv.work_version_id = matching_wv.id
+    INNER JOIN "SubmissionVersion" sv
+      ON sv.work_version_id = matching_wv.id
+     AND sv.status = ${status}
     INNER JOIN "Submission" s ON s.id = sv.submission_id AND s.site_id = ${siteId}
   `;
   return rows.map((r) => r.id);
@@ -325,7 +330,7 @@ export async function dbListLatestPublishedSubmissions(
   // short-circuits.
   let searchIds: string[] | undefined;
   if (where?.q) {
-    searchIds = await dbSearchSubmissionIds(ctx.site.id, where.q);
+    searchIds = await dbSearchSubmissionIds(ctx.site.id, status, where.q);
   }
   let subjectIds: string[] | undefined;
   if (where?.subject) {

--- a/platform/scms/tests/integration/workflow/site-doi-resolve.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-doi-resolve.spec.ts
@@ -232,6 +232,14 @@ describe('sites.submissions.published.get — delivered package', () => {
     const dto = await sites.submissions.published.get(testData.context, uuidv7());
     expect(dto).toBeNull();
   });
+
+  test('does not resolve a work published on another site', async () => {
+    const otherSiteId = await createBareSite();
+    const seed = await seedPublishedWorkWithDoi(testData, { siteId: otherSiteId });
+
+    const dto = await sites.submissions.published.get(testData.context, seed.workId);
+    expect(dto).toBeNull();
+  });
 });
 
 /* ---------------------------------------------------------------------------

--- a/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
@@ -452,6 +452,53 @@ describe('site works listing — search / sort / date filters', () => {
     expect(dto.items).toHaveLength(0);
   });
 
+  test('q on a published listing ignores draft-only submission versions', async () => {
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'Draft work' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(0);
+    expect(dto.items).toHaveLength(0);
+  });
+
+  test('q on a published listing ignores unpublished version text on a resubmission', async () => {
+    const prisma = await getPrismaClient();
+    const now = new Date().toISOString();
+    const draftWorkVersionId = uuidv7();
+    await prisma.workVersion.create({
+      data: {
+        id: draftWorkVersionId,
+        date_created: now,
+        date_modified: now,
+        title: 'Unpublished resubmit title unique-xyz',
+        authors: [],
+        work: { connect: { id: seeds[0].workId } },
+      },
+    });
+    await prisma.submissionVersion.create({
+      data: {
+        id: uuidv7(),
+        date_created: now,
+        date_modified: now,
+        status: 'DRAFT',
+        submission: { connect: { id: seeds[0].submissionId } },
+        work_version: { connect: { id: draftWorkVersionId } },
+        submitted_by: { connect: { id: testData.userId } },
+      },
+    });
+
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'unique-xyz' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(0);
+    expect(dto.items).toHaveLength(0);
+  });
+
   test('subject filters to an exact case-insensitive metadata match', async () => {
     const dto = await listPublishedWorks(
       testData.context,

--- a/prisma/schema/migrations/20260612150000_add_published_versions_hot_path_index/migration.sql
+++ b/prisma/schema/migrations/20260612150000_add_published_versions_hot_path_index/migration.sql
@@ -1,0 +1,15 @@
+-- prisma-migrate-disable-next-transaction
+-- Partial index for published work resolve versions list
+-- (`dbGetPublishedVersionsForSubmission` in
+-- `packages/scms-server/src/backend/loaders/sites/submissions/published/get.server.ts`).
+--
+-- After resolving the latest published submission version, the handler loads all
+-- published versions for the same submission ordered by `date_created DESC`. A
+-- partial index on `status = 'PUBLISHED'` keeps the btree small and matches the
+-- filter predicate.
+
+SET statement_timeout = 0;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "SubmissionVersion_published_submission_date_created_idx"
+  ON "SubmissionVersion" (submission_id, date_created DESC)
+  WHERE status = 'PUBLISHED';


### PR DESCRIPTION
- **📦 Narrow siteWorkDtoSelect submission relations**
- **🐛 Restore published-date calendar URL sync on clear and single-day pick**
- **🔍 Scope works listing search to listing status**


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core published-article resolution and listing search semantics (including intentional cross-site null and status-filtered search); requires deploying the new partial index for full DB benefit.
> 
> **Overview**
> **Speeds up the theme hot path** for `GET …/works/:id/published` (and shared thumbnail/social loaders) by introducing `resolve.server.ts`: index-friendly raw SQL for work id vs slug, `site_id` scoping instead of `Site.name`, then `findUnique` with trimmed Prisma selects (`siteWorkDtoSelect`, `publishedThumbnailSelect`, shared `siteWorkSubmissionSelect`). The embedded **versions** query and cross-site behavior are tightened (`submission_id` + `site_id`; works published only elsewhere return null). A **partial index** on published `SubmissionVersion` rows backs the versions list ordering.
> 
> **Site works listing search** (`dbSearchSubmissionIds`) now joins only submission versions matching the listing **status**, so published `q` no longer matches draft-only or newer draft titles on resubmissions.
> 
> **Submissions date filter UI** syncs URL params on calendar clear, commits a single-day pick when the popover closes, and uses the shared draft-range helper.
> 
> Integration tests cover cross-site published resolve and status-scoped search; the published route file moves to a folder layout without changing cache headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3d88ed6f5f454abc511ea2e867faae89443fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->