### PR TITLE
🎂 finish baking the version popover

### DIFF
--- a/.changeset/version-timeline-hover-popovers.md
+++ b/.changeset/version-timeline-hover-popovers.md
@@ -1,0 +1,13 @@
+---
+'@curvenote/scms-core': minor
+'@curvenote/scms': minor
+'@curvenote/scms-sites-ext': minor
+---
+
+Add version timeline hover popovers on works and submissions listings.
+
+- **Works listing** — a Timeline control opens a lazy-loaded work-version timeline with created/modified dates, work version tags, and compact site chips for linked submission versions (status ring + inline tag).
+- **Submissions listing** — status badges, version tags, and published/retracted chips open the submission-version timeline (publication date, tag, status, activity line).
+- **Shared `@curvenote/scms-core` UI** — `VersionTimelineHoverCard`, row renderers, client cache/revalidate hook, and JSON URL helpers reused by both surfaces.
+- **Trimmed API payloads** — `/app/works/:workId/versions` and `/app/sites/:siteName/submissions/:submissionId/versions` return at most eight visible entries plus dashed gap markers when versions are omitted; a footer link opens the full timeline on the work details or submission detail page.
+- **Selection rules** — submission timelines prioritise published versions and the first significant (oldest published, else inaugural) version; work timelines always show the first work version and prefer versions with submission versions, then published submission versions.

--- a/ee/sites/package.json
+++ b/ee/sites/package.json
@@ -72,7 +72,7 @@
     "date-fns": "3.6.0",
     "doi-utils": "^2.0.5",
     "js-yaml": "^4.1.1",
-    "lucide-react": "^0.564.0",
+    "lucide-react": "^1.18.0",
     "myst-common": "^1.9.3",
     "myst-config": "^1.9.3",
     "myst-to-react": "^1.0.0",

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.spec.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.spec.ts
@@ -10,7 +10,7 @@ vi.mock('@curvenote/scms-server', async (importOriginal) => {
     getPrismaClient: vi.fn(),
     getConfiguredWorkflow: vi.fn(() => ({
       states: {
-        PUBLISHED: { label: 'Published' },
+        PUBLISHED: { label: 'Published', tags: ['end'] },
         IN_REVIEW: { label: 'In review' },
       },
     })),
@@ -79,6 +79,7 @@ describe('dbLoadSubmissionVersionsTimeline', () => {
         date_published: '2026-05-03T00:00:00.000Z',
         status: 'PUBLISHED',
         statusLabel: 'Published',
+        statusTags: ['end'],
         tag: 'v2',
       },
       {
@@ -88,6 +89,7 @@ describe('dbLoadSubmissionVersionsTimeline', () => {
         date_published: undefined,
         status: 'IN_REVIEW',
         statusLabel: 'In review',
+        statusTags: undefined,
         tag: 'v1',
       },
     ]);

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.spec.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.spec.ts
@@ -53,6 +53,7 @@ describe('dbLoadSubmissionVersionsTimeline', () => {
         {
           id: 'v-new',
           date_created: '2026-05-02T00:00:00.000Z',
+          date_modified: '2026-05-02T12:00:00.000Z',
           date_published: '2026-05-03T00:00:00.000Z',
           status: 'PUBLISHED',
           tags: ['v2'],
@@ -60,6 +61,7 @@ describe('dbLoadSubmissionVersionsTimeline', () => {
         {
           id: 'v-old',
           date_created: '2026-05-01T00:00:00.000Z',
+          date_modified: '2026-05-01T00:00:00.000Z',
           date_published: null,
           status: 'IN_REVIEW',
           tags: ['v1'],
@@ -73,6 +75,7 @@ describe('dbLoadSubmissionVersionsTimeline', () => {
       {
         id: 'v-new',
         date_created: '2026-05-02T00:00:00.000Z',
+        date_modified: '2026-05-02T12:00:00.000Z',
         date_published: '2026-05-03T00:00:00.000Z',
         status: 'PUBLISHED',
         statusLabel: 'Published',
@@ -81,6 +84,7 @@ describe('dbLoadSubmissionVersionsTimeline', () => {
       {
         id: 'v-old',
         date_created: '2026-05-01T00:00:00.000Z',
+        date_modified: '2026-05-01T00:00:00.000Z',
         date_published: undefined,
         status: 'IN_REVIEW',
         statusLabel: 'In review',
@@ -108,6 +112,7 @@ describe('dbLoadSubmissionVersionsTimeline', () => {
           select: {
             id: true,
             date_created: true,
+            date_modified: true,
             date_published: true,
             status: true,
             tags: true,

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.ts
@@ -4,6 +4,7 @@ import { firstVersionTag } from '../$siteName.submissions._index/index.versions.
 export type VersionTimelineEntry = {
   id: string;
   date_created: string;
+  date_modified: string;
   date_published?: string;
   status: string;
   statusLabel: string;
@@ -39,6 +40,7 @@ export async function dbLoadSubmissionVersionsTimeline(
         select: {
           id: true,
           date_created: true,
+          date_modified: true,
           date_published: true,
           status: true,
           tags: true,
@@ -56,6 +58,7 @@ export async function dbLoadSubmissionVersionsTimeline(
   return submission.versions.map((row) => ({
     id: row.id,
     date_created: row.date_created,
+    date_modified: row.date_modified,
     date_published: row.date_published ?? undefined,
     status: row.status,
     statusLabel: workflow.states[row.status]?.label ?? row.status,

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.ts
@@ -54,6 +54,7 @@ export async function dbLoadSubmissionVersionsTimeline(
     date_published: row.date_published ?? undefined,
     status: row.status,
     statusLabel: workflow.states[row.status]?.label ?? row.status,
+    statusTags: workflow.states[row.status]?.tags,
     tag: firstVersionTag(row),
   }));
 }

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.ts
@@ -1,15 +1,7 @@
 import { getConfiguredWorkflow, getPrismaClient, type SiteContext } from '@curvenote/scms-server';
 import { firstVersionTag } from '../$siteName.submissions._index/index.versions.server.js';
 
-export type VersionTimelineEntry = {
-  id: string;
-  date_created: string;
-  date_modified: string;
-  date_published?: string;
-  status: string;
-  statusLabel: string;
-  tag?: string;
-};
+import type { VersionTimelineEntry } from '@curvenote/scms-core';
 
 /**
  * All submission versions for the version-timeline hover card (newest first).

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/route.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/route.ts
@@ -1,7 +1,11 @@
 import type { LoaderFunctionArgs } from 'react-router';
 import { data } from 'react-router';
 import { withAppSiteContext } from '@curvenote/scms-server';
-import { site as siteScopes } from '@curvenote/scms-core';
+import {
+  site as siteScopes,
+  submissionVersionsSeeAllUrl,
+  trimSubmissionVersionTimeline,
+} from '@curvenote/scms-core';
 import { dbLoadSubmissionVersionsTimeline } from './db.server.js';
 
 /**
@@ -9,7 +13,7 @@ import { dbLoadSubmissionVersionsTimeline } from './db.server.js';
  *
  * JSON-only, no default export. Contract:
  *   GET /app/sites/:siteName/submissions/:submissionId/versions
- *     200 -> { versions: VersionTimelineEntry[] }   (newest first)
+ *     200 -> TrimmedVersionTimeline<VersionTimelineEntry>   (newest first, max 8 visible)
  *     400 -> { error }                              (missing route param)
  *     401/403 -> auth/scope failure (NOT a redirect — see below)
  *     404 -> { error: 'Submission not found' }      (cross-site or unknown id)
@@ -25,8 +29,9 @@ import { dbLoadSubmissionVersionsTimeline } from './db.server.js';
 export async function loader(args: LoaderFunctionArgs) {
   const ctx = await withAppSiteContext(args, [siteScopes.submissions.list]);
 
+  const siteName = args.params.siteName;
   const submissionId = args.params.submissionId;
-  if (!submissionId) {
+  if (!siteName || !submissionId) {
     return data({ error: 'Missing submission id' }, { status: 400 });
   }
 
@@ -35,5 +40,7 @@ export async function loader(args: LoaderFunctionArgs) {
     return data({ error: 'Submission not found' }, { status: 404 });
   }
 
-  return data({ versions });
+  return data(
+    trimSubmissionVersionTimeline(versions, submissionVersionsSeeAllUrl(siteName, submissionId)),
+  );
 }

--- a/ee/sites/src/routes/$siteName.submissions._index/SubmissionsListItem.tsx
+++ b/ee/sites/src/routes/$siteName.submissions._index/SubmissionsListItem.tsx
@@ -1,5 +1,10 @@
 import { Link } from 'react-router';
-import { summarizeAuthors, ui, VersionTimelineHoverCard } from '@curvenote/scms-core';
+import {
+  summarizeAuthors,
+  ui,
+  SubmissionVersionTimelineHoverCard,
+  submissionVersionsTimelineUrl,
+} from '@curvenote/scms-core';
 import {
   Collection,
   HasPublishedVersion,
@@ -10,7 +15,6 @@ import type { SubmissionsIndexItem } from './types.js';
 import { DoiBadge } from './DoiBadge.js';
 import { SubmissionListingDates } from './SubmissionListingDates.js';
 import { SubmissionStatusBadge } from './SubmissionStatusBadge.js';
-import { submissionVersionsTimelineUrl } from '../../submissionVersionsTimelineUrl.js';
 
 const AUTHORS_MAX_DISPLAY = 5;
 
@@ -62,27 +66,27 @@ export function SubmissionsListItem({
               />
             ) : null}
             {item.publishedVersion ? (
-              <VersionTimelineHoverCard versionsUrl={versionsUrl}>
+              <SubmissionVersionTimelineHoverCard versionsUrl={versionsUrl}>
                 <HasPublishedVersion date={item.publishedVersion.date_created} disableTooltip />
-              </VersionTimelineHoverCard>
+              </SubmissionVersionTimelineHoverCard>
             ) : null}
             {!item.publishedVersion && item.retractedVersion ? (
-              <VersionTimelineHoverCard versionsUrl={versionsUrl}>
+              <SubmissionVersionTimelineHoverCard versionsUrl={versionsUrl}>
                 <HasRetractedVersion date={item.retractedVersion.date_created} disableTooltip />
-              </VersionTimelineHoverCard>
+              </SubmissionVersionTimelineHoverCard>
             ) : null}
             {item.versionTag ? (
-              <VersionTimelineHoverCard versionsUrl={versionsUrl}>
+              <SubmissionVersionTimelineHoverCard versionsUrl={versionsUrl}>
                 <ui.VersionTagBadge tag={item.versionTag} disableTooltip />
-              </VersionTimelineHoverCard>
+              </SubmissionVersionTimelineHoverCard>
             ) : null}
             {item.doi ? <DoiBadge doi={item.doi} /> : null}
           </div>
         </div>
         <div className="flex shrink-0 items-center justify-start sm:w-[200px] sm:justify-center">
-          <VersionTimelineHoverCard versionsUrl={versionsUrl} align="end">
+          <SubmissionVersionTimelineHoverCard versionsUrl={versionsUrl} align="end">
             <SubmissionStatusBadge status={item.status} label={item.statusLabel} />
-          </VersionTimelineHoverCard>
+          </SubmissionVersionTimelineHoverCard>
         </div>
       </div>
       <SubmissionListingDates

--- a/ee/sites/src/routes/$siteName.submissions._index/SubmissionsListItem.tsx
+++ b/ee/sites/src/routes/$siteName.submissions._index/SubmissionsListItem.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router';
-import { summarizeAuthors, ui } from '@curvenote/scms-core';
+import { summarizeAuthors, ui, VersionTimelineHoverCard } from '@curvenote/scms-core';
 import {
   Collection,
   HasPublishedVersion,
@@ -10,7 +10,7 @@ import type { SubmissionsIndexItem } from './types.js';
 import { DoiBadge } from './DoiBadge.js';
 import { SubmissionListingDates } from './SubmissionListingDates.js';
 import { SubmissionStatusBadge } from './SubmissionStatusBadge.js';
-import { VersionTimelineHoverCard } from './VersionTimelineHoverCard.js';
+import { submissionVersionsTimelineUrl } from '../../submissionVersionsTimelineUrl.js';
 
 const AUTHORS_MAX_DISPLAY = 5;
 
@@ -29,6 +29,7 @@ export function SubmissionsListItem({
 }: SubmissionsListItemProps) {
   const authorSummary = summarizeAuthors(item.authors, { maxDisplay: AUTHORS_MAX_DISPLAY });
   const fullAuthorList = item.authors.map((author) => author.name).join(', ');
+  const versionsUrl = submissionVersionsTimelineUrl(siteName, item.id);
 
   return (
     <div className="border-b border-gray-200 px-5 py-4 last:border-b-0 dark:border-gray-700">
@@ -61,17 +62,17 @@ export function SubmissionsListItem({
               />
             ) : null}
             {item.publishedVersion ? (
-              <VersionTimelineHoverCard siteName={siteName} submissionId={item.id}>
+              <VersionTimelineHoverCard versionsUrl={versionsUrl}>
                 <HasPublishedVersion date={item.publishedVersion.date_created} disableTooltip />
               </VersionTimelineHoverCard>
             ) : null}
             {!item.publishedVersion && item.retractedVersion ? (
-              <VersionTimelineHoverCard siteName={siteName} submissionId={item.id}>
+              <VersionTimelineHoverCard versionsUrl={versionsUrl}>
                 <HasRetractedVersion date={item.retractedVersion.date_created} disableTooltip />
               </VersionTimelineHoverCard>
             ) : null}
             {item.versionTag ? (
-              <VersionTimelineHoverCard siteName={siteName} submissionId={item.id}>
+              <VersionTimelineHoverCard versionsUrl={versionsUrl}>
                 <ui.VersionTagBadge tag={item.versionTag} disableTooltip />
               </VersionTimelineHoverCard>
             ) : null}
@@ -79,7 +80,7 @@ export function SubmissionsListItem({
           </div>
         </div>
         <div className="flex shrink-0 items-center justify-start sm:w-[200px] sm:justify-center">
-          <VersionTimelineHoverCard siteName={siteName} submissionId={item.id} align="end">
+          <VersionTimelineHoverCard versionsUrl={versionsUrl} align="end">
             <SubmissionStatusBadge status={item.status} label={item.statusLabel} />
           </VersionTimelineHoverCard>
         </div>

--- a/ee/sites/src/routes/$siteName.submissions._index/SubmissionsListItem.tsx
+++ b/ee/sites/src/routes/$siteName.submissions._index/SubmissionsListItem.tsx
@@ -18,6 +18,8 @@ import { SubmissionStatusBadge } from './SubmissionStatusBadge.js';
 
 const AUTHORS_MAX_DISPLAY = 5;
 
+const SUBMISSION_TIMELINE_TITLE = 'Submissions';
+
 interface SubmissionsListItemProps {
   siteName: string;
   item: SubmissionsIndexItem;
@@ -66,17 +68,26 @@ export function SubmissionsListItem({
               />
             ) : null}
             {item.publishedVersion ? (
-              <SubmissionVersionTimelineHoverCard versionsUrl={versionsUrl}>
+              <SubmissionVersionTimelineHoverCard
+                versionsUrl={versionsUrl}
+                title={SUBMISSION_TIMELINE_TITLE}
+              >
                 <HasPublishedVersion date={item.publishedVersion.date_created} disableTooltip />
               </SubmissionVersionTimelineHoverCard>
             ) : null}
             {!item.publishedVersion && item.retractedVersion ? (
-              <SubmissionVersionTimelineHoverCard versionsUrl={versionsUrl}>
+              <SubmissionVersionTimelineHoverCard
+                versionsUrl={versionsUrl}
+                title={SUBMISSION_TIMELINE_TITLE}
+              >
                 <HasRetractedVersion date={item.retractedVersion.date_created} disableTooltip />
               </SubmissionVersionTimelineHoverCard>
             ) : null}
             {item.versionTag ? (
-              <SubmissionVersionTimelineHoverCard versionsUrl={versionsUrl}>
+              <SubmissionVersionTimelineHoverCard
+                versionsUrl={versionsUrl}
+                title={SUBMISSION_TIMELINE_TITLE}
+              >
                 <ui.VersionTagBadge tag={item.versionTag} disableTooltip />
               </SubmissionVersionTimelineHoverCard>
             ) : null}
@@ -84,7 +95,11 @@ export function SubmissionsListItem({
           </div>
         </div>
         <div className="flex shrink-0 items-center justify-start sm:w-[200px] sm:justify-center">
-          <SubmissionVersionTimelineHoverCard versionsUrl={versionsUrl} align="end">
+          <SubmissionVersionTimelineHoverCard
+            versionsUrl={versionsUrl}
+            align="end"
+            title={SUBMISSION_TIMELINE_TITLE}
+          >
             <SubmissionStatusBadge status={item.status} label={item.statusLabel} />
           </SubmissionVersionTimelineHoverCard>
         </div>

--- a/ee/sites/src/routes/$siteName.submissions._index/VersionTimelineHoverCard.tsx
+++ b/ee/sites/src/routes/$siteName.submissions._index/VersionTimelineHoverCard.tsx
@@ -5,7 +5,6 @@ import {
   cn,
   formatDate,
   formatDatetime,
-  formatToNow,
   getStatusButtonClasses,
   getStatusDotClasses,
   ui,
@@ -42,7 +41,38 @@ function TimelineSkeleton() {
   );
 }
 
+function PublishedDate({ datePublished }: { datePublished?: string }) {
+  if (datePublished) {
+    return (
+      <ui.Tooltip>
+        <ui.TooltipTrigger asChild>
+          <time className="text-xs font-medium text-foreground" dateTime={datePublished}>
+            {formatDate(datePublished)}
+          </time>
+        </ui.TooltipTrigger>
+        <ui.TooltipContent sideOffset={4}>
+          Publication date · {formatDatetime(datePublished)}
+        </ui.TooltipContent>
+      </ui.Tooltip>
+    );
+  }
+
+  return (
+    <ui.Tooltip>
+      <ui.TooltipTrigger asChild>
+        <span className="text-xs font-normal text-muted-foreground">no publication date</span>
+      </ui.TooltipTrigger>
+      <ui.TooltipContent sideOffset={4}>
+        Publication date — no publication date for this version
+      </ui.TooltipContent>
+    </ui.Tooltip>
+  );
+}
+
 function TimelineRow({ entry }: { entry: VersionTimelineEntry }) {
+  const activityDate = entry.date_modified ?? entry.date_created;
+  const activityPrefix = entry.date_modified ? 'Updated' : 'Created';
+
   return (
     <div className="flex relative gap-3">
       <span
@@ -54,13 +84,7 @@ function TimelineRow({ entry }: { entry: VersionTimelineEntry }) {
       />
       <div className="flex-1 space-y-1 min-w-0">
         <div className="flex flex-wrap gap-y-1 gap-x-2 items-center">
-          <time
-            className="text-xs font-medium text-foreground"
-            dateTime={entry.date_created}
-            title={formatDatetime(entry.date_created)}
-          >
-            {formatDate(entry.date_created)}
-          </time>
+          <PublishedDate datePublished={entry.date_published} />
           {entry.tag ? (
             <ui.VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
           ) : null}
@@ -73,11 +97,9 @@ function TimelineRow({ entry }: { entry: VersionTimelineEntry }) {
             {entry.statusLabel}
           </span>
         </div>
-        {entry.date_published ? (
-          <p className="text-[11px] text-muted-foreground">
-            Published {formatToNow(entry.date_published, { addSuffix: true })}
-          </p>
-        ) : null}
+        <p className="text-[11px] text-muted-foreground" title={formatDatetime(activityDate)}>
+          {activityPrefix}: {formatDate(activityDate)}
+        </p>
       </div>
     </div>
   );

--- a/ee/sites/src/submissionVersionsTimelineUrl.ts
+++ b/ee/sites/src/submissionVersionsTimelineUrl.ts
@@ -1,4 +1,0 @@
-/** JSON resource route for the shared {@link @curvenote/scms-core#VersionTimelineHoverCard}. */
-export function submissionVersionsTimelineUrl(siteName: string, submissionId: string) {
-  return `/app/sites/${encodeURIComponent(siteName)}/submissions/${encodeURIComponent(submissionId)}/versions`;
-}

--- a/ee/sites/src/submissionVersionsTimelineUrl.ts
+++ b/ee/sites/src/submissionVersionsTimelineUrl.ts
@@ -1,0 +1,4 @@
+/** JSON resource route for the shared {@link @curvenote/scms-core#VersionTimelineHoverCard}. */
+export function submissionVersionsTimelineUrl(siteName: string, submissionId: string) {
+  return `/app/sites/${encodeURIComponent(siteName)}/submissions/${encodeURIComponent(submissionId)}/versions`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "date-fns": "3.6.0",
         "doi-utils": "^2.0.5",
         "js-yaml": "^4.1.1",
-        "lucide-react": "^0.564.0",
+        "lucide-react": "^1.18.0",
         "myst-common": "^1.9.3",
         "myst-config": "^1.9.3",
         "myst-to-react": "^1.0.0",
@@ -5050,6 +5050,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+      "integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
@@ -5190,6 +5207,23 @@
       "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
       "cpu": [
         "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+      "integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+      "cpu": [
+        "loong64"
       ],
       "dev": true,
       "license": "MIT",
@@ -6622,6 +6656,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jest/schemas": {
@@ -10180,6 +10226,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@rgrove/parse-xml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@rgrove/parse-xml/-/parse-xml-4.2.0.tgz",
+      "integrity": "sha512-UuBOt7BOsKVOkFXRe4Ypd/lADuNIfqJXv8GvHqtXaTYXPPKkj2nS2zPllVsrtRjcomDhIJVBnZwfmlI222WH8g==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@rjsf/utils": {
       "version": "5.24.13",
       "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.24.13.tgz",
@@ -12842,6 +12897,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2-sftp-client": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-sftp-client/-/ssh2-sftp-client-9.0.6.tgz",
+      "integrity": "sha512-4+KvXO/V77y9VjI2op2T8+RCGI/GXQAwR0q5Qkj/EJ5YSeyKszqZP6F8i3H3txYoBqjc7sgorqyvBP3+w1EHyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ssh2": "^1.0.0"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/supports-color": {
       "version": "8.1.3",
       "license": "MIT"
@@ -12891,6 +12983,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/xast": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/xast/-/xast-2.0.4.tgz",
+      "integrity": "sha512-6Q6HWhHXR5EEKcxgF5YBW5XPAAtCi/GgyCWHx6wR7dZTXF5rv2B2fm0hgpSscJqaVDVm6n1DAVbsM8RSM5PlMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -14703,7 +14804,6 @@
     },
     "node_modules/asn1": {
       "version": "0.2.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
@@ -14984,7 +15084,6 @@
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
@@ -15296,6 +15395,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/builtins": {
@@ -16590,6 +16698,21 @@
       "version": "0.0.1",
       "license": "MIT"
     },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/concurrently": {
       "version": "9.2.1",
       "dev": true,
@@ -16785,6 +16908,20 @@
       "license": "MIT",
       "dependencies": {
         "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/cpx": {
@@ -17307,6 +17444,22 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/css-selector-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
+      "integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -18988,6 +19141,346 @@
         "@esbuild/win32-arm64": "0.28.0",
         "@esbuild/win32-ia32": "0.28.0",
         "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/esbuild-android-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+      "integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+      "integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+      "integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+      "integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+      "integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+      "integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+      "integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+      "integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+      "integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+      "integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+      "integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+      "integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+      "integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+      "integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+      "integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+      "integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+      "integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+      "integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+      "integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+      "integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
@@ -25889,9 +26382,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.564.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.564.0.tgz",
-      "integrity": "sha512-JJ8GVTQqFwuliifD48U6+h7DXEHdkhJ/E87kksGByII3qHxtPciVb8T8woQONHBQgHVOl7rSMrrip3SeVNy7Fg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.18.0.tgz",
+      "integrity": "sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -27789,7 +28282,6 @@
     },
     "node_modules/nan": {
       "version": "2.25.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -30375,6 +30867,279 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pmc-node-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pmc-node-utils/-/pmc-node-utils-0.3.1.tgz",
+      "integrity": "sha512-ofCqphRccMNw32sugWWU3BMNnj7Yis3XkNRntq2+SfpQy60pji28tlhwrnxW/cZuWVpVGuHg6k241X0Lv60SQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/xast": "^2.0.4",
+        "adm-zip": "^0.5.10",
+        "chalk": "^5.3.0",
+        "commander": "^11.1.0",
+        "css-selector-parser": "^3.0.5",
+        "doi-utils": "^2.0.3",
+        "inquirer": "^9.2.23",
+        "js-yaml": "^4.1.0",
+        "myst-cli": "^1.3.1",
+        "myst-cli-utils": "^2.0.10",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
+        "myst-to-jats": "^1.0.27",
+        "nanoid": "^5.0.9",
+        "pmc-utils": "0.3.1",
+        "tar": "^7.4.3",
+        "unist-builder": "^4.0.0",
+        "unist-util-select": "^5.1.0",
+        "unist-util-visit": "^5.0.0",
+        "uuid": "^10.0.0",
+        "vfile": "^5.0.0",
+        "which": "^4.0.0",
+        "xast-util-to-xml": "^4.0.0",
+        "zod": "^3.23.8"
+      },
+      "bin": {
+        "pmc": "dist/pmc.cjs"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-builder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-4.0.0.tgz",
+      "integrity": "sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-util-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-5.1.0.tgz",
+      "integrity": "sha512-4A5mfokSHG/rNQ4g7gSbdEs+H586xyd24sdJqF1IWamqrLHvYb+DH48fzxowyOhOfK7YSqX+XlCojAyuuyyT2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.1.0",
+        "nth-check": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pmc-node-utils/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/pmc-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pmc-utils/-/pmc-utils-0.3.1.tgz",
+      "integrity": "sha512-ri9DmmEf4375ES9+xjLqdfX4Y++QzBVfXkSgsrepBmYVnoF4j8CJy/Cqt/0gcLWjWaB2Ilih7v83yJP3+Vdj3w==",
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "^0.5.10",
+        "css-selector-parser": "^3.0.5",
+        "doi-utils": "^2.0.3",
+        "js-yaml": "^4.1.0",
+        "myst-common": "^1.5.1",
+        "myst-frontmatter": "^1.5.1",
+        "myst-to-jats": "^1.0.27",
+        "nanoid": "^5.0.9",
+        "unist-builder": "^4.0.0",
+        "unist-util-select": "^5.1.0",
+        "unist-util-visit": "^5.0.0",
+        "uuid": "^10.0.0",
+        "xast-util-from-xml": "^4.0.0",
+        "xast-util-to-xml": "^4.0.0",
+        "xml-formatter": "^3.6.3",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-builder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-4.0.0.tgz",
+      "integrity": "sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-util-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-5.1.0.tgz",
+      "integrity": "sha512-4A5mfokSHG/rNQ4g7gSbdEs+H586xyd24sdJqF1IWamqrLHvYb+DH48fzxowyOhOfK7YSqX+XlCojAyuuyyT2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.1.0",
+        "nth-check": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/pmc-utils/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/points-on-curve": {
@@ -33449,6 +34214,40 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
+    "node_modules/ssh2-sftp-client": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-12.1.1.tgz",
+      "integrity": "sha512-wYVDgwkpcKG2iPGQQ+QR33xkWqLFIaVrYvA+uON4pmxTPaPuB81f1aooUEPN75e/9DCK6rrKYXb6zR6zP3+EtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "concat-stream": "^2.0.0",
+        "ssh2": "^1.16.0"
+      },
+      "engines": {
+        "node": ">=18.20.4"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://square.link/u/4g7sPflL"
+      }
+    },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "dev": true,
@@ -34351,6 +35150,52 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/teeny-request": {
@@ -36095,7 +36940,6 @@
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
-      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/type-check": {
@@ -38994,6 +39838,64 @@
         }
       }
     },
+    "node_modules/xast-util-from-xml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xast-util-from-xml/-/xast-util-from-xml-4.0.0.tgz",
+      "integrity": "sha512-Pwj6Bw5XARduMeTWpeEfmfgT8/Ma3oiMI4bBIRzCd7GH26A/dn3x7jDc2BHBCQxxdQniTh0MjVUYbjaj4Ljb+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@rgrove/parse-xml": "^4.1.0",
+        "@types/xast": "^2.0.0",
+        "vfile-location": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/xast-util-from-xml/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/xast-util-from-xml/node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/xast-util-to-xml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xast-util-to-xml/-/xast-util-to-xml-4.0.0.tgz",
+      "integrity": "sha512-r1euIWS5yZJUNpfN+ReE4m7Vld2iytaOPJtuXVuRQacRZwqRN1MAb+dv0aGLrdXOZrpGLyvUFf1Upyrb3R5qBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/xast": "^2.0.0",
+        "ccount": "^2.0.0",
+        "stringify-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/xdg-app-paths": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
@@ -39030,6 +39932,18 @@
       "version": "1.0.1",
       "license": "MIT"
     },
+    "node_modules/xml-formatter": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/xml-formatter/-/xml-formatter-3.7.0.tgz",
+      "integrity": "sha512-+8qTc3zv2UcJ1v9IsSIce37Dl4MQG14Cp7tWrwmy202UaI1wqRukw5QMX1JHsV+DX64yw77EgGsj2s5wGvuMbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-parser-xo": "^4.1.5"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/xml-js": {
       "version": "1.6.11",
       "license": "MIT",
@@ -39045,6 +39959,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xml-parser-xo": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/xml-parser-xo/-/xml-parser-xo-4.1.6.tgz",
+      "integrity": "sha512-mXbSNSM+rIwndoxSwmFa83bOdeP8G/cOGr7XvxA67X7ebCzoAuVez9JYDCDub3zRDNBZxIbfjuXLSsamr7NfwQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/xmlchars": {
@@ -40199,7 +41122,7 @@
         "firebase": "^12.5.0",
         "firebase-admin": "^13.5.0",
         "js-yaml": "^4.1.1",
-        "lucide-react": "^0.564.0",
+        "lucide-react": "^1.18.0",
         "md5": "^2.3.0",
         "mermaid": "^11.10.0",
         "myst-to-react": "^1.3.0",
@@ -41690,7 +42613,7 @@
         "isbot": "^5",
         "js-yaml": "^4.1.1",
         "jsonwebtoken": "^9.0.3",
-        "lucide-react": "^0.564.0",
+        "lucide-react": "^1.18.0",
         "myst-to-react": "^0.17.1",
         "nprogress": "^0.2.0",
         "officeparser": "^6.0.4",

--- a/packages/scms-core/package.json
+++ b/packages/scms-core/package.json
@@ -98,7 +98,7 @@
     "firebase": "^12.5.0",
     "firebase-admin": "^13.5.0",
     "js-yaml": "^4.1.1",
-    "lucide-react": "^0.564.0",
+    "lucide-react": "^1.18.0",
     "md5": "^2.3.0",
     "mermaid": "^11.10.0",
     "myst-to-react": "^1.3.0",

--- a/packages/scms-core/src/components/SubmissionVersionSiteChip.tsx
+++ b/packages/scms-core/src/components/SubmissionVersionSiteChip.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router';
 import type { WorkVersionTimelineSubmissionVersion } from '../types/versionTimeline.js';
+import { formatDatetime } from '../utils/formatDate.js';
 import { cn } from '../utils/cn.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js';
 
@@ -100,6 +101,12 @@ export function SubmissionVersionSiteChip({
         <span className="font-medium">{siteLabel}</span>
         <span className="text-muted-foreground"> · {submissionVersion.statusLabel}</span>
         {tag ? <span className="text-muted-foreground"> · {tag}</span> : null}
+        {submissionVersion.date_published ? (
+          <span className="text-muted-foreground">
+            {' '}
+            · Publication date · {formatDatetime(submissionVersion.date_published)}
+          </span>
+        ) : null}
       </TooltipContent>
     </Tooltip>
   );

--- a/packages/scms-core/src/components/SubmissionVersionSiteChip.tsx
+++ b/packages/scms-core/src/components/SubmissionVersionSiteChip.tsx
@@ -83,6 +83,9 @@ export function SubmissionVersionSiteChip({
       <TooltipContent sideOffset={4}>
         <span className="font-medium">{siteLabel}</span>
         <span className="text-muted-foreground"> · {submissionVersion.statusLabel}</span>
+        {submissionVersion.tag ? (
+          <span className="text-muted-foreground"> · {submissionVersion.tag}</span>
+        ) : null}
       </TooltipContent>
     </Tooltip>
   );

--- a/packages/scms-core/src/components/SubmissionVersionSiteChip.tsx
+++ b/packages/scms-core/src/components/SubmissionVersionSiteChip.tsx
@@ -1,0 +1,89 @@
+import { Link } from 'react-router';
+import type { WorkVersionTimelineSubmissionVersion } from '../types/versionTimeline.js';
+import { cn } from '../utils/cn.js';
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js';
+
+function getStatusRingClasses(statusTags?: string[]) {
+  if (!statusTags?.length) {
+    return 'ring-border bg-muted/40';
+  }
+
+  const hasEnd = statusTags.includes('end');
+  const hasError = statusTags.includes('error');
+  const hasWarning = statusTags.includes('warning');
+
+  if (hasError) {
+    return 'ring-red-500 bg-red-50 dark:bg-red-950/40 dark:ring-red-400';
+  }
+  if (hasWarning) {
+    return 'ring-orange-500 bg-orange-50 dark:bg-orange-950/40 dark:ring-orange-400';
+  }
+  if (hasEnd && !hasError && !hasWarning) {
+    return 'ring-green-600 bg-green-50 dark:bg-green-950/40 dark:ring-green-500';
+  }
+
+  return 'ring-border bg-muted/40';
+}
+
+function SiteMark({ site }: { site: WorkVersionTimelineSubmissionVersion['site'] }) {
+  if (site.logo) {
+    return <img src={site.logo} alt="" className="object-contain rounded-sm size-4" aria-hidden />;
+  }
+
+  return (
+    <span
+      className="flex justify-center items-center rounded-sm size-4 text-[9px] font-semibold uppercase bg-background text-muted-foreground"
+      aria-hidden
+    >
+      {site.name.slice(0, 1)}
+    </span>
+  );
+}
+
+export function SubmissionVersionSiteChip({
+  submissionVersion,
+  workId,
+}: {
+  submissionVersion: WorkVersionTimelineSubmissionVersion;
+  workId?: string;
+}) {
+  const siteLabel = submissionVersion.site.title || submissionVersion.site.name;
+  const href = workId
+    ? `/app/works/${workId}/site/${submissionVersion.site.name}/submission/${submissionVersion.id}`
+    : undefined;
+
+  const chip = (
+    <span
+      className={cn(
+        'inline-flex shrink-0 items-center justify-center rounded-full p-0.5 ring-2 ring-offset-1 ring-offset-popover',
+        getStatusRingClasses(submissionVersion.statusTags),
+        href && 'transition-opacity hover:opacity-80',
+      )}
+    >
+      <SiteMark site={submissionVersion.site} />
+    </span>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {href ? (
+          <Link
+            to={href}
+            className="inline-flex"
+            aria-label={`${siteLabel}: ${submissionVersion.statusLabel}`}
+            onClick={(event) => event.stopPropagation()}
+          >
+            {chip}
+          </Link>
+        ) : (
+          <span className="inline-flex cursor-default">{chip}</span>
+        )}
+      </TooltipTrigger>
+      <TooltipContent sideOffset={4}>
+        <span className="font-medium">{siteLabel}</span>
+        <span className="text-muted-foreground"> · {submissionVersion.statusLabel}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/scms-core/src/components/SubmissionVersionSiteChip.tsx
+++ b/packages/scms-core/src/components/SubmissionVersionSiteChip.tsx
@@ -1,30 +1,9 @@
 import { Link } from 'react-router';
 import type { WorkVersionTimelineSubmissionVersion } from '../types/versionTimeline.js';
 import { formatDatetime } from '../utils/formatDate.js';
+import { getStatusRingClasses } from '../utils/status.js';
 import { cn } from '../utils/cn.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js';
-
-function getStatusRingClasses(statusTags?: string[]) {
-  if (!statusTags?.length) {
-    return 'ring-border bg-muted/40';
-  }
-
-  const hasEnd = statusTags.includes('end');
-  const hasError = statusTags.includes('error');
-  const hasWarning = statusTags.includes('warning');
-
-  if (hasError) {
-    return 'ring-red-500 bg-red-50 dark:bg-red-950/40 dark:ring-red-400';
-  }
-  if (hasWarning) {
-    return 'ring-orange-500 bg-orange-50 dark:bg-orange-950/40 dark:ring-orange-400';
-  }
-  if (hasEnd && !hasError && !hasWarning) {
-    return 'ring-green-600 bg-green-50 dark:bg-green-950/40 dark:ring-green-500';
-  }
-
-  return 'ring-border bg-muted/40';
-}
 
 function SiteMark({ site }: { site: WorkVersionTimelineSubmissionVersion['site'] }) {
   if (site.logo) {

--- a/packages/scms-core/src/components/SubmissionVersionSiteChip.tsx
+++ b/packages/scms-core/src/components/SubmissionVersionSiteChip.tsx
@@ -59,8 +59,8 @@ export function SubmissionVersionSiteChip({
   const chip = (
     <span
       className={cn(
-        'inline-flex shrink-0 items-center justify-center gap-1 rounded-md ring-2 ring-offset-1 ring-offset-popover',
-        tag ? 'px-1 py-0.5' : 'p-1',
+        'inline-flex h-4 shrink-0 items-center justify-center gap-0.5 rounded-md ring-2',
+        tag ? 'px-1' : 'px-0.5',
         getStatusRingClasses(submissionVersion.statusTags),
         href && 'transition-opacity hover:opacity-80',
       )}
@@ -68,10 +68,8 @@ export function SubmissionVersionSiteChip({
       <SiteMark site={submissionVersion.site} />
       {tag ? (
         <>
-          <span className="w-px self-stretch my-0.5 bg-border/80 shrink-0" aria-hidden />
-          <span className="text-[10px] font-mono leading-none text-foreground/90 pr-0.5">
-            {tag}
-          </span>
+          <span className="w-px h-3 bg-border/80 shrink-0" aria-hidden />
+          <span className="text-[10px] font-mono leading-4 text-foreground/90">{tag}</span>
         </>
       ) : null}
     </span>
@@ -87,14 +85,14 @@ export function SubmissionVersionSiteChip({
         {href ? (
           <Link
             to={href}
-            className="inline-flex"
+            className="inline-flex items-center"
             aria-label={ariaLabel}
             onClick={(event) => event.stopPropagation()}
           >
             {chip}
           </Link>
         ) : (
-          <span className="inline-flex cursor-default">{chip}</span>
+          <span className="inline-flex items-center cursor-default">{chip}</span>
         )}
       </TooltipTrigger>
       <TooltipContent sideOffset={4}>

--- a/packages/scms-core/src/components/SubmissionVersionSiteChip.tsx
+++ b/packages/scms-core/src/components/SubmissionVersionSiteChip.tsx
@@ -27,12 +27,14 @@ function getStatusRingClasses(statusTags?: string[]) {
 
 function SiteMark({ site }: { site: WorkVersionTimelineSubmissionVersion['site'] }) {
   if (site.logo) {
-    return <img src={site.logo} alt="" className="object-contain rounded-sm size-4" aria-hidden />;
+    return (
+      <img src={site.logo} alt="" className="object-contain size-4 max-w-4 max-h-4" aria-hidden />
+    );
   }
 
   return (
     <span
-      className="flex justify-center items-center rounded-sm size-4 text-[9px] font-semibold uppercase bg-background text-muted-foreground"
+      className="flex justify-center items-center size-4 text-[9px] font-semibold uppercase text-muted-foreground"
       aria-hidden
     >
       {site.name.slice(0, 1)}
@@ -48,6 +50,7 @@ export function SubmissionVersionSiteChip({
   workId?: string;
 }) {
   const siteLabel = submissionVersion.site.title || submissionVersion.site.name;
+  const tag = submissionVersion.tag;
   const href = workId
     ? `/app/works/${workId}/site/${submissionVersion.site.name}/submission/${submissionVersion.id}`
     : undefined;
@@ -55,14 +58,27 @@ export function SubmissionVersionSiteChip({
   const chip = (
     <span
       className={cn(
-        'inline-flex shrink-0 items-center justify-center rounded-full p-0.5 ring-2 ring-offset-1 ring-offset-popover',
+        'inline-flex shrink-0 items-center justify-center gap-1 rounded-md ring-2 ring-offset-1 ring-offset-popover',
+        tag ? 'px-1 py-0.5' : 'p-1',
         getStatusRingClasses(submissionVersion.statusTags),
         href && 'transition-opacity hover:opacity-80',
       )}
     >
       <SiteMark site={submissionVersion.site} />
+      {tag ? (
+        <>
+          <span className="w-px self-stretch my-0.5 bg-border/80 shrink-0" aria-hidden />
+          <span className="text-[10px] font-mono leading-none text-foreground/90 pr-0.5">
+            {tag}
+          </span>
+        </>
+      ) : null}
     </span>
   );
+
+  const ariaLabel = tag
+    ? `${siteLabel}: ${submissionVersion.statusLabel}, ${tag}`
+    : `${siteLabel}: ${submissionVersion.statusLabel}`;
 
   return (
     <Tooltip>
@@ -71,7 +87,7 @@ export function SubmissionVersionSiteChip({
           <Link
             to={href}
             className="inline-flex"
-            aria-label={`${siteLabel}: ${submissionVersion.statusLabel}`}
+            aria-label={ariaLabel}
             onClick={(event) => event.stopPropagation()}
           >
             {chip}
@@ -83,9 +99,7 @@ export function SubmissionVersionSiteChip({
       <TooltipContent sideOffset={4}>
         <span className="font-medium">{siteLabel}</span>
         <span className="text-muted-foreground"> · {submissionVersion.statusLabel}</span>
-        {submissionVersion.tag ? (
-          <span className="text-muted-foreground"> · {submissionVersion.tag}</span>
-        ) : null}
+        {tag ? <span className="text-muted-foreground"> · {tag}</span> : null}
       </TooltipContent>
     </Tooltip>
   );

--- a/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
+++ b/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { useState } from 'react';
-import { GitBranch } from 'lucide-react';
+import { Timeline } from 'lucide-react';
 import type { VersionTimelineEntry, WorkVersionTimelineEntry } from '../types/versionTimeline.js';
 import { useVersionTimeline } from '../hooks/useVersionTimeline.js';
 import { SubmissionVersionTimelineRow, WorkVersionTimelineRow } from './VersionTimelineRows.js';
@@ -87,7 +87,7 @@ export function VersionTimelineHoverCard<T extends { id: string }>({
       </HoverCardTrigger>
       <HoverCardContent align={align} side={side} sideOffset={8} className="w-80 p-3">
         <div className="mb-2 flex items-center gap-1.5 border-b border-border pb-2 text-xs font-semibold text-foreground">
-          <GitBranch className="size-3.5 shrink-0" aria-hidden />
+          <Timeline className="size-3.5 shrink-0" aria-hidden />
           <span>{title}</span>
           {data?.length != null && !loading ? (
             <span className="font-normal text-muted-foreground">({data.length})</span>

--- a/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
+++ b/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
@@ -194,27 +194,45 @@ export type VersionTimelineHoverCardProps<T extends { id: string }> = {
   title?: string;
 };
 
-export function SubmissionVersionTimelineHoverCard(
-  props: Omit<VersionTimelineHoverCardProps<VersionTimelineEntry>, 'renderRow'>,
-) {
+export function SubmissionVersionTimelineHoverCard({
+  versionsUrl,
+  children,
+  align,
+  side,
+  title,
+}: Omit<VersionTimelineHoverCardProps<VersionTimelineEntry>, 'renderRow'>) {
   return (
     <VersionTimelineHoverCard<VersionTimelineEntry>
-      {...props}
+      versionsUrl={versionsUrl}
+      align={align}
+      side={side}
+      title={title}
       renderRow={(entry) => <SubmissionVersionTimelineRow entry={entry} />}
-    />
+    >
+      {children}
+    </VersionTimelineHoverCard>
   );
 }
 
 export function WorkVersionTimelineHoverCard({
   workId,
-  ...props
+  versionsUrl,
+  children,
+  align,
+  side,
+  title,
 }: Omit<VersionTimelineHoverCardProps<WorkVersionTimelineEntry>, 'renderRow'> & {
   workId?: string;
 }) {
   return (
     <VersionTimelineHoverCard<WorkVersionTimelineEntry>
-      {...props}
+      versionsUrl={versionsUrl}
+      align={align}
+      side={side}
+      title={title}
       renderRow={(entry) => <WorkVersionTimelineRow entry={entry} workId={workId} />}
-    />
+    >
+      {children}
+    </VersionTimelineHoverCard>
   );
 }

--- a/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
+++ b/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
@@ -1,21 +1,14 @@
 import type { ReactNode } from 'react';
 import { useState } from 'react';
-import { GitBranch, Tag } from 'lucide-react';
-import type { VersionTimelineEntry } from '../types/versionTimeline.js';
+import { GitBranch } from 'lucide-react';
+import type { VersionTimelineEntry, WorkVersionTimelineEntry } from '../types/versionTimeline.js';
 import { useVersionTimeline } from '../hooks/useVersionTimeline.js';
-import { formatDate, formatDatetime } from '../utils/formatDate.js';
-import { getStatusButtonClasses, getStatusDotClasses } from '../utils/status.js';
-import { cn } from '../utils/cn.js';
+import { SubmissionVersionTimelineRow, WorkVersionTimelineRow } from './VersionTimelineRows.js';
 import { HoverCard, HoverCardArrow, HoverCardContent, HoverCardTrigger } from './ui/hover-card.js';
-import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js';
-import { VersionTagBadge } from './ui/VersionTagBadge.js';
 
-export type { VersionTimelineEntry } from '../types/versionTimeline.js';
+export type { VersionTimelineEntry, WorkVersionTimelineEntry } from '../types/versionTimeline.js';
 
 function TimelineRail() {
-  // `w-px` renders to the right of its anchor; `-translate-x-1/2` shifts it
-  // a half-pixel left so the rail's visual center sits exactly on the dot
-  // center (dots are size-2.5 → center at left+5px).
   return (
     <span
       className="absolute left-[5px] top-2 bottom-0 w-px -translate-x-1/2 bg-border"
@@ -41,78 +34,16 @@ function TimelineSkeleton() {
   );
 }
 
-function PublishedDate({ datePublished }: { datePublished?: string }) {
-  if (datePublished) {
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <time className="text-xs font-medium text-foreground" dateTime={datePublished}>
-            {formatDate(datePublished)}
-          </time>
-        </TooltipTrigger>
-        <TooltipContent sideOffset={4}>
-          Publication date · {formatDatetime(datePublished)}
-        </TooltipContent>
-      </Tooltip>
-    );
-  }
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className="text-xs font-normal text-muted-foreground">no publication date</span>
-      </TooltipTrigger>
-      <TooltipContent sideOffset={4}>
-        Publication date — no publication date for this version
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
-function TimelineRow({ entry }: { entry: VersionTimelineEntry }) {
-  const activityDate = entry.date_modified ?? entry.date_created;
-  const activityPrefix = entry.date_modified ? 'Updated' : 'Created';
-
-  return (
-    <div className="flex relative gap-3">
-      <span
-        className={cn(
-          'relative z-10 mt-[3px] size-2.5 shrink-0 rounded-full border border-gray-300 ring-2 ring-popover dark:border-gray-600',
-          getStatusDotClasses(entry.status),
-        )}
-        aria-hidden
-      />
-      <div className="flex-1 space-y-1 min-w-0">
-        <div className="flex flex-wrap gap-y-1 gap-x-2 items-center">
-          <PublishedDate datePublished={entry.date_published} />
-          {entry.tag ? (
-            <VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
-          ) : null}
-          <span
-            className={cn(
-              getStatusButtonClasses(entry.status),
-              'inline-flex items-center rounded-full px-2 py-[1px] text-[11px] leading-tight',
-            )}
-          >
-            {entry.statusLabel}
-          </span>
-        </div>
-        <p className="text-[11px] text-muted-foreground" title={formatDatetime(activityDate)}>
-          {activityPrefix}: {formatDate(activityDate)}
-        </p>
-      </div>
-    </div>
-  );
-}
-
-export function VersionTimelineContent({
+export function VersionTimelineContent<T extends { id: string }>({
   data,
   loading,
   error,
+  renderRow,
 }: {
-  data?: VersionTimelineEntry[];
+  data?: T[];
   loading: boolean;
   error?: string;
+  renderRow: (entry: T) => ReactNode;
 }) {
   if (loading && !data?.length) {
     return <TimelineSkeleton />;
@@ -130,28 +61,30 @@ export function VersionTimelineContent({
     <div className="overflow-y-auto relative pt-1 pb-2 space-y-4 max-h-72">
       <TimelineRail />
       {data.map((entry) => (
-        <TimelineRow key={entry.id} entry={entry} />
+        <div key={entry.id}>{renderRow(entry)}</div>
       ))}
     </div>
   );
 }
 
-export function VersionTimelineHoverCard({
+export function VersionTimelineHoverCard<T extends { id: string }>({
   versionsUrl,
   children,
+  renderRow,
   align = 'start',
   side = 'top',
   title = 'Versions',
 }: {
-  /** JSON resource URL returning `{ versions: VersionTimelineEntry[] }`. */
+  /** JSON resource URL returning `{ versions: T[] }`. */
   versionsUrl: string;
   children: ReactNode;
+  renderRow: (entry: T) => ReactNode;
   align?: 'start' | 'center' | 'end';
   side?: 'top' | 'right' | 'bottom' | 'left';
   title?: string;
 }) {
   const [open, setOpen] = useState(false);
-  const { data, loading, error } = useVersionTimeline(versionsUrl, { open });
+  const { data, loading, error } = useVersionTimeline<T>(versionsUrl, { open });
 
   return (
     <HoverCard open={open} onOpenChange={setOpen} openDelay={400} closeDelay={100}>
@@ -168,9 +101,34 @@ export function VersionTimelineHoverCard({
             <span className="font-normal text-muted-foreground">({data.length})</span>
           ) : null}
         </div>
-        <VersionTimelineContent data={data} loading={loading} error={error} />
+        <VersionTimelineContent data={data} loading={loading} error={error} renderRow={renderRow} />
         <HoverCardArrow className="fill-popover" />
       </HoverCardContent>
     </HoverCard>
+  );
+}
+
+export function SubmissionVersionTimelineHoverCard(
+  props: Omit<Parameters<typeof VersionTimelineHoverCard<VersionTimelineEntry>>[0], 'renderRow'>,
+) {
+  return (
+    <VersionTimelineHoverCard
+      {...props}
+      renderRow={(entry) => <SubmissionVersionTimelineRow entry={entry} />}
+    />
+  );
+}
+
+export function WorkVersionTimelineHoverCard(
+  props: Omit<
+    Parameters<typeof VersionTimelineHoverCard<WorkVersionTimelineEntry>>[0],
+    'renderRow'
+  >,
+) {
+  return (
+    <VersionTimelineHoverCard
+      {...props}
+      renderRow={(entry) => <WorkVersionTimelineRow entry={entry} />}
+    />
   );
 }

--- a/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
+++ b/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
@@ -121,13 +121,16 @@ export function SubmissionVersionTimelineHoverCard(
   );
 }
 
-export function WorkVersionTimelineHoverCard(
-  props: Omit<VersionTimelineHoverCardProps<WorkVersionTimelineEntry>, 'renderRow'>,
-) {
+export function WorkVersionTimelineHoverCard({
+  workId,
+  ...props
+}: Omit<VersionTimelineHoverCardProps<WorkVersionTimelineEntry>, 'renderRow'> & {
+  workId?: string;
+}) {
   return (
     <VersionTimelineHoverCard<WorkVersionTimelineEntry>
       {...props}
-      renderRow={(entry) => <WorkVersionTimelineRow entry={entry} />}
+      renderRow={(entry) => <WorkVersionTimelineRow entry={entry} workId={workId} />}
     />
   );
 }

--- a/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
+++ b/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
@@ -1,16 +1,16 @@
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { GitBranch, Tag } from 'lucide-react';
-import {
-  cn,
-  formatDate,
-  formatDatetime,
-  getStatusButtonClasses,
-  getStatusDotClasses,
-  ui,
-} from '@curvenote/scms-core';
-import type { VersionTimelineEntry } from '../$siteName.submissions.$submissionId.versions/db.server.js';
-import { useSubmissionVersionTimeline } from './versionTimeline.js';
+import type { VersionTimelineEntry } from '../types/versionTimeline.js';
+import { useVersionTimeline } from '../hooks/useVersionTimeline.js';
+import { formatDate, formatDatetime } from '../utils/formatDate.js';
+import { getStatusButtonClasses, getStatusDotClasses } from '../utils/status.js';
+import { cn } from '../utils/cn.js';
+import { HoverCard, HoverCardArrow, HoverCardContent, HoverCardTrigger } from './ui/hover-card.js';
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js';
+import { VersionTagBadge } from './ui/VersionTagBadge.js';
+
+export type { VersionTimelineEntry } from '../types/versionTimeline.js';
 
 function TimelineRail() {
   // `w-px` renders to the right of its anchor; `-translate-x-1/2` shifts it
@@ -44,28 +44,28 @@ function TimelineSkeleton() {
 function PublishedDate({ datePublished }: { datePublished?: string }) {
   if (datePublished) {
     return (
-      <ui.Tooltip>
-        <ui.TooltipTrigger asChild>
+      <Tooltip>
+        <TooltipTrigger asChild>
           <time className="text-xs font-medium text-foreground" dateTime={datePublished}>
             {formatDate(datePublished)}
           </time>
-        </ui.TooltipTrigger>
-        <ui.TooltipContent sideOffset={4}>
+        </TooltipTrigger>
+        <TooltipContent sideOffset={4}>
           Publication date · {formatDatetime(datePublished)}
-        </ui.TooltipContent>
-      </ui.Tooltip>
+        </TooltipContent>
+      </Tooltip>
     );
   }
 
   return (
-    <ui.Tooltip>
-      <ui.TooltipTrigger asChild>
+    <Tooltip>
+      <TooltipTrigger asChild>
         <span className="text-xs font-normal text-muted-foreground">no publication date</span>
-      </ui.TooltipTrigger>
-      <ui.TooltipContent sideOffset={4}>
+      </TooltipTrigger>
+      <TooltipContent sideOffset={4}>
         Publication date — no publication date for this version
-      </ui.TooltipContent>
-    </ui.Tooltip>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -86,7 +86,7 @@ function TimelineRow({ entry }: { entry: VersionTimelineEntry }) {
         <div className="flex flex-wrap gap-y-1 gap-x-2 items-center">
           <PublishedDate datePublished={entry.date_published} />
           {entry.tag ? (
-            <ui.VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
+            <VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
           ) : null}
           <span
             className={cn(
@@ -105,7 +105,7 @@ function TimelineRow({ entry }: { entry: VersionTimelineEntry }) {
   );
 }
 
-function VersionTimelineContent({
+export function VersionTimelineContent({
   data,
   loading,
   error,
@@ -137,39 +137,40 @@ function VersionTimelineContent({
 }
 
 export function VersionTimelineHoverCard({
-  siteName,
-  submissionId,
+  versionsUrl,
   children,
   align = 'start',
   side = 'top',
+  title = 'Versions',
 }: {
-  siteName: string;
-  submissionId: string;
+  /** JSON resource URL returning `{ versions: VersionTimelineEntry[] }`. */
+  versionsUrl: string;
   children: ReactNode;
   align?: 'start' | 'center' | 'end';
   side?: 'top' | 'right' | 'bottom' | 'left';
+  title?: string;
 }) {
   const [open, setOpen] = useState(false);
-  const { data, loading, error } = useSubmissionVersionTimeline(siteName, submissionId, { open });
+  const { data, loading, error } = useVersionTimeline(versionsUrl, { open });
 
   return (
-    <ui.HoverCard open={open} onOpenChange={setOpen} openDelay={400} closeDelay={100}>
-      <ui.HoverCardTrigger asChild>
+    <HoverCard open={open} onOpenChange={setOpen} openDelay={400} closeDelay={100}>
+      <HoverCardTrigger asChild>
         <span className="inline-flex cursor-default transition-[filter] duration-150 hover:brightness-[0.97] dark:hover:brightness-[1.06]">
           {children}
         </span>
-      </ui.HoverCardTrigger>
-      <ui.HoverCardContent align={align} side={side} sideOffset={8} className="w-80 p-3">
+      </HoverCardTrigger>
+      <HoverCardContent align={align} side={side} sideOffset={8} className="w-80 p-3">
         <div className="mb-2 flex items-center gap-1.5 border-b border-border pb-2 text-xs font-semibold text-foreground">
           <GitBranch className="size-3.5 shrink-0" aria-hidden />
-          <span>Versions</span>
+          <span>{title}</span>
           {data?.length != null && !loading ? (
             <span className="font-normal text-muted-foreground">({data.length})</span>
           ) : null}
         </div>
         <VersionTimelineContent data={data} loading={loading} error={error} />
-        <ui.HoverCardArrow className="fill-popover" />
-      </ui.HoverCardContent>
-    </ui.HoverCard>
+        <HoverCardArrow className="fill-popover" />
+      </HoverCardContent>
+    </HoverCard>
   );
 }

--- a/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
+++ b/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
@@ -74,15 +74,7 @@ export function VersionTimelineHoverCard<T extends { id: string }>({
   align = 'start',
   side = 'top',
   title = 'Versions',
-}: {
-  /** JSON resource URL returning `{ versions: T[] }`. */
-  versionsUrl: string;
-  children: ReactNode;
-  renderRow: (entry: T) => ReactNode;
-  align?: 'start' | 'center' | 'end';
-  side?: 'top' | 'right' | 'bottom' | 'left';
-  title?: string;
-}) {
+}: VersionTimelineHoverCardProps<T>) {
   const [open, setOpen] = useState(false);
   const { data, loading, error } = useVersionTimeline<T>(versionsUrl, { open });
 
@@ -108,11 +100,21 @@ export function VersionTimelineHoverCard<T extends { id: string }>({
   );
 }
 
+export type VersionTimelineHoverCardProps<T extends { id: string }> = {
+  /** JSON resource URL returning `{ versions: T[] }`. */
+  versionsUrl: string;
+  children: ReactNode;
+  renderRow: (entry: T) => ReactNode;
+  align?: 'start' | 'center' | 'end';
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  title?: string;
+};
+
 export function SubmissionVersionTimelineHoverCard(
-  props: Omit<Parameters<typeof VersionTimelineHoverCard<VersionTimelineEntry>>[0], 'renderRow'>,
+  props: Omit<VersionTimelineHoverCardProps<VersionTimelineEntry>, 'renderRow'>,
 ) {
   return (
-    <VersionTimelineHoverCard
+    <VersionTimelineHoverCard<VersionTimelineEntry>
       {...props}
       renderRow={(entry) => <SubmissionVersionTimelineRow entry={entry} />}
     />
@@ -120,13 +122,10 @@ export function SubmissionVersionTimelineHoverCard(
 }
 
 export function WorkVersionTimelineHoverCard(
-  props: Omit<
-    Parameters<typeof VersionTimelineHoverCard<WorkVersionTimelineEntry>>[0],
-    'renderRow'
-  >,
+  props: Omit<VersionTimelineHoverCardProps<WorkVersionTimelineEntry>, 'renderRow'>,
 ) {
   return (
-    <VersionTimelineHoverCard
+    <VersionTimelineHoverCard<WorkVersionTimelineEntry>
       {...props}
       renderRow={(entry) => <WorkVersionTimelineRow entry={entry} />}
     />

--- a/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
+++ b/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
@@ -1,26 +1,23 @@
 import type { ReactNode } from 'react';
 import { useState } from 'react';
-import { Timeline } from 'lucide-react';
-import type { VersionTimelineEntry, WorkVersionTimelineEntry } from '../types/versionTimeline.js';
+import { Link } from 'react-router';
+import { Ellipsis, Timeline } from 'lucide-react';
+import type {
+  TrimmedVersionTimeline,
+  VersionTimelineDisplayItem,
+  VersionTimelineEntry,
+  WorkVersionTimelineEntry,
+} from '../types/versionTimeline.js';
 import { useVersionTimeline } from '../hooks/useVersionTimeline.js';
 import { SubmissionVersionTimelineRow, WorkVersionTimelineRow } from './VersionTimelineRows.js';
+import { cn } from '../utils/cn.js';
 import { HoverCard, HoverCardArrow, HoverCardContent, HoverCardTrigger } from './ui/hover-card.js';
 
 export type { VersionTimelineEntry, WorkVersionTimelineEntry } from '../types/versionTimeline.js';
 
-function TimelineRail() {
-  return (
-    <span
-      className="absolute left-[5px] top-2 bottom-0 w-px -translate-x-1/2 bg-border"
-      aria-hidden
-    />
-  );
-}
-
 function TimelineSkeleton() {
   return (
     <div className="relative pt-1 pb-2 space-y-4">
-      <TimelineRail />
       {[0, 1, 2].map((i) => (
         <div key={i} className="flex relative gap-3">
           <span className="relative z-10 mt-[3px] size-2.5 shrink-0 rounded-full bg-muted ring-2 ring-popover animate-pulse" />
@@ -34,35 +31,114 @@ function TimelineSkeleton() {
   );
 }
 
+function TimelineConnector({ dashed }: { dashed: boolean }) {
+  return (
+    <span
+      className={cn(
+        'absolute left-[5px] top-[14px] h-[calc(100%+1rem)] w-px -translate-x-1/2',
+        dashed ? 'border-l border-dashed border-muted-foreground/40' : 'bg-border',
+      )}
+      aria-hidden
+    />
+  );
+}
+
+function VersionTimelineGapRow({ hiddenCount }: { hiddenCount: number }) {
+  return (
+    <div className="flex relative gap-3 py-0.5">
+      <div className="relative z-10 flex flex-col items-center w-2.5 shrink-0 self-stretch">
+        <span className="w-px flex-1 min-h-2 border-l border-dashed border-muted-foreground/40" />
+        <Ellipsis className="size-3 shrink-0 text-muted-foreground/60" aria-hidden />
+        <span className="w-px flex-1 min-h-2 border-l border-dashed border-muted-foreground/40" />
+      </div>
+      <p className="self-center text-[10px] text-muted-foreground">
+        {hiddenCount} version{hiddenCount === 1 ? '' : 's'} hidden
+      </p>
+    </div>
+  );
+}
+
+function connectorDashedAfter<T extends { id: string }>(
+  items: VersionTimelineDisplayItem<T>[],
+  index: number,
+): boolean {
+  if (index >= items.length - 1) return false;
+  const current = items[index];
+  const next = items[index + 1];
+  return current.type === 'gap' || next.type === 'gap';
+}
+
 export function VersionTimelineContent<T extends { id: string }>({
-  data,
+  timeline,
   loading,
   error,
   renderRow,
 }: {
-  data?: T[];
+  timeline?: TrimmedVersionTimeline<T>;
   loading: boolean;
   error?: string;
   renderRow: (entry: T) => ReactNode;
 }) {
-  if (loading && !data?.length) {
+  const items = timeline?.items;
+
+  if (loading && !items?.length) {
     return <TimelineSkeleton />;
   }
 
-  if (error && !data?.length) {
+  if (error && !items?.length) {
     return <p className="text-xs text-muted-foreground">{error}</p>;
   }
 
-  if (!data?.length) {
+  if (!items?.length) {
     return <p className="text-xs text-muted-foreground">No versions</p>;
   }
 
   return (
     <div className="overflow-y-auto relative pt-1 pb-2 space-y-4 max-h-72">
-      <TimelineRail />
-      {data.map((entry) => (
-        <div key={entry.id}>{renderRow(entry)}</div>
-      ))}
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+
+        if (item.type === 'gap') {
+          return (
+            <div key={`gap-${index}`} className="relative">
+              {!isLast ? <TimelineConnector dashed={connectorDashedAfter(items, index)} /> : null}
+              <VersionTimelineGapRow hiddenCount={item.hiddenCount} />
+            </div>
+          );
+        }
+
+        const dashedBelow = !isLast && connectorDashedAfter(items, index);
+
+        return (
+          <div key={item.version.id} className="relative">
+            {!isLast ? <TimelineConnector dashed={dashedBelow} /> : null}
+            {renderRow(item.version)}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function VersionTimelineHiddenFooter({
+  hidden,
+  seeAllHref,
+}: {
+  hidden: number;
+  seeAllHref: string;
+}) {
+  if (hidden <= 0 || !seeAllHref) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2 border-t border-border pt-2">
+      <Link
+        to={seeAllHref}
+        className="text-[11px] text-muted-foreground hover:text-foreground hover:underline"
+      >
+        {hidden} version{hidden === 1 ? '' : 's'} hidden · click to see all
+      </Link>
     </div>
   );
 }
@@ -89,11 +165,19 @@ export function VersionTimelineHoverCard<T extends { id: string }>({
         <div className="mb-2 flex items-center gap-1.5 border-b border-border pb-2 text-xs font-semibold text-foreground">
           <Timeline className="size-3.5 shrink-0" aria-hidden />
           <span>{title}</span>
-          {data?.length != null && !loading ? (
-            <span className="font-normal text-muted-foreground">({data.length})</span>
+          {data?.total != null && !loading ? (
+            <span className="font-normal text-muted-foreground">({data.total})</span>
           ) : null}
         </div>
-        <VersionTimelineContent data={data} loading={loading} error={error} renderRow={renderRow} />
+        <VersionTimelineContent
+          timeline={data}
+          loading={loading}
+          error={error}
+          renderRow={renderRow}
+        />
+        {data ? (
+          <VersionTimelineHiddenFooter hidden={data.hidden} seeAllHref={data.seeAllHref} />
+        ) : null}
         <HoverCardArrow className="fill-popover" />
       </HoverCardContent>
     </HoverCard>
@@ -101,7 +185,7 @@ export function VersionTimelineHoverCard<T extends { id: string }>({
 }
 
 export type VersionTimelineHoverCardProps<T extends { id: string }> = {
-  /** JSON resource URL returning `{ versions: T[] }`. */
+  /** JSON resource URL returning a trimmed version timeline payload. */
   versionsUrl: string;
   children: ReactNode;
   renderRow: (entry: T) => ReactNode;

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import { Tag } from 'lucide-react';
 import type { VersionTimelineEntry, WorkVersionTimelineEntry } from '../types/versionTimeline.js';
 import { formatDate, formatDatetime } from '../utils/formatDate.js';
 import { getStatusDotClasses, getStatusRingClasses } from '../utils/status.js';
@@ -101,7 +100,7 @@ export function SubmissionVersionTimelineRow({ entry }: { entry: VersionTimeline
       <div className="flex flex-wrap gap-x-1.5 gap-y-1 items-center min-h-4">
         <PublishedDate datePublished={entry.date_published} />
         {entry.tag ? (
-          <VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
+          <VersionTagBadge tag={entry.tag} disableTooltip className="shrink-0" />
         ) : null}
         <SubmissionVersionTimelineStatusChip
           statusLabel={entry.statusLabel}

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -1,0 +1,123 @@
+import type { ReactNode } from 'react';
+import { Tag } from 'lucide-react';
+import type { VersionTimelineEntry, WorkVersionTimelineEntry } from '../types/versionTimeline.js';
+import { formatDate, formatDatetime } from '../utils/formatDate.js';
+import { getStatusButtonClasses, getStatusDotClasses } from '../utils/status.js';
+import { cn } from '../utils/cn.js';
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js';
+import { VersionTagBadge } from './ui/VersionTagBadge.js';
+
+export function VersionTimelineRowShell({
+  dotStatus,
+  children,
+}: {
+  dotStatus: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex relative gap-3">
+      <span
+        className={cn(
+          'relative z-10 mt-[3px] size-2.5 shrink-0 rounded-full border border-gray-300 ring-2 ring-popover dark:border-gray-600',
+          getStatusDotClasses(dotStatus),
+        )}
+        aria-hidden
+      />
+      <div className="flex-1 space-y-1 min-w-0">{children}</div>
+    </div>
+  );
+}
+
+function PublishedDate({ datePublished }: { datePublished?: string }) {
+  if (datePublished) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <time className="text-xs font-medium text-foreground" dateTime={datePublished}>
+            {formatDate(datePublished)}
+          </time>
+        </TooltipTrigger>
+        <TooltipContent sideOffset={4}>
+          Publication date · {formatDatetime(datePublished)}
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="text-xs font-normal text-muted-foreground">no publication date</span>
+      </TooltipTrigger>
+      <TooltipContent sideOffset={4}>
+        Publication date — no publication date for this version
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function CreatedDate({ dateCreated }: { dateCreated: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <time className="text-xs font-medium text-foreground" dateTime={dateCreated}>
+          {formatDate(dateCreated)}
+        </time>
+      </TooltipTrigger>
+      <TooltipContent sideOffset={4}>Created · {formatDatetime(dateCreated)}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function SubmissionVersionTimelineRow({ entry }: { entry: VersionTimelineEntry }) {
+  const activityDate = entry.date_modified ?? entry.date_created;
+  const activityPrefix = entry.date_modified ? 'Updated' : 'Created';
+
+  return (
+    <VersionTimelineRowShell dotStatus={entry.status}>
+      <div className="flex flex-wrap gap-y-1 gap-x-2 items-center">
+        <PublishedDate datePublished={entry.date_published} />
+        {entry.tag ? (
+          <VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
+        ) : null}
+        <span
+          className={cn(
+            getStatusButtonClasses(entry.status),
+            'inline-flex items-center rounded-full px-2 py-[1px] text-[11px] leading-tight',
+          )}
+        >
+          {entry.statusLabel}
+        </span>
+      </div>
+      <p className="text-[11px] text-muted-foreground" title={formatDatetime(activityDate)}>
+        {activityPrefix}: {formatDate(activityDate)}
+      </p>
+    </VersionTimelineRowShell>
+  );
+}
+
+export function WorkVersionTimelineRow({ entry }: { entry: WorkVersionTimelineEntry }) {
+  return (
+    <VersionTimelineRowShell dotStatus={entry.draft ? 'DRAFT' : 'PUBLISHED'}>
+      <div className="flex flex-wrap gap-y-1 gap-x-2 items-center">
+        <CreatedDate dateCreated={entry.date_created} />
+        {entry.tag ? (
+          <VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
+        ) : null}
+        <span
+          className={cn(
+            entry.draft
+              ? 'bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300'
+              : 'bg-emerald-50 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200',
+            'inline-flex items-center rounded-full px-2 py-[1px] text-[11px] leading-tight',
+          )}
+        >
+          {entry.label}
+        </span>
+      </div>
+      <p className="text-[11px] text-muted-foreground" title={formatDatetime(entry.date_modified)}>
+        Modified: {formatDate(entry.date_modified)}
+      </p>
+    </VersionTimelineRowShell>
+  );
+}

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -114,12 +114,11 @@ export function WorkVersionTimelineRow({
           <VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
         ) : null}
         {submissionVersions.map((submissionVersion) => (
-          <span key={submissionVersion.id} className="inline-flex gap-1 items-center">
-            <SubmissionVersionSiteChip submissionVersion={submissionVersion} workId={workId} />
-            {submissionVersion.tag ? (
-              <VersionTagBadge tag={submissionVersion.tag} disableTooltip className="shrink-0" />
-            ) : null}
-          </span>
+          <SubmissionVersionSiteChip
+            key={submissionVersion.id}
+            submissionVersion={submissionVersion}
+            workId={workId}
+          />
         ))}
       </div>
       <p className="text-[11px] text-muted-foreground" title={formatDatetime(entry.date_modified)}>

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -104,16 +104,6 @@ export function WorkVersionTimelineRow({ entry }: { entry: WorkVersionTimelineEn
         {entry.tag ? (
           <VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
         ) : null}
-        <span
-          className={cn(
-            entry.draft
-              ? 'bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300'
-              : 'bg-emerald-50 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200',
-            'inline-flex items-center rounded-full px-2 py-[1px] text-[11px] leading-tight',
-          )}
-        >
-          {entry.label}
-        </span>
       </div>
       <p className="text-[11px] text-muted-foreground" title={formatDatetime(entry.date_modified)}>
         Modified: {formatDate(entry.date_modified)}

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -16,7 +16,7 @@ export function VersionTimelineRowShell({
   children: ReactNode;
 }) {
   return (
-    <div className="flex relative gap-3">
+    <div className="flex relative gap-3 items-start">
       <span
         className={cn(
           'relative z-10 mt-[3px] size-2.5 shrink-0 rounded-full border border-gray-300 ring-2 ring-popover dark:border-gray-600',
@@ -24,7 +24,7 @@ export function VersionTimelineRowShell({
         )}
         aria-hidden
       />
-      <div className="flex-1 space-y-1 min-w-0">{children}</div>
+      <div className="flex-1 space-y-1 min-w-0 pt-px">{children}</div>
     </div>
   );
 }
@@ -34,7 +34,7 @@ function PublishedDate({ datePublished }: { datePublished?: string }) {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <time className="text-xs font-medium text-foreground" dateTime={datePublished}>
+          <time className="text-xs font-medium leading-4 text-foreground" dateTime={datePublished}>
             {formatDate(datePublished)}
           </time>
         </TooltipTrigger>
@@ -48,7 +48,9 @@ function PublishedDate({ datePublished }: { datePublished?: string }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="text-xs font-normal text-muted-foreground">no publication date</span>
+        <span className="text-xs font-normal leading-4 text-muted-foreground">
+          no publication date
+        </span>
       </TooltipTrigger>
       <TooltipContent sideOffset={4}>
         Publication date — no publication date for this version
@@ -61,7 +63,7 @@ function CreatedDate({ dateCreated }: { dateCreated: string }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="text-xs font-medium text-foreground">
+        <span className="inline-flex items-center text-xs font-medium leading-4 text-foreground">
           Created: <time dateTime={dateCreated}>{formatDate(dateCreated)}</time>
         </span>
       </TooltipTrigger>
@@ -76,7 +78,7 @@ export function SubmissionVersionTimelineRow({ entry }: { entry: VersionTimeline
 
   return (
     <VersionTimelineRowShell dotStatus={entry.status}>
-      <div className="flex flex-wrap gap-y-1 gap-x-2 items-center">
+      <div className="flex flex-wrap gap-x-2 gap-y-1 items-center min-h-4">
         <PublishedDate datePublished={entry.date_published} />
         {entry.tag ? (
           <VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
@@ -108,7 +110,7 @@ export function WorkVersionTimelineRow({
 
   return (
     <VersionTimelineRowShell dotStatus={entry.draft ? 'DRAFT' : 'PUBLISHED'}>
-      <div className="flex flex-wrap gap-y-1 gap-x-2 items-center">
+      <div className="flex flex-wrap gap-x-2 gap-y-1 items-center min-h-4">
         <CreatedDate dateCreated={entry.date_created} />
         {entry.tag ? (
           <VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -60,9 +60,9 @@ function CreatedDate({ dateCreated }: { dateCreated: string }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <time className="text-xs font-medium text-foreground" dateTime={dateCreated}>
-          {formatDate(dateCreated)}
-        </time>
+        <span className="text-xs font-medium text-foreground">
+          Created: <time dateTime={dateCreated}>{formatDate(dateCreated)}</time>
+        </span>
       </TooltipTrigger>
       <TooltipContent sideOffset={4}>Created · {formatDatetime(dateCreated)}</TooltipContent>
     </Tooltip>

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -58,30 +58,83 @@ function PublishedDate({ datePublished }: { datePublished?: string }) {
   );
 }
 
-function SubmissionVersionTimelineChip({
-  tag,
+function SubmissionVersionTimelineTag({ tag }: { tag?: string }) {
+  if (!tag) {
+    return <span className="w-7 shrink-0" aria-hidden />;
+  }
+
+  return (
+    <span className="inline-flex h-4 w-7 shrink-0 items-center justify-center text-[10px] font-mono leading-none text-foreground/90">
+      {tag}
+    </span>
+  );
+}
+
+function SubmissionVersionTimelineStatusChip({
   statusLabel,
   statusTags,
 }: {
-  tag?: string;
   statusLabel: string;
   statusTags?: string[];
 }) {
   return (
     <span
       className={cn(
-        'inline-flex h-4 shrink-0 items-center justify-center gap-0.5 rounded-md ring-2 px-1',
+        'inline-flex h-4 shrink-0 items-center justify-center rounded-md ring-2 px-1.5 justify-self-end',
         getStatusRingClasses(statusTags),
       )}
     >
-      {tag ? (
-        <>
-          <span className="text-[10px] font-mono leading-none text-foreground/90">{tag}</span>
-          <span className="w-px h-3 bg-border/80 shrink-0" aria-hidden />
-        </>
-      ) : null}
       <span className="text-[10px] leading-none text-foreground/90">{statusLabel}</span>
     </span>
+  );
+}
+
+function TimelineRowMetaGrid({
+  date,
+  tag,
+  status,
+  wideDate = false,
+}: {
+  date: ReactNode;
+  tag?: ReactNode;
+  status: ReactNode;
+  wideDate?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        'grid min-h-4 items-center gap-x-2',
+        wideDate
+          ? 'grid-cols-[7.5rem_1.75rem_minmax(0,1fr)]'
+          : 'grid-cols-[5.25rem_1.75rem_minmax(0,1fr)]',
+      )}
+    >
+      <div className="min-w-0">{date}</div>
+      {tag ?? <span className="w-7 shrink-0" aria-hidden />}
+      <div className="flex min-w-0 justify-end">{status}</div>
+    </div>
+  );
+}
+
+function TimelineRowChipGrid({
+  date,
+  chips,
+  wideDate = false,
+}: {
+  date: ReactNode;
+  chips: ReactNode;
+  wideDate?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        'grid min-h-4 items-center gap-x-2',
+        wideDate ? 'grid-cols-[7.5rem_minmax(0,1fr)]' : 'grid-cols-[5.25rem_minmax(0,1fr)]',
+      )}
+    >
+      <div className="min-w-0">{date}</div>
+      <div className="flex min-w-0 flex-wrap justify-end gap-1">{chips}</div>
+    </div>
   );
 }
 
@@ -104,14 +157,16 @@ export function SubmissionVersionTimelineRow({ entry }: { entry: VersionTimeline
 
   return (
     <VersionTimelineRowShell dotStatus={entry.status}>
-      <div className="flex flex-wrap gap-x-1.5 gap-y-1 items-center min-h-4">
-        <PublishedDate datePublished={entry.date_published} />
-        <SubmissionVersionTimelineChip
-          tag={entry.tag}
-          statusLabel={entry.statusLabel}
-          statusTags={entry.statusTags}
-        />
-      </div>
+      <TimelineRowMetaGrid
+        date={<PublishedDate datePublished={entry.date_published} />}
+        tag={<SubmissionVersionTimelineTag tag={entry.tag} />}
+        status={
+          <SubmissionVersionTimelineStatusChip
+            statusLabel={entry.statusLabel}
+            statusTags={entry.statusTags}
+          />
+        }
+      />
       <p className="text-[11px] text-muted-foreground" title={formatDatetime(activityDate)}>
         {activityPrefix}: {formatDate(activityDate)}
       </p>
@@ -130,16 +185,17 @@ export function WorkVersionTimelineRow({
 
   return (
     <VersionTimelineRowShell dotStatus={entry.draft ? 'DRAFT' : 'PUBLISHED'}>
-      <div className="flex flex-wrap gap-x-1.5 gap-y-1 items-center min-h-4">
-        <CreatedDate dateCreated={entry.date_created} />
-        {submissionVersions.map((submissionVersion) => (
+      <TimelineRowChipGrid
+        date={<CreatedDate dateCreated={entry.date_created} />}
+        wideDate
+        chips={submissionVersions.map((submissionVersion) => (
           <SubmissionVersionSiteChip
             key={submissionVersion.id}
             submissionVersion={submissionVersion}
             workId={workId}
           />
         ))}
-      </div>
+      />
       <p className="text-[11px] text-muted-foreground" title={formatDatetime(entry.date_modified)}>
         Modified: {formatDate(entry.date_modified)}
       </p>

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -6,6 +6,7 @@ import { getStatusButtonClasses, getStatusDotClasses } from '../utils/status.js'
 import { cn } from '../utils/cn.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js';
 import { VersionTagBadge } from './ui/VersionTagBadge.js';
+import { SubmissionVersionSiteChip } from './SubmissionVersionSiteChip.js';
 
 export function VersionTimelineRowShell({
   dotStatus,
@@ -96,7 +97,15 @@ export function SubmissionVersionTimelineRow({ entry }: { entry: VersionTimeline
   );
 }
 
-export function WorkVersionTimelineRow({ entry }: { entry: WorkVersionTimelineEntry }) {
+export function WorkVersionTimelineRow({
+  entry,
+  workId,
+}: {
+  entry: WorkVersionTimelineEntry;
+  workId?: string;
+}) {
+  const submissionVersions = entry.submissionVersions ?? [];
+
   return (
     <VersionTimelineRowShell dotStatus={entry.draft ? 'DRAFT' : 'PUBLISHED'}>
       <div className="flex flex-wrap gap-y-1 gap-x-2 items-center">
@@ -104,6 +113,13 @@ export function WorkVersionTimelineRow({ entry }: { entry: WorkVersionTimelineEn
         {entry.tag ? (
           <VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
         ) : null}
+        {submissionVersions.map((submissionVersion) => (
+          <SubmissionVersionSiteChip
+            key={submissionVersion.id}
+            submissionVersion={submissionVersion}
+            workId={workId}
+          />
+        ))}
       </div>
       <p className="text-[11px] text-muted-foreground" title={formatDatetime(entry.date_modified)}>
         Modified: {formatDate(entry.date_modified)}

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -4,7 +4,6 @@ import { formatDate, formatDatetime } from '../utils/formatDate.js';
 import { getStatusDotClasses, getStatusRingClasses } from '../utils/status.js';
 import { cn } from '../utils/cn.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js';
-import { VersionTagBadge } from './ui/VersionTagBadge.js';
 import { SubmissionVersionSiteChip } from './SubmissionVersionSiteChip.js';
 
 export function VersionTimelineRowShell({
@@ -59,20 +58,28 @@ function PublishedDate({ datePublished }: { datePublished?: string }) {
   );
 }
 
-function SubmissionVersionTimelineStatusChip({
+function SubmissionVersionTimelineChip({
+  tag,
   statusLabel,
   statusTags,
 }: {
+  tag?: string;
   statusLabel: string;
   statusTags?: string[];
 }) {
   return (
     <span
       className={cn(
-        'inline-flex h-4 shrink-0 items-center justify-center rounded-md ring-2 px-1.5',
+        'inline-flex h-4 shrink-0 items-center justify-center gap-0.5 rounded-md ring-2 px-1',
         getStatusRingClasses(statusTags),
       )}
     >
+      {tag ? (
+        <>
+          <span className="text-[10px] font-mono leading-none text-foreground/90">{tag}</span>
+          <span className="w-px h-3 bg-border/80 shrink-0" aria-hidden />
+        </>
+      ) : null}
       <span className="text-[10px] leading-none text-foreground/90">{statusLabel}</span>
     </span>
   );
@@ -99,10 +106,8 @@ export function SubmissionVersionTimelineRow({ entry }: { entry: VersionTimeline
     <VersionTimelineRowShell dotStatus={entry.status}>
       <div className="flex flex-wrap gap-x-1.5 gap-y-1 items-center min-h-4">
         <PublishedDate datePublished={entry.date_published} />
-        {entry.tag ? (
-          <VersionTagBadge tag={entry.tag} disableTooltip className="shrink-0" />
-        ) : null}
-        <SubmissionVersionTimelineStatusChip
+        <SubmissionVersionTimelineChip
+          tag={entry.tag}
           statusLabel={entry.statusLabel}
           statusTags={entry.statusTags}
         />

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -1,9 +1,11 @@
 import type { ReactNode } from 'react';
+import { Tag } from 'lucide-react';
 import type { VersionTimelineEntry, WorkVersionTimelineEntry } from '../types/versionTimeline.js';
 import { formatDate, formatDatetime } from '../utils/formatDate.js';
 import { getStatusDotClasses, getStatusRingClasses } from '../utils/status.js';
 import { cn } from '../utils/cn.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js';
+import { VersionTagBadge } from './ui/VersionTagBadge.js';
 import { SubmissionVersionSiteChip } from './SubmissionVersionSiteChip.js';
 
 export function VersionTimelineRowShell({
@@ -58,18 +60,6 @@ function PublishedDate({ datePublished }: { datePublished?: string }) {
   );
 }
 
-function SubmissionVersionTimelineTag({ tag }: { tag?: string }) {
-  if (!tag) {
-    return <span className="w-7 shrink-0" aria-hidden />;
-  }
-
-  return (
-    <span className="inline-flex h-4 w-7 shrink-0 items-center justify-center text-[10px] font-mono leading-none text-foreground/90">
-      {tag}
-    </span>
-  );
-}
-
 function SubmissionVersionTimelineStatusChip({
   statusLabel,
   statusTags,
@@ -80,61 +70,12 @@ function SubmissionVersionTimelineStatusChip({
   return (
     <span
       className={cn(
-        'inline-flex h-4 shrink-0 items-center justify-center rounded-md ring-2 px-1.5 justify-self-end',
+        'inline-flex h-4 shrink-0 items-center justify-center rounded-md ring-2 px-1.5',
         getStatusRingClasses(statusTags),
       )}
     >
       <span className="text-[10px] leading-none text-foreground/90">{statusLabel}</span>
     </span>
-  );
-}
-
-function TimelineRowMetaGrid({
-  date,
-  tag,
-  status,
-  wideDate = false,
-}: {
-  date: ReactNode;
-  tag?: ReactNode;
-  status: ReactNode;
-  wideDate?: boolean;
-}) {
-  return (
-    <div
-      className={cn(
-        'grid min-h-4 items-center gap-x-2',
-        wideDate
-          ? 'grid-cols-[7.5rem_1.75rem_minmax(0,1fr)]'
-          : 'grid-cols-[5.25rem_1.75rem_minmax(0,1fr)]',
-      )}
-    >
-      <div className="min-w-0">{date}</div>
-      {tag ?? <span className="w-7 shrink-0" aria-hidden />}
-      <div className="flex min-w-0 justify-end">{status}</div>
-    </div>
-  );
-}
-
-function TimelineRowChipGrid({
-  date,
-  chips,
-  wideDate = false,
-}: {
-  date: ReactNode;
-  chips: ReactNode;
-  wideDate?: boolean;
-}) {
-  return (
-    <div
-      className={cn(
-        'grid min-h-4 items-center gap-x-2',
-        wideDate ? 'grid-cols-[7.5rem_minmax(0,1fr)]' : 'grid-cols-[5.25rem_minmax(0,1fr)]',
-      )}
-    >
-      <div className="min-w-0">{date}</div>
-      <div className="flex min-w-0 flex-wrap justify-end gap-1">{chips}</div>
-    </div>
   );
 }
 
@@ -157,16 +98,16 @@ export function SubmissionVersionTimelineRow({ entry }: { entry: VersionTimeline
 
   return (
     <VersionTimelineRowShell dotStatus={entry.status}>
-      <TimelineRowMetaGrid
-        date={<PublishedDate datePublished={entry.date_published} />}
-        tag={<SubmissionVersionTimelineTag tag={entry.tag} />}
-        status={
-          <SubmissionVersionTimelineStatusChip
-            statusLabel={entry.statusLabel}
-            statusTags={entry.statusTags}
-          />
-        }
-      />
+      <div className="flex flex-wrap gap-x-1.5 gap-y-1 items-center min-h-4">
+        <PublishedDate datePublished={entry.date_published} />
+        {entry.tag ? (
+          <VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
+        ) : null}
+        <SubmissionVersionTimelineStatusChip
+          statusLabel={entry.statusLabel}
+          statusTags={entry.statusTags}
+        />
+      </div>
       <p className="text-[11px] text-muted-foreground" title={formatDatetime(activityDate)}>
         {activityPrefix}: {formatDate(activityDate)}
       </p>
@@ -185,17 +126,16 @@ export function WorkVersionTimelineRow({
 
   return (
     <VersionTimelineRowShell dotStatus={entry.draft ? 'DRAFT' : 'PUBLISHED'}>
-      <TimelineRowChipGrid
-        date={<CreatedDate dateCreated={entry.date_created} />}
-        wideDate
-        chips={submissionVersions.map((submissionVersion) => (
+      <div className="flex flex-wrap gap-x-1.5 gap-y-1 items-center min-h-4">
+        <CreatedDate dateCreated={entry.date_created} />
+        {submissionVersions.map((submissionVersion) => (
           <SubmissionVersionSiteChip
             key={submissionVersion.id}
             submissionVersion={submissionVersion}
             workId={workId}
           />
         ))}
-      />
+      </div>
       <p className="text-[11px] text-muted-foreground" title={formatDatetime(entry.date_modified)}>
         Modified: {formatDate(entry.date_modified)}
       </p>

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -112,9 +112,6 @@ export function WorkVersionTimelineRow({
     <VersionTimelineRowShell dotStatus={entry.draft ? 'DRAFT' : 'PUBLISHED'}>
       <div className="flex flex-wrap gap-x-2 gap-y-1 items-center min-h-4">
         <CreatedDate dateCreated={entry.date_created} />
-        {entry.tag ? (
-          <VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
-        ) : null}
         {submissionVersions.map((submissionVersion) => (
           <SubmissionVersionSiteChip
             key={submissionVersion.id}

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -114,11 +114,12 @@ export function WorkVersionTimelineRow({
           <VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
         ) : null}
         {submissionVersions.map((submissionVersion) => (
-          <SubmissionVersionSiteChip
-            key={submissionVersion.id}
-            submissionVersion={submissionVersion}
-            workId={workId}
-          />
+          <span key={submissionVersion.id} className="inline-flex gap-1 items-center">
+            <SubmissionVersionSiteChip submissionVersion={submissionVersion} workId={workId} />
+            {submissionVersion.tag ? (
+              <VersionTagBadge tag={submissionVersion.tag} disableTooltip className="shrink-0" />
+            ) : null}
+          </span>
         ))}
       </div>
       <p className="text-[11px] text-muted-foreground" title={formatDatetime(entry.date_modified)}>

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -1,11 +1,9 @@
 import type { ReactNode } from 'react';
-import { Tag } from 'lucide-react';
 import type { VersionTimelineEntry, WorkVersionTimelineEntry } from '../types/versionTimeline.js';
 import { formatDate, formatDatetime } from '../utils/formatDate.js';
-import { getStatusButtonClasses, getStatusDotClasses } from '../utils/status.js';
+import { getStatusDotClasses, getStatusRingClasses } from '../utils/status.js';
 import { cn } from '../utils/cn.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js';
-import { VersionTagBadge } from './ui/VersionTagBadge.js';
 import { SubmissionVersionSiteChip } from './SubmissionVersionSiteChip.js';
 
 export function VersionTimelineRowShell({
@@ -34,7 +32,10 @@ function PublishedDate({ datePublished }: { datePublished?: string }) {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <time className="text-xs font-medium leading-4 text-foreground" dateTime={datePublished}>
+          <time
+            className="inline-flex h-4 items-center text-xs font-medium leading-none text-foreground"
+            dateTime={datePublished}
+          >
             {formatDate(datePublished)}
           </time>
         </TooltipTrigger>
@@ -48,14 +49,39 @@ function PublishedDate({ datePublished }: { datePublished?: string }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="text-xs font-normal leading-4 text-muted-foreground">
-          no publication date
+        <span className="inline-flex h-4 items-center text-xs font-normal leading-none text-muted-foreground">
+          no date
         </span>
       </TooltipTrigger>
-      <TooltipContent sideOffset={4}>
-        Publication date — no publication date for this version
-      </TooltipContent>
+      <TooltipContent sideOffset={4}>Publication date — no date for this version</TooltipContent>
     </Tooltip>
+  );
+}
+
+function SubmissionVersionTimelineChip({
+  tag,
+  statusLabel,
+  statusTags,
+}: {
+  tag?: string;
+  statusLabel: string;
+  statusTags?: string[];
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex h-4 shrink-0 items-center justify-center gap-0.5 rounded-md ring-2 px-1',
+        getStatusRingClasses(statusTags),
+      )}
+    >
+      {tag ? (
+        <>
+          <span className="text-[10px] font-mono leading-none text-foreground/90">{tag}</span>
+          <span className="w-px h-3 bg-border/80 shrink-0" aria-hidden />
+        </>
+      ) : null}
+      <span className="text-[10px] leading-none text-foreground/90">{statusLabel}</span>
+    </span>
   );
 }
 
@@ -63,7 +89,7 @@ function CreatedDate({ dateCreated }: { dateCreated: string }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="inline-flex items-center text-xs font-medium leading-4 text-foreground">
+        <span className="inline-flex h-4 items-center text-xs font-medium leading-none text-foreground">
           Created: <time dateTime={dateCreated}>{formatDate(dateCreated)}</time>
         </span>
       </TooltipTrigger>
@@ -78,19 +104,13 @@ export function SubmissionVersionTimelineRow({ entry }: { entry: VersionTimeline
 
   return (
     <VersionTimelineRowShell dotStatus={entry.status}>
-      <div className="flex flex-wrap gap-x-2 gap-y-1 items-center min-h-4">
+      <div className="flex flex-wrap gap-x-1.5 gap-y-1 items-center min-h-4">
         <PublishedDate datePublished={entry.date_published} />
-        {entry.tag ? (
-          <VersionTagBadge tag={entry.tag} icon={Tag} disableTooltip className="shrink-0" />
-        ) : null}
-        <span
-          className={cn(
-            getStatusButtonClasses(entry.status),
-            'inline-flex items-center rounded-full px-2 py-[1px] text-[11px] leading-tight',
-          )}
-        >
-          {entry.statusLabel}
-        </span>
+        <SubmissionVersionTimelineChip
+          tag={entry.tag}
+          statusLabel={entry.statusLabel}
+          statusTags={entry.statusTags}
+        />
       </div>
       <p className="text-[11px] text-muted-foreground" title={formatDatetime(activityDate)}>
         {activityPrefix}: {formatDate(activityDate)}
@@ -110,7 +130,7 @@ export function WorkVersionTimelineRow({
 
   return (
     <VersionTimelineRowShell dotStatus={entry.draft ? 'DRAFT' : 'PUBLISHED'}>
-      <div className="flex flex-wrap gap-x-2 gap-y-1 items-center min-h-4">
+      <div className="flex flex-wrap gap-x-1.5 gap-y-1 items-center min-h-4">
         <CreatedDate dateCreated={entry.date_created} />
         {submissionVersions.map((submissionVersion) => (
           <SubmissionVersionSiteChip

--- a/packages/scms-core/src/components/index.ts
+++ b/packages/scms-core/src/components/index.ts
@@ -14,6 +14,7 @@ export * from './StatsSection.js';
 export * from './SubmissionActionsDropdown.js';
 export * from './SubmissionVersionsTable.js';
 export * from './VersionTimelineHoverCard.js';
+export * from './SubmissionVersionSiteChip.js';
 export * from './SystemAdminBadge.js';
 export * from './ThemeSwitcher.js';
 export * from './UserCard.js';

--- a/packages/scms-core/src/components/index.ts
+++ b/packages/scms-core/src/components/index.ts
@@ -13,6 +13,7 @@ export * from './SlugLike.js';
 export * from './StatsSection.js';
 export * from './SubmissionActionsDropdown.js';
 export * from './SubmissionVersionsTable.js';
+export * from './VersionTimelineHoverCard.js';
 export * from './SystemAdminBadge.js';
 export * from './ThemeSwitcher.js';
 export * from './UserCard.js';

--- a/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx
+++ b/packages/scms-core/src/components/ui/SubmissionVersionBadge.tsx
@@ -110,7 +110,6 @@ export function SubmissionVersionBadge({
         'cursor-pointer': shouldShowLink,
       })}
       asChild={shouldShowLink}
-      title={`SID: ${sv.submission.id}\nSVID: ${sv.id}`}
     >
       {shouldShowLink ? (
         <Link

--- a/packages/scms-core/src/hooks/index.ts
+++ b/packages/scms-core/src/hooks/index.ts
@@ -12,3 +12,4 @@ export * from './usePrevious.js';
 export * from './useRevalidate.js';
 export * from './useSites.js';
 export * from './useToggle.js';
+export * from './useVersionTimeline.js';

--- a/packages/scms-core/src/hooks/useVersionTimeline.ts
+++ b/packages/scms-core/src/hooks/useVersionTimeline.ts
@@ -1,15 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
-import type { VersionTimelineResponse } from '../types/versionTimeline.js';
+import type { TrimmedVersionTimeline, VersionTimelineResponse } from '../types/versionTimeline.js';
 
-const timelineCache = new Map<string, unknown[]>();
-const inFlight = new Map<string, Promise<unknown[]>>();
+const timelineCache = new Map<string, TrimmedVersionTimeline<{ id: string }>>();
+const inFlight = new Map<string, Promise<TrimmedVersionTimeline<{ id: string }>>>();
 
 export async function loadVersionTimeline<T extends { id: string }>(
   versionsUrl: string,
-): Promise<T[]> {
+): Promise<TrimmedVersionTimeline<T>> {
   const existing = inFlight.get(versionsUrl);
   if (existing) {
-    return existing as Promise<T[]>;
+    return existing as Promise<TrimmedVersionTimeline<T>>;
   }
 
   const promise = (async () => {
@@ -22,19 +22,25 @@ export async function loadVersionTimeline<T extends { id: string }>(
     }
 
     const body = (await response.json()) as VersionTimelineResponse<T>;
-    const versions = body.versions;
-    if (!Array.isArray(versions)) {
+    if (!Array.isArray(body.items) || typeof body.total !== 'number') {
       throw new Error('Invalid versions response');
     }
 
-    timelineCache.set(versionsUrl, versions);
-    return versions;
+    const timeline: TrimmedVersionTimeline<T> = {
+      total: body.total,
+      hidden: body.hidden ?? 0,
+      seeAllHref: body.seeAllHref ?? '',
+      items: body.items,
+    };
+
+    timelineCache.set(versionsUrl, timeline as TrimmedVersionTimeline<{ id: string }>);
+    return timeline;
   })();
 
   inFlight.set(versionsUrl, promise);
 
   try {
-    return (await promise) as T[];
+    return (await promise) as TrimmedVersionTimeline<T>;
   } finally {
     inFlight.delete(versionsUrl);
   }
@@ -42,15 +48,17 @@ export async function loadVersionTimeline<T extends { id: string }>(
 
 export function getCachedVersionTimeline<T extends { id: string }>(
   versionsUrl: string,
-): T[] | undefined {
-  return timelineCache.get(versionsUrl) as T[] | undefined;
+): TrimmedVersionTimeline<T> | undefined {
+  return timelineCache.get(versionsUrl) as TrimmedVersionTimeline<T> | undefined;
 }
 
 export function useVersionTimeline<T extends { id: string }>(
   versionsUrl: string,
   { open }: { open: boolean },
 ) {
-  const [data, setData] = useState<T[] | undefined>(() => getCachedVersionTimeline<T>(versionsUrl));
+  const [data, setData] = useState<TrimmedVersionTimeline<T> | undefined>(() =>
+    getCachedVersionTimeline<T>(versionsUrl),
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
   const mountedRef = useRef(true);
@@ -74,9 +82,9 @@ export function useVersionTimeline<T extends { id: string }>(
       setError(undefined);
 
       void loadVersionTimeline<T>(versionsUrl)
-        .then((versions) => {
+        .then((timeline) => {
           if (!mountedRef.current) return;
-          setData(versions);
+          setData(timeline);
         })
         .catch(() => {
           // Keep showing stale cache on background revalidate failure.
@@ -88,9 +96,9 @@ export function useVersionTimeline<T extends { id: string }>(
     setError(undefined);
 
     void loadVersionTimeline<T>(versionsUrl)
-      .then((versions) => {
+      .then((timeline) => {
         if (!mountedRef.current) return;
-        setData(versions);
+        setData(timeline);
         setLoading(false);
       })
       .catch((err: unknown) => {

--- a/packages/scms-core/src/hooks/useVersionTimeline.ts
+++ b/packages/scms-core/src/hooks/useVersionTimeline.ts
@@ -1,13 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
-import type { VersionTimelineEntry } from '../types/versionTimeline.js';
+import type { VersionTimelineResponse } from '../types/versionTimeline.js';
 
-const timelineCache = new Map<string, VersionTimelineEntry[]>();
-const inFlight = new Map<string, Promise<VersionTimelineEntry[]>>();
+const timelineCache = new Map<string, unknown[]>();
+const inFlight = new Map<string, Promise<unknown[]>>();
 
-export async function loadVersionTimeline(versionsUrl: string): Promise<VersionTimelineEntry[]> {
+export async function loadVersionTimeline<T extends { id: string }>(
+  versionsUrl: string,
+): Promise<T[]> {
   const existing = inFlight.get(versionsUrl);
   if (existing) {
-    return existing;
+    return existing as Promise<T[]>;
   }
 
   const promise = (async () => {
@@ -19,7 +21,7 @@ export async function loadVersionTimeline(versionsUrl: string): Promise<VersionT
       throw new Error(`Failed to load versions (${response.status})`);
     }
 
-    const body = (await response.json()) as { versions?: VersionTimelineEntry[] };
+    const body = (await response.json()) as VersionTimelineResponse<T>;
     const versions = body.versions;
     if (!Array.isArray(versions)) {
       throw new Error('Invalid versions response');
@@ -32,20 +34,23 @@ export async function loadVersionTimeline(versionsUrl: string): Promise<VersionT
   inFlight.set(versionsUrl, promise);
 
   try {
-    return await promise;
+    return (await promise) as T[];
   } finally {
     inFlight.delete(versionsUrl);
   }
 }
 
-export function getCachedVersionTimeline(versionsUrl: string): VersionTimelineEntry[] | undefined {
-  return timelineCache.get(versionsUrl);
+export function getCachedVersionTimeline<T extends { id: string }>(
+  versionsUrl: string,
+): T[] | undefined {
+  return timelineCache.get(versionsUrl) as T[] | undefined;
 }
 
-export function useVersionTimeline(versionsUrl: string, { open }: { open: boolean }) {
-  const [data, setData] = useState<VersionTimelineEntry[] | undefined>(() =>
-    getCachedVersionTimeline(versionsUrl),
-  );
+export function useVersionTimeline<T extends { id: string }>(
+  versionsUrl: string,
+  { open }: { open: boolean },
+) {
+  const [data, setData] = useState<T[] | undefined>(() => getCachedVersionTimeline<T>(versionsUrl));
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
   const mountedRef = useRef(true);
@@ -62,13 +67,13 @@ export function useVersionTimeline(versionsUrl: string, { open }: { open: boolea
       return;
     }
 
-    const cached = getCachedVersionTimeline(versionsUrl);
+    const cached = getCachedVersionTimeline<T>(versionsUrl);
     if (cached) {
       setData(cached);
       setLoading(false);
       setError(undefined);
 
-      void loadVersionTimeline(versionsUrl)
+      void loadVersionTimeline<T>(versionsUrl)
         .then((versions) => {
           if (!mountedRef.current) return;
           setData(versions);
@@ -82,7 +87,7 @@ export function useVersionTimeline(versionsUrl: string, { open }: { open: boolea
     setLoading(true);
     setError(undefined);
 
-    void loadVersionTimeline(versionsUrl)
+    void loadVersionTimeline<T>(versionsUrl)
       .then((versions) => {
         if (!mountedRef.current) return;
         setData(versions);

--- a/packages/scms-core/src/hooks/useVersionTimeline.ts
+++ b/packages/scms-core/src/hooks/useVersionTimeline.ts
@@ -1,29 +1,17 @@
 import { useEffect, useRef, useState } from 'react';
-import type { VersionTimelineEntry } from '../$siteName.submissions.$submissionId.versions/db.server.js';
+import type { VersionTimelineEntry } from '../types/versionTimeline.js';
 
 const timelineCache = new Map<string, VersionTimelineEntry[]>();
 const inFlight = new Map<string, Promise<VersionTimelineEntry[]>>();
 
-function cacheKey(siteName: string, submissionId: string) {
-  return `${siteName}:${submissionId}`;
-}
-
-function versionsUrl(siteName: string, submissionId: string) {
-  return `/app/sites/${encodeURIComponent(siteName)}/submissions/${encodeURIComponent(submissionId)}/versions`;
-}
-
-export async function loadSubmissionVersionTimeline(
-  siteName: string,
-  submissionId: string,
-): Promise<VersionTimelineEntry[]> {
-  const key = cacheKey(siteName, submissionId);
-  const existing = inFlight.get(key);
+export async function loadVersionTimeline(versionsUrl: string): Promise<VersionTimelineEntry[]> {
+  const existing = inFlight.get(versionsUrl);
   if (existing) {
     return existing;
   }
 
   const promise = (async () => {
-    const response = await fetch(versionsUrl(siteName, submissionId), {
+    const response = await fetch(versionsUrl, {
       headers: { Accept: 'application/json' },
     });
 
@@ -37,33 +25,26 @@ export async function loadSubmissionVersionTimeline(
       throw new Error('Invalid versions response');
     }
 
-    timelineCache.set(key, versions);
+    timelineCache.set(versionsUrl, versions);
     return versions;
   })();
 
-  inFlight.set(key, promise);
+  inFlight.set(versionsUrl, promise);
 
   try {
     return await promise;
   } finally {
-    inFlight.delete(key);
+    inFlight.delete(versionsUrl);
   }
 }
 
-export function getCachedSubmissionVersionTimeline(
-  siteName: string,
-  submissionId: string,
-): VersionTimelineEntry[] | undefined {
-  return timelineCache.get(cacheKey(siteName, submissionId));
+export function getCachedVersionTimeline(versionsUrl: string): VersionTimelineEntry[] | undefined {
+  return timelineCache.get(versionsUrl);
 }
 
-export function useSubmissionVersionTimeline(
-  siteName: string,
-  submissionId: string,
-  { open }: { open: boolean },
-) {
+export function useVersionTimeline(versionsUrl: string, { open }: { open: boolean }) {
   const [data, setData] = useState<VersionTimelineEntry[] | undefined>(() =>
-    getCachedSubmissionVersionTimeline(siteName, submissionId),
+    getCachedVersionTimeline(versionsUrl),
   );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
@@ -81,13 +62,13 @@ export function useSubmissionVersionTimeline(
       return;
     }
 
-    const cached = getCachedSubmissionVersionTimeline(siteName, submissionId);
+    const cached = getCachedVersionTimeline(versionsUrl);
     if (cached) {
       setData(cached);
       setLoading(false);
       setError(undefined);
 
-      void loadSubmissionVersionTimeline(siteName, submissionId)
+      void loadVersionTimeline(versionsUrl)
         .then((versions) => {
           if (!mountedRef.current) return;
           setData(versions);
@@ -101,7 +82,7 @@ export function useSubmissionVersionTimeline(
     setLoading(true);
     setError(undefined);
 
-    void loadSubmissionVersionTimeline(siteName, submissionId)
+    void loadVersionTimeline(versionsUrl)
       .then((versions) => {
         if (!mountedRef.current) return;
         setData(versions);
@@ -112,7 +93,7 @@ export function useSubmissionVersionTimeline(
         setError(err instanceof Error ? err.message : 'Could not load versions');
         setLoading(false);
       });
-  }, [open, siteName, submissionId]);
+  }, [open, versionsUrl]);
 
   return { data, loading, error };
 }

--- a/packages/scms-core/src/index.ts
+++ b/packages/scms-core/src/index.ts
@@ -13,6 +13,8 @@ export type {
   WorkVersionTimelineEntry,
   WorkVersionTimelineSubmissionVersion,
   VersionTimelineResponse,
+  TrimmedVersionTimeline,
+  VersionTimelineDisplayItem,
 } from './types/versionTimeline.js';
 
 // Re-export commonly used types from ui components

--- a/packages/scms-core/src/index.ts
+++ b/packages/scms-core/src/index.ts
@@ -8,7 +8,11 @@ export * from './services/index.js';
 export * from './utils/index.js';
 export * from './workflow/index.js';
 
-export type { VersionTimelineEntry, VersionTimelineResponse } from './types/versionTimeline.js';
+export type {
+  VersionTimelineEntry,
+  WorkVersionTimelineEntry,
+  VersionTimelineResponse,
+} from './types/versionTimeline.js';
 
 // Re-export commonly used types from ui components
 export type { DraftWork } from './components/ui/dialogs/types.js';

--- a/packages/scms-core/src/index.ts
+++ b/packages/scms-core/src/index.ts
@@ -8,5 +8,7 @@ export * from './services/index.js';
 export * from './utils/index.js';
 export * from './workflow/index.js';
 
+export type { VersionTimelineEntry, VersionTimelineResponse } from './types/versionTimeline.js';
+
 // Re-export commonly used types from ui components
 export type { DraftWork } from './components/ui/dialogs/types.js';

--- a/packages/scms-core/src/index.ts
+++ b/packages/scms-core/src/index.ts
@@ -11,6 +11,7 @@ export * from './workflow/index.js';
 export type {
   VersionTimelineEntry,
   WorkVersionTimelineEntry,
+  WorkVersionTimelineSubmissionVersion,
   VersionTimelineResponse,
 } from './types/versionTimeline.js';
 

--- a/packages/scms-core/src/types/versionTimeline.ts
+++ b/packages/scms-core/src/types/versionTimeline.ts
@@ -34,6 +34,16 @@ export type WorkVersionTimelineEntry = {
   submissionVersions?: WorkVersionTimelineSubmissionVersion[];
 };
 
-export type VersionTimelineResponse<T = VersionTimelineEntry> = {
-  versions: T[];
+export type VersionTimelineDisplayItem<T> =
+  | { type: 'version'; version: T }
+  | { type: 'gap'; hiddenCount: number };
+
+/** Compact lazy-load payload for version timeline hover cards (trimmed server-side). */
+export type TrimmedVersionTimeline<T = VersionTimelineEntry> = {
+  total: number;
+  hidden: number;
+  seeAllHref: string;
+  items: VersionTimelineDisplayItem<T>[];
 };
+
+export type VersionTimelineResponse<T = VersionTimelineEntry> = TrimmedVersionTimeline<T>;

--- a/packages/scms-core/src/types/versionTimeline.ts
+++ b/packages/scms-core/src/types/versionTimeline.ts
@@ -13,8 +13,6 @@ export type WorkVersionTimelineEntry = {
   date_created: string;
   date_modified: string;
   draft: boolean;
-  /** Display label, e.g. `v2` or `Draft`. */
-  label: string;
   tag?: string;
 };
 

--- a/packages/scms-core/src/types/versionTimeline.ts
+++ b/packages/scms-core/src/types/versionTimeline.ts
@@ -8,6 +8,16 @@ export type VersionTimelineEntry = {
   tag?: string;
 };
 
-export type VersionTimelineResponse = {
-  versions: VersionTimelineEntry[];
+export type WorkVersionTimelineEntry = {
+  id: string;
+  date_created: string;
+  date_modified: string;
+  draft: boolean;
+  /** Display label, e.g. `v2` or `Draft`. */
+  label: string;
+  tag?: string;
+};
+
+export type VersionTimelineResponse<T = VersionTimelineEntry> = {
+  versions: T[];
 };

--- a/packages/scms-core/src/types/versionTimeline.ts
+++ b/packages/scms-core/src/types/versionTimeline.ts
@@ -13,6 +13,7 @@ export type WorkVersionTimelineSubmissionVersion = {
   submissionId: string;
   status: string;
   statusLabel: string;
+  date_published?: string;
   /** First submission-version tag (e.g. v2), not workflow status tags. */
   tag?: string;
   /** Workflow state tags — used for status accent on compact site chips. */

--- a/packages/scms-core/src/types/versionTimeline.ts
+++ b/packages/scms-core/src/types/versionTimeline.ts
@@ -5,6 +5,8 @@ export type VersionTimelineEntry = {
   date_published?: string;
   status: string;
   statusLabel: string;
+  /** Workflow state tags — used for status accent on compact timeline chips. */
+  statusTags?: string[];
   tag?: string;
 };
 

--- a/packages/scms-core/src/types/versionTimeline.ts
+++ b/packages/scms-core/src/types/versionTimeline.ts
@@ -30,7 +30,6 @@ export type WorkVersionTimelineEntry = {
   date_created: string;
   date_modified: string;
   draft: boolean;
-  tag?: string;
   submissionVersions?: WorkVersionTimelineSubmissionVersion[];
 };
 

--- a/packages/scms-core/src/types/versionTimeline.ts
+++ b/packages/scms-core/src/types/versionTimeline.ts
@@ -13,6 +13,8 @@ export type WorkVersionTimelineSubmissionVersion = {
   submissionId: string;
   status: string;
   statusLabel: string;
+  /** First submission-version tag (e.g. v2), not workflow status tags. */
+  tag?: string;
   /** Workflow state tags — used for status accent on compact site chips. */
   statusTags?: string[];
   site: {

--- a/packages/scms-core/src/types/versionTimeline.ts
+++ b/packages/scms-core/src/types/versionTimeline.ts
@@ -1,0 +1,13 @@
+export type VersionTimelineEntry = {
+  id: string;
+  date_created: string;
+  date_modified: string;
+  date_published?: string;
+  status: string;
+  statusLabel: string;
+  tag?: string;
+};
+
+export type VersionTimelineResponse = {
+  versions: VersionTimelineEntry[];
+};

--- a/packages/scms-core/src/types/versionTimeline.ts
+++ b/packages/scms-core/src/types/versionTimeline.ts
@@ -8,12 +8,27 @@ export type VersionTimelineEntry = {
   tag?: string;
 };
 
+export type WorkVersionTimelineSubmissionVersion = {
+  id: string;
+  submissionId: string;
+  status: string;
+  statusLabel: string;
+  /** Workflow state tags — used for status accent on compact site chips. */
+  statusTags?: string[];
+  site: {
+    name: string;
+    title?: string;
+    logo?: string;
+  };
+};
+
 export type WorkVersionTimelineEntry = {
   id: string;
   date_created: string;
   date_modified: string;
   draft: boolean;
   tag?: string;
+  submissionVersions?: WorkVersionTimelineSubmissionVersion[];
 };
 
 export type VersionTimelineResponse<T = VersionTimelineEntry> = {

--- a/packages/scms-core/src/utils/index.ts
+++ b/packages/scms-core/src/utils/index.ts
@@ -20,6 +20,7 @@ export * from './stringReplacements.js';
 export * from './truncate.js';
 export * from './wildcard.js';
 export * from './formatZodError.js';
+export * from './versionTimelineUrls.js';
 export * from './workVersionMetadata.js';
 
 export const version = 'v1';

--- a/packages/scms-core/src/utils/index.ts
+++ b/packages/scms-core/src/utils/index.ts
@@ -21,6 +21,7 @@ export * from './truncate.js';
 export * from './wildcard.js';
 export * from './formatZodError.js';
 export * from './versionTimelineUrls.js';
+export * from './versionTimelineTrim.js';
 export * from './workVersionMetadata.js';
 
 export const version = 'v1';

--- a/packages/scms-core/src/utils/status.ts
+++ b/packages/scms-core/src/utils/status.ts
@@ -55,3 +55,26 @@ export function getStatusDotClasses(status: JobStatus | string) {
 
   return 'bg-neutral-400';
 }
+
+/** Ring/background accent for compact timeline chips (site badges, submission rows). */
+export function getStatusRingClasses(statusTags?: string[]) {
+  if (!statusTags?.length) {
+    return 'ring-border bg-muted/40';
+  }
+
+  const hasEnd = statusTags.includes('end');
+  const hasError = statusTags.includes('error');
+  const hasWarning = statusTags.includes('warning');
+
+  if (hasError) {
+    return 'ring-red-500 bg-red-50 dark:bg-red-950/40 dark:ring-red-400';
+  }
+  if (hasWarning) {
+    return 'ring-orange-500 bg-orange-50 dark:bg-orange-950/40 dark:ring-orange-400';
+  }
+  if (hasEnd && !hasError && !hasWarning) {
+    return 'ring-green-600 bg-green-50 dark:bg-green-950/40 dark:ring-green-500';
+  }
+
+  return 'ring-border bg-muted/40';
+}

--- a/packages/scms-core/src/utils/versionTimelineTrim.test.ts
+++ b/packages/scms-core/src/utils/versionTimelineTrim.test.ts
@@ -1,0 +1,136 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import type { VersionTimelineEntry, WorkVersionTimelineEntry } from '../types/versionTimeline.js';
+import {
+  VERSION_TIMELINE_MAX_VISIBLE,
+  buildDisplayItems,
+  firstSignificantSubmissionVersionIndex,
+  trimSubmissionVersionTimeline,
+  trimWorkVersionTimeline,
+} from './versionTimelineTrim.js';
+
+function submissionVersion(id: string, published?: string): VersionTimelineEntry {
+  return {
+    id,
+    date_created: id,
+    date_modified: id,
+    date_published: published,
+    status: published ? 'PUBLISHED' : 'DRAFT',
+    statusLabel: published ? 'Published' : 'Draft',
+  };
+}
+
+function workVersion(
+  id: string,
+  options: {
+    submissionVersions?: WorkVersionTimelineEntry['submissionVersions'];
+  } = {},
+): WorkVersionTimelineEntry {
+  return {
+    id,
+    date_created: id,
+    date_modified: id,
+    draft: false,
+    submissionVersions: options.submissionVersions,
+  };
+}
+
+describe('buildDisplayItems', () => {
+  it('inserts gap items between non-adjacent indices', () => {
+    const versions = ['a', 'b', 'c', 'd', 'e'];
+    const items = buildDisplayItems(versions, [0, 2, 4]);
+
+    expect(items).toEqual([
+      { type: 'version', version: 'a' },
+      { type: 'gap', hiddenCount: 1 },
+      { type: 'version', version: 'c' },
+      { type: 'gap', hiddenCount: 1 },
+      { type: 'version', version: 'e' },
+    ]);
+  });
+});
+
+describe('firstSignificantSubmissionVersionIndex', () => {
+  it('returns oldest published version when any exist', () => {
+    const versions = [
+      submissionVersion('new', '2026-02-01'),
+      submissionVersion('mid'),
+      submissionVersion('old', '2026-01-01'),
+    ];
+
+    expect(firstSignificantSubmissionVersionIndex(versions)).toBe(2);
+  });
+
+  it('returns oldest version when none are published', () => {
+    const versions = [submissionVersion('new'), submissionVersion('old')];
+
+    expect(firstSignificantSubmissionVersionIndex(versions)).toBe(1);
+  });
+});
+
+describe('trimSubmissionVersionTimeline', () => {
+  it('returns all versions when at or below the cap', () => {
+    const versions = Array.from({ length: VERSION_TIMELINE_MAX_VISIBLE }, (_, index) =>
+      submissionVersion(`v-${index}`),
+    );
+
+    const result = trimSubmissionVersionTimeline(versions, '/see-all');
+
+    expect(result.total).toBe(VERSION_TIMELINE_MAX_VISIBLE);
+    expect(result.hidden).toBe(0);
+    expect(result.items.every((item) => item.type === 'version')).toBe(true);
+  });
+
+  it('keeps first significant and published versions when trimming', () => {
+    const versions = Array.from({ length: 12 }, (_, index) =>
+      submissionVersion(`v-${index}`, index === 11 || index === 0 ? '2026-01-01' : undefined),
+    );
+
+    const result = trimSubmissionVersionTimeline(versions, '/see-all');
+
+    expect(result.total).toBe(12);
+    expect(result.hidden).toBe(4);
+    expect(result.seeAllHref).toBe('/see-all');
+
+    const visibleIds = result.items
+      .filter((item) => item.type === 'version')
+      .map((item) => (item.type === 'version' ? item.version.id : ''));
+
+    expect(visibleIds).toContain('v-11');
+    expect(visibleIds).toContain('v-0');
+    expect(visibleIds.length).toBe(VERSION_TIMELINE_MAX_VISIBLE);
+    expect(result.items.some((item) => item.type === 'gap')).toBe(true);
+  });
+});
+
+describe('trimWorkVersionTimeline', () => {
+  it('always includes the first work version', () => {
+    const versions = Array.from({ length: 12 }, (_, index) =>
+      workVersion(`wv-${index}`, {
+        submissionVersions:
+          index % 3 === 0
+            ? [
+                {
+                  id: `sv-${index}`,
+                  submissionId: 'sub-1',
+                  status: index === 9 ? 'PUBLISHED' : 'DRAFT',
+                  statusLabel: 'Draft',
+                  date_published: index === 9 ? '2026-01-01' : undefined,
+                  site: { name: 'demo' },
+                },
+              ]
+            : [],
+      }),
+    );
+
+    const result = trimWorkVersionTimeline(versions, '/works/1/details');
+
+    const visibleIds = result.items
+      .filter((item) => item.type === 'version')
+      .map((item) => (item.type === 'version' ? item.version.id : ''));
+
+    expect(visibleIds).toContain('wv-11');
+    expect(visibleIds.length).toBe(VERSION_TIMELINE_MAX_VISIBLE);
+    expect(result.hidden).toBe(4);
+  });
+});

--- a/packages/scms-core/src/utils/versionTimelineTrim.ts
+++ b/packages/scms-core/src/utils/versionTimelineTrim.ts
@@ -1,0 +1,168 @@
+import type {
+  VersionTimelineDisplayItem,
+  VersionTimelineEntry,
+  TrimmedVersionTimeline,
+  WorkVersionTimelineEntry,
+} from '../types/versionTimeline.js';
+
+export type {
+  VersionTimelineDisplayItem,
+  TrimmedVersionTimeline,
+} from '../types/versionTimeline.js';
+
+export const VERSION_TIMELINE_MAX_VISIBLE = 8;
+
+function selectIndices(
+  count: number,
+  maxVisible: number,
+  required: number[],
+  score: (index: number) => number,
+): number[] {
+  if (count <= maxVisible) {
+    return Array.from({ length: count }, (_, index) => index);
+  }
+
+  const selected = new Set<number>();
+  for (const index of required) {
+    if (index >= 0 && index < count) {
+      selected.add(index);
+    }
+  }
+
+  const candidates = Array.from({ length: count }, (_, index) => index)
+    .filter((index) => !selected.has(index))
+    .sort((a, b) => {
+      const scoreDiff = score(b) - score(a);
+      if (scoreDiff !== 0) return scoreDiff;
+      return a - b;
+    });
+
+  for (const index of candidates) {
+    if (selected.size >= maxVisible) break;
+    selected.add(index);
+  }
+
+  return [...selected].sort((a, b) => a - b);
+}
+
+export function buildDisplayItems<T>(
+  versions: T[],
+  selectedIndices: number[],
+): VersionTimelineDisplayItem<T>[] {
+  if (selectedIndices.length === 0) {
+    return [];
+  }
+
+  const items: VersionTimelineDisplayItem<T>[] = [];
+  let previousIndex = -1;
+
+  for (const index of selectedIndices) {
+    const gap = index - previousIndex - 1;
+    if (gap > 0) {
+      items.push({ type: 'gap', hiddenCount: gap });
+    }
+    items.push({ type: 'version', version: versions[index] });
+    previousIndex = index;
+  }
+
+  return items;
+}
+
+export function trimVersionTimeline<T>(
+  versions: T[],
+  options: {
+    seeAllHref: string;
+    maxVisible?: number;
+    requiredIndices: number[];
+    score: (index: number, version: T) => number;
+  },
+): TrimmedVersionTimeline<T> {
+  const maxVisible = options.maxVisible ?? VERSION_TIMELINE_MAX_VISIBLE;
+  const selectedIndices = selectIndices(
+    versions.length,
+    maxVisible,
+    options.requiredIndices,
+    (index) => options.score(index, versions[index]),
+  );
+
+  return {
+    total: versions.length,
+    hidden: versions.length - selectedIndices.length,
+    seeAllHref: options.seeAllHref,
+    items: buildDisplayItems(versions, selectedIndices),
+  };
+}
+
+/** Oldest published version, otherwise the inaugural (oldest) version. */
+export function firstSignificantSubmissionVersionIndex(versions: VersionTimelineEntry[]): number {
+  if (versions.length === 0) return 0;
+
+  for (let index = versions.length - 1; index >= 0; index -= 1) {
+    if (versions[index].date_published) {
+      return index;
+    }
+  }
+
+  return versions.length - 1;
+}
+
+export function submissionVersionTimelineScore(
+  index: number,
+  version: VersionTimelineEntry,
+  count: number,
+): number {
+  let score = count - index;
+  if (version.date_published) {
+    score += 1_000;
+  }
+  return score;
+}
+
+export function trimSubmissionVersionTimeline(
+  versions: VersionTimelineEntry[],
+  seeAllHref: string,
+): TrimmedVersionTimeline<VersionTimelineEntry> {
+  const required = [firstSignificantSubmissionVersionIndex(versions)];
+
+  return trimVersionTimeline(versions, {
+    seeAllHref,
+    requiredIndices: required,
+    score: (index, version) => submissionVersionTimelineScore(index, version, versions.length),
+  });
+}
+
+function workVersionHasSubmissionVersions(version: WorkVersionTimelineEntry): boolean {
+  return (version.submissionVersions?.length ?? 0) > 0;
+}
+
+function workVersionHasPublishedSubmission(version: WorkVersionTimelineEntry): boolean {
+  return (version.submissionVersions ?? []).some((sv) => Boolean(sv.date_published));
+}
+
+export function workVersionTimelineScore(
+  index: number,
+  version: WorkVersionTimelineEntry,
+  count: number,
+): number {
+  let score = count - index;
+  if (workVersionHasSubmissionVersions(version)) {
+    score += 500;
+  }
+  if (workVersionHasPublishedSubmission(version)) {
+    score += 1_000;
+  }
+  return score;
+}
+
+export function trimWorkVersionTimeline(
+  versions: WorkVersionTimelineEntry[],
+  seeAllHref: string,
+): TrimmedVersionTimeline<WorkVersionTimelineEntry> {
+  const required = versions.length > 0 ? [versions.length - 1] : [];
+
+  return trimVersionTimeline(versions, {
+    seeAllHref,
+    requiredIndices: required,
+    score: (index, version) => workVersionTimelineScore(index, version, versions.length),
+  });
+}

--- a/packages/scms-core/src/utils/versionTimelineUrls.ts
+++ b/packages/scms-core/src/utils/versionTimelineUrls.ts
@@ -7,3 +7,13 @@ export function submissionVersionsTimelineUrl(siteName: string, submissionId: st
 export function workVersionsTimelineUrl(workId: string) {
   return `/app/works/${encodeURIComponent(workId)}/versions`;
 }
+
+/** Full submission versions listing on the submission detail page. */
+export function submissionVersionsSeeAllUrl(siteName: string, submissionId: string) {
+  return `/app/sites/${encodeURIComponent(siteName)}/submissions/${encodeURIComponent(submissionId)}`;
+}
+
+/** Full work version timeline on the work details page. */
+export function workVersionsSeeAllUrl(workId: string) {
+  return `/app/works/${encodeURIComponent(workId)}/details`;
+}

--- a/packages/scms-core/src/utils/versionTimelineUrls.ts
+++ b/packages/scms-core/src/utils/versionTimelineUrls.ts
@@ -1,0 +1,9 @@
+/** JSON resource route for submission version timelines (sites extension). */
+export function submissionVersionsTimelineUrl(siteName: string, submissionId: string) {
+  return `/app/sites/${encodeURIComponent(siteName)}/submissions/${encodeURIComponent(submissionId)}/versions`;
+}
+
+/** JSON resource route for work version timelines (works app). */
+export function workVersionsTimelineUrl(workId: string) {
+  return `/app/works/${encodeURIComponent(workId)}/versions`;
+}

--- a/platform/scms/app/routes.ts
+++ b/platform/scms/app/routes.ts
@@ -157,6 +157,7 @@ export default [
       index('routes/app/works._index/route.tsx'),
       route('new', 'routes/app/works.new/route.tsx'),
       route('drafts', 'routes/app/works.drafts/route.tsx'),
+      route(':workId/versions', 'routes/app/works.$workId.versions/route.ts'),
       route(':workId', 'routes/app/works.$workId/route.tsx', [
         ...getRoutesForMountPoint('app/works/:workId'),
         // index('routes/app/works.$workId._index/route.tsx'),

--- a/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
@@ -215,10 +215,10 @@ function WorkVersionTimelineInner({
             <ui.TooltipProvider delayDuration={1000}>
               <ui.Tooltip delayDuration={1000}>
                 <ui.TooltipTrigger asChild>
-                  <span className="cursor-default">v{versionNumber}</span>
+                  <span className="cursor-default">r{versionNumber}</span>
                 </ui.TooltipTrigger>
                 <ui.TooltipContent side="top" className="text-sm">
-                  {formatDate(v.date_created, 'MMM d, yyyy h:mm:ss a')}
+                  Revision {versionNumber}
                 </ui.TooltipContent>
               </ui.Tooltip>
             </ui.TooltipProvider>

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
@@ -41,6 +41,7 @@ describe('dbLoadWorkVersionsTimeline', () => {
             id: 'sv-2',
             status: 'PUBLISHED',
             tags: ['v2'],
+            date_published: '2026-05-02T08:00:00.000Z',
             submission: {
               id: 'sub-1',
               site: {
@@ -78,6 +79,7 @@ describe('dbLoadWorkVersionsTimeline', () => {
             submissionId: 'sub-1',
             status: 'PUBLISHED',
             statusLabel: 'Published',
+            date_published: '2026-05-02T08:00:00.000Z',
             tag: 'v2',
             statusTags: ['ok', 'end'],
             site: {

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { SIMPLE_PUBLIC_WORKFLOW } from '@curvenote/scms-core';
 
 vi.mock('@curvenote/scms-server', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@curvenote/scms-server')>();
@@ -9,6 +10,8 @@ vi.mock('@curvenote/scms-server', async (importOriginal) => {
     getPrismaClient: vi.fn(),
   };
 });
+
+const workflows = { SIMPLE: SIMPLE_PUBLIC_WORKFLOW };
 
 describe('dbLoadWorkVersionsTimeline', () => {
   let mockPrisma: {
@@ -24,22 +27,30 @@ describe('dbLoadWorkVersionsTimeline', () => {
     vi.mocked(getPrismaClient).mockResolvedValue(mockPrisma as never);
   });
 
-  it('returns versions newest-first with tags', async () => {
+  it('returns versions newest-first with tags and linked submission versions', async () => {
     const { dbLoadWorkVersionsTimeline } = await import('./db.server.js');
     mockPrisma.workVersion.findMany.mockResolvedValue([
-      {
-        id: 'wv-draft',
-        date_created: '2026-05-03T00:00:00.000Z',
-        date_modified: '2026-05-03T12:00:00.000Z',
-        draft: true,
-        tags: ['draft-tag'],
-      },
       {
         id: 'wv-2',
         date_created: '2026-05-02T00:00:00.000Z',
         date_modified: '2026-05-02T12:00:00.000Z',
         draft: false,
         tags: ['v2'],
+        submissionVersions: [
+          {
+            id: 'sv-2',
+            status: 'PUBLISHED',
+            submission: {
+              id: 'sub-1',
+              site: {
+                name: 'demo',
+                title: 'Demo Site',
+                metadata: { logo: 'https://example.com/logo.png' },
+              },
+              collection: { workflow: 'SIMPLE' },
+            },
+          },
+        ],
       },
       {
         id: 'wv-1',
@@ -47,25 +58,33 @@ describe('dbLoadWorkVersionsTimeline', () => {
         date_modified: '2026-05-01T00:00:00.000Z',
         draft: false,
         tags: [],
+        submissionVersions: [],
       },
     ]);
 
-    const result = await dbLoadWorkVersionsTimeline('work-1');
+    const result = await dbLoadWorkVersionsTimeline('work-1', workflows);
 
     expect(result).toEqual([
-      {
-        id: 'wv-draft',
-        date_created: '2026-05-03T00:00:00.000Z',
-        date_modified: '2026-05-03T12:00:00.000Z',
-        draft: true,
-        tag: 'draft-tag',
-      },
       {
         id: 'wv-2',
         date_created: '2026-05-02T00:00:00.000Z',
         date_modified: '2026-05-02T12:00:00.000Z',
         draft: false,
         tag: 'v2',
+        submissionVersions: [
+          {
+            id: 'sv-2',
+            submissionId: 'sub-1',
+            status: 'PUBLISHED',
+            statusLabel: 'Published',
+            statusTags: ['ok', 'end'],
+            site: {
+              name: 'demo',
+              title: 'Demo Site',
+              logo: 'https://example.com/logo.png',
+            },
+          },
+        ],
       },
       {
         id: 'wv-1',
@@ -73,6 +92,7 @@ describe('dbLoadWorkVersionsTimeline', () => {
         date_modified: '2026-05-01T00:00:00.000Z',
         draft: false,
         tag: undefined,
+        submissionVersions: [],
       },
     ]);
   });

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
@@ -40,6 +40,7 @@ describe('dbLoadWorkVersionsTimeline', () => {
           {
             id: 'sv-2',
             status: 'PUBLISHED',
+            tags: ['v2'],
             submission: {
               id: 'sub-1',
               site: {
@@ -77,6 +78,7 @@ describe('dbLoadWorkVersionsTimeline', () => {
             submissionId: 'sub-1',
             status: 'PUBLISHED',
             statusLabel: 'Published',
+            tag: 'v2',
             statusTags: ['ok', 'end'],
             site: {
               name: 'demo',

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
@@ -27,7 +27,7 @@ describe('dbLoadWorkVersionsTimeline', () => {
     vi.mocked(getPrismaClient).mockResolvedValue(mockPrisma as never);
   });
 
-  it('returns versions newest-first with tags and linked submission versions', async () => {
+  it('returns versions newest-first with linked submission versions', async () => {
     const { dbLoadWorkVersionsTimeline } = await import('./db.server.js');
     mockPrisma.workVersion.findMany.mockResolvedValue([
       {
@@ -35,7 +35,6 @@ describe('dbLoadWorkVersionsTimeline', () => {
         date_created: '2026-05-02T00:00:00.000Z',
         date_modified: '2026-05-02T12:00:00.000Z',
         draft: false,
-        tags: ['v2'],
         submissionVersions: [
           {
             id: 'sv-2',
@@ -59,7 +58,6 @@ describe('dbLoadWorkVersionsTimeline', () => {
         date_created: '2026-05-01T00:00:00.000Z',
         date_modified: '2026-05-01T00:00:00.000Z',
         draft: false,
-        tags: [],
         submissionVersions: [],
       },
     ]);
@@ -72,7 +70,6 @@ describe('dbLoadWorkVersionsTimeline', () => {
         date_created: '2026-05-02T00:00:00.000Z',
         date_modified: '2026-05-02T12:00:00.000Z',
         draft: false,
-        tag: 'v2',
         submissionVersions: [
           {
             id: 'sv-2',
@@ -95,7 +92,6 @@ describe('dbLoadWorkVersionsTimeline', () => {
         date_created: '2026-05-01T00:00:00.000Z',
         date_modified: '2026-05-01T00:00:00.000Z',
         draft: false,
-        tag: undefined,
         submissionVersions: [],
       },
     ]);

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
@@ -1,0 +1,82 @@
+/* eslint-disable @typescript-eslint/consistent-type-imports */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('@curvenote/scms-server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@curvenote/scms-server')>();
+  return {
+    ...actual,
+    getPrismaClient: vi.fn(),
+  };
+});
+
+describe('dbLoadWorkVersionsTimeline', () => {
+  let mockPrisma: {
+    workVersion: { findMany: ReturnType<typeof vi.fn> };
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockPrisma = {
+      workVersion: { findMany: vi.fn() },
+    };
+    const { getPrismaClient } = await import('@curvenote/scms-server');
+    vi.mocked(getPrismaClient).mockResolvedValue(mockPrisma as never);
+  });
+
+  it('returns versions newest-first with draft labels and version numbers', async () => {
+    const { dbLoadWorkVersionsTimeline } = await import('./db.server.js');
+    mockPrisma.workVersion.findMany.mockResolvedValue([
+      {
+        id: 'wv-draft',
+        date_created: '2026-05-03T00:00:00.000Z',
+        date_modified: '2026-05-03T12:00:00.000Z',
+        draft: true,
+        tags: ['draft-tag'],
+      },
+      {
+        id: 'wv-2',
+        date_created: '2026-05-02T00:00:00.000Z',
+        date_modified: '2026-05-02T12:00:00.000Z',
+        draft: false,
+        tags: ['v2'],
+      },
+      {
+        id: 'wv-1',
+        date_created: '2026-05-01T00:00:00.000Z',
+        date_modified: '2026-05-01T00:00:00.000Z',
+        draft: false,
+        tags: [],
+      },
+    ]);
+
+    const result = await dbLoadWorkVersionsTimeline('work-1');
+
+    expect(result).toEqual([
+      {
+        id: 'wv-draft',
+        date_created: '2026-05-03T00:00:00.000Z',
+        date_modified: '2026-05-03T12:00:00.000Z',
+        draft: true,
+        label: 'Draft',
+        tag: 'draft-tag',
+      },
+      {
+        id: 'wv-2',
+        date_created: '2026-05-02T00:00:00.000Z',
+        date_modified: '2026-05-02T12:00:00.000Z',
+        draft: false,
+        label: 'v2',
+        tag: 'v2',
+      },
+      {
+        id: 'wv-1',
+        date_created: '2026-05-01T00:00:00.000Z',
+        date_modified: '2026-05-01T00:00:00.000Z',
+        draft: false,
+        label: 'v1',
+        tag: undefined,
+      },
+    ]);
+  });
+});

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
@@ -24,7 +24,7 @@ describe('dbLoadWorkVersionsTimeline', () => {
     vi.mocked(getPrismaClient).mockResolvedValue(mockPrisma as never);
   });
 
-  it('returns versions newest-first with draft labels and version numbers', async () => {
+  it('returns versions newest-first with tags', async () => {
     const { dbLoadWorkVersionsTimeline } = await import('./db.server.js');
     mockPrisma.workVersion.findMany.mockResolvedValue([
       {
@@ -58,7 +58,6 @@ describe('dbLoadWorkVersionsTimeline', () => {
         date_created: '2026-05-03T00:00:00.000Z',
         date_modified: '2026-05-03T12:00:00.000Z',
         draft: true,
-        label: 'Draft',
         tag: 'draft-tag',
       },
       {
@@ -66,7 +65,6 @@ describe('dbLoadWorkVersionsTimeline', () => {
         date_created: '2026-05-02T00:00:00.000Z',
         date_modified: '2026-05-02T12:00:00.000Z',
         draft: false,
-        label: 'v2',
         tag: 'v2',
       },
       {
@@ -74,7 +72,6 @@ describe('dbLoadWorkVersionsTimeline', () => {
         date_created: '2026-05-01T00:00:00.000Z',
         date_modified: '2026-05-01T00:00:00.000Z',
         draft: false,
-        label: 'v1',
         tag: undefined,
       },
     ]);

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
@@ -1,11 +1,54 @@
 import { getPrismaClient } from '@curvenote/scms-server';
-import type { WorkVersionTimelineEntry } from '@curvenote/scms-core';
+import type { WorkVersionTimelineEntry, Workflow } from '@curvenote/scms-core';
+
+function siteLogoFromMetadata(metadata: unknown): string | undefined {
+  if (!metadata || typeof metadata !== 'object' || !('logo' in metadata)) {
+    return undefined;
+  }
+  const logo = (metadata as { logo?: unknown }).logo;
+  return typeof logo === 'string' ? logo : undefined;
+}
+
+function mapSubmissionVersions(
+  submissionVersions: Array<{
+    id: string;
+    status: string;
+    submission: {
+      id: string;
+      site: { name: string; title: string | null; metadata: unknown };
+      collection: { workflow: string };
+    };
+  }>,
+  workflows: Record<string, Workflow>,
+): WorkVersionTimelineEntry['submissionVersions'] {
+  return submissionVersions
+    .map((sv) => {
+      const workflow = workflows[sv.submission.collection.workflow] ?? workflows.SIMPLE;
+      const state = workflow?.states[sv.status];
+      const site = sv.submission.site;
+
+      return {
+        id: sv.id,
+        submissionId: sv.submission.id,
+        status: sv.status,
+        statusLabel: state?.label ?? sv.status,
+        statusTags: state?.tags,
+        site: {
+          name: site.name,
+          title: site.title ?? undefined,
+          logo: siteLogoFromMetadata(site.metadata),
+        },
+      };
+    })
+    .sort((a, b) => a.site.name.localeCompare(b.site.name));
+}
 
 /**
  * All work versions for the version-timeline hover card (newest first).
  */
 export async function dbLoadWorkVersionsTimeline(
   workId: string,
+  workflows: Record<string, Workflow>,
 ): Promise<WorkVersionTimelineEntry[]> {
   const prisma = await getPrismaClient();
 
@@ -18,6 +61,29 @@ export async function dbLoadWorkVersionsTimeline(
       date_modified: true,
       draft: true,
       tags: true,
+      submissionVersions: {
+        select: {
+          id: true,
+          status: true,
+          submission: {
+            select: {
+              id: true,
+              site: {
+                select: {
+                  name: true,
+                  title: true,
+                  metadata: true,
+                },
+              },
+              collection: {
+                select: {
+                  workflow: true,
+                },
+              },
+            },
+          },
+        },
+      },
     },
   });
 
@@ -27,5 +93,6 @@ export async function dbLoadWorkVersionsTimeline(
     date_modified: row.date_modified,
     draft: row.draft,
     tag: row.tags[0],
+    submissionVersions: mapSubmissionVersions(row.submissionVersions, workflows),
   }));
 }

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
@@ -13,6 +13,7 @@ function mapSubmissionVersions(
   submissionVersions: Array<{
     id: string;
     status: string;
+    tags: string[];
     submission: {
       id: string;
       site: { name: string; title: string | null; metadata: unknown };
@@ -32,6 +33,7 @@ function mapSubmissionVersions(
         submissionId: sv.submission.id,
         status: sv.status,
         statusLabel: state?.label ?? sv.status,
+        tag: sv.tags[0],
         statusTags: state?.tags,
         site: {
           name: site.name,
@@ -65,6 +67,7 @@ export async function dbLoadWorkVersionsTimeline(
         select: {
           id: true,
           status: true,
+          tags: true,
           submission: {
             select: {
               id: true,

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
@@ -14,6 +14,7 @@ function mapSubmissionVersions(
     id: string;
     status: string;
     tags: string[];
+    date_published: string | null;
     submission: {
       id: string;
       site: { name: string; title: string | null; metadata: unknown };
@@ -33,6 +34,7 @@ function mapSubmissionVersions(
         submissionId: sv.submission.id,
         status: sv.status,
         statusLabel: state?.label ?? sv.status,
+        date_published: sv.date_published ?? undefined,
         tag: sv.tags[0],
         statusTags: state?.tags,
         site: {
@@ -68,6 +70,7 @@ export async function dbLoadWorkVersionsTimeline(
           id: true,
           status: true,
           tags: true,
+          date_published: true,
           submission: {
             select: {
               id: true,

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
@@ -21,22 +21,11 @@ export async function dbLoadWorkVersionsTimeline(
     },
   });
 
-  const finalizedAsc = rows
-    .filter((row) => !row.draft)
-    .slice()
-    .sort((a, b) => Date.parse(a.date_created) - Date.parse(b.date_created));
-
-  const labelById = new Map<string, string>();
-  finalizedAsc.forEach((row, index) => {
-    labelById.set(row.id, `v${index + 1}`);
-  });
-
   return rows.map((row) => ({
     id: row.id,
     date_created: row.date_created,
     date_modified: row.date_modified,
     draft: row.draft,
-    label: row.draft ? 'Draft' : (labelById.get(row.id) ?? 'Version'),
     tag: row.tags[0],
   }));
 }

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
@@ -1,0 +1,42 @@
+import { getPrismaClient } from '@curvenote/scms-server';
+import type { WorkVersionTimelineEntry } from '@curvenote/scms-core';
+
+/**
+ * All work versions for the version-timeline hover card (newest first).
+ */
+export async function dbLoadWorkVersionsTimeline(
+  workId: string,
+): Promise<WorkVersionTimelineEntry[]> {
+  const prisma = await getPrismaClient();
+
+  const rows = await prisma.workVersion.findMany({
+    where: { work_id: workId },
+    orderBy: { date_created: 'desc' },
+    select: {
+      id: true,
+      date_created: true,
+      date_modified: true,
+      draft: true,
+      tags: true,
+    },
+  });
+
+  const finalizedAsc = rows
+    .filter((row) => !row.draft)
+    .slice()
+    .sort((a, b) => Date.parse(a.date_created) - Date.parse(b.date_created));
+
+  const labelById = new Map<string, string>();
+  finalizedAsc.forEach((row, index) => {
+    labelById.set(row.id, `v${index + 1}`);
+  });
+
+  return rows.map((row) => ({
+    id: row.id,
+    date_created: row.date_created,
+    date_modified: row.date_modified,
+    draft: row.draft,
+    label: row.draft ? 'Draft' : (labelById.get(row.id) ?? 'Version'),
+    tag: row.tags[0],
+  }));
+}

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
@@ -64,7 +64,6 @@ export async function dbLoadWorkVersionsTimeline(
       date_created: true,
       date_modified: true,
       draft: true,
-      tags: true,
       submissionVersions: {
         select: {
           id: true,
@@ -98,7 +97,6 @@ export async function dbLoadWorkVersionsTimeline(
     date_created: row.date_created,
     date_modified: row.date_modified,
     draft: row.draft,
-    tag: row.tags[0],
     submissionVersions: mapSubmissionVersions(row.submissionVersions, workflows),
   }));
 }

--- a/platform/scms/app/routes/app/works.$workId.versions/route.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/route.ts
@@ -1,0 +1,19 @@
+import type { LoaderFunctionArgs } from 'react-router';
+import { data } from 'react-router';
+import { withAppWorkContext } from '@curvenote/scms-server';
+import { scopes } from '@curvenote/scms-core';
+import { dbLoadWorkVersionsTimeline } from './db.server.js';
+
+/**
+ * Resource route powering the works-listing work-version timeline hover card.
+ *
+ * JSON-only, no default export. Contract:
+ *   GET /app/works/:workId/versions
+ *     200 -> { versions: WorkVersionTimelineEntry[] }   (newest first)
+ */
+export async function loader(args: LoaderFunctionArgs) {
+  const ctx = await withAppWorkContext(args, [scopes.work.id.read], { redirect: false });
+
+  const versions = await dbLoadWorkVersionsTimeline(ctx.work.id);
+  return data({ versions });
+}

--- a/platform/scms/app/routes/app/works.$workId.versions/route.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/route.ts
@@ -1,7 +1,13 @@
 import type { LoaderFunctionArgs } from 'react-router';
 import { data } from 'react-router';
 import { withAppWorkContext } from '@curvenote/scms-server';
-import { getWorkflows, registerExtensionWorkflows, scopes } from '@curvenote/scms-core';
+import {
+  getWorkflows,
+  registerExtensionWorkflows,
+  scopes,
+  trimWorkVersionTimeline,
+  workVersionsSeeAllUrl,
+} from '@curvenote/scms-core';
 import { extensions } from '../../../extensions/client.js';
 import { dbLoadWorkVersionsTimeline } from './db.server.js';
 
@@ -10,12 +16,12 @@ import { dbLoadWorkVersionsTimeline } from './db.server.js';
  *
  * JSON-only, no default export. Contract:
  *   GET /app/works/:workId/versions
- *     200 -> { versions: WorkVersionTimelineEntry[] }   (newest first)
+ *     200 -> TrimmedVersionTimeline<WorkVersionTimelineEntry>   (newest first, max 8 visible)
  */
 export async function loader(args: LoaderFunctionArgs) {
   const ctx = await withAppWorkContext(args, [scopes.work.id.read], { redirect: false });
 
   const workflows = getWorkflows(ctx.$config, registerExtensionWorkflows(extensions));
   const versions = await dbLoadWorkVersionsTimeline(ctx.work.id, workflows);
-  return data({ versions });
+  return data(trimWorkVersionTimeline(versions, workVersionsSeeAllUrl(ctx.work.id)));
 }

--- a/platform/scms/app/routes/app/works.$workId.versions/route.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/route.ts
@@ -1,7 +1,8 @@
 import type { LoaderFunctionArgs } from 'react-router';
 import { data } from 'react-router';
 import { withAppWorkContext } from '@curvenote/scms-server';
-import { scopes } from '@curvenote/scms-core';
+import { getWorkflows, registerExtensionWorkflows, scopes } from '@curvenote/scms-core';
+import { extensions } from '../../../extensions/client.js';
 import { dbLoadWorkVersionsTimeline } from './db.server.js';
 
 /**
@@ -14,6 +15,7 @@ import { dbLoadWorkVersionsTimeline } from './db.server.js';
 export async function loader(args: LoaderFunctionArgs) {
   const ctx = await withAppWorkContext(args, [scopes.work.id.read], { redirect: false });
 
-  const versions = await dbLoadWorkVersionsTimeline(ctx.work.id);
+  const workflows = getWorkflows(ctx.$config, registerExtensionWorkflows(extensions));
+  const versions = await dbLoadWorkVersionsTimeline(ctx.work.id, workflows);
   return data({ versions });
 }

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -5,11 +5,9 @@ import {
   primitives,
   ui,
   WorkVersionTimelineHoverCard,
-  SubmissionVersionTimelineHoverCard,
   workVersionsTimelineUrl,
-  submissionVersionsTimelineUrl,
 } from '@curvenote/scms-core';
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, History } from 'lucide-react';
 import type { dbGetWorksAndSubmissionVersions } from './db.server';
 
 export type WorkCardDBO = Awaited<ReturnType<typeof dbGetWorksAndSubmissionVersions>>[0];
@@ -135,36 +133,32 @@ export function WorkListItem({
                 if (!latestNonDraftSubmissionVersion || !workflow) return null;
 
                 return (
-                  <SubmissionVersionTimelineHoverCard
+                  <ui.SubmissionVersionBadge
                     key={`submission-badge-${submission.id}`}
-                    versionsUrl={submissionVersionsTimelineUrl(submission.site.name, submission.id)}
-                  >
-                    <ui.SubmissionVersionBadge
-                      submissionVersion={{
-                        id: latestNonDraftSubmissionVersion.id,
-                        status: latestNonDraftSubmissionVersion.status,
-                        submission: {
-                          id: submission.id,
-                          collection: {
-                            workflow: submission.collection.workflow,
-                          },
-                          site: {
-                            name: submission.site.name,
-                            title: submission.site.title,
-                            metadata: submission.site.metadata,
-                          },
+                    submissionVersion={{
+                      id: latestNonDraftSubmissionVersion.id,
+                      status: latestNonDraftSubmissionVersion.status,
+                      submission: {
+                        id: submission.id,
+                        collection: {
+                          workflow: submission.collection.workflow,
                         },
-                      }}
-                      workflows={{ [submission.collection.workflow]: workflow }}
-                      basePath={`/app/works/${work.id}`}
-                      workVersionId={
-                        latestNonDraftSubmissionVersion.work_version?.id || latestVersion?.id || ''
-                      }
-                      showSite
-                      showLink={false}
-                      variant="outline"
-                    />
-                  </SubmissionVersionTimelineHoverCard>
+                        site: {
+                          name: submission.site.name,
+                          title: submission.site.title,
+                          metadata: submission.site.metadata,
+                        },
+                      },
+                    }}
+                    workflows={{ [submission.collection.workflow]: workflow }}
+                    basePath={`/app/works/${work.id}`}
+                    workVersionId={
+                      latestNonDraftSubmissionVersion.work_version?.id || latestVersion?.id || ''
+                    }
+                    showSite
+                    showLink={false}
+                    variant="outline"
+                  />
                 );
               })}
           </div>
@@ -174,32 +168,35 @@ export function WorkListItem({
         <div className="flex flex-col flex-shrink-0 items-center self-stretch w-48 pt-[1px]">
           <div className="flex flex-wrap gap-2 justify-center mb-2 w-full">
             {activityTime && (
-              <WorkVersionTimelineHoverCard versionsUrl={workVersionsUrl} align="end">
-                <primitives.Chip
-                  className="text-gray-500 border-[1px] border-gray-200 dark:border-gray-500 dark:text-gray-500"
-                  title={`Last activity was ${activityTime}`}
-                >
-                  Activity {activityTime}
-                </primitives.Chip>
-              </WorkVersionTimelineHoverCard>
+              <primitives.Chip
+                className="text-gray-500 border-[1px] border-gray-200 dark:border-gray-500 dark:text-gray-500"
+                title={`Last activity was ${activityTime}`}
+              >
+                Activity {activityTime}
+              </primitives.Chip>
             )}
           </div>
 
-          {/* Published Date */}
           {publishedDate && (
-            <WorkVersionTimelineHoverCard versionsUrl={workVersionsUrl} align="end">
-              <div className="text-xs text-gray-600 dark:text-gray-400">
-                Published: {formatDate(publishedDate)}
-              </div>
-            </WorkVersionTimelineHoverCard>
+            <div className="text-xs text-gray-600 dark:text-gray-400">
+              Published: {formatDate(publishedDate)}
+            </div>
           )}
           {!publishedDate && latestVersion && (
-            <WorkVersionTimelineHoverCard versionsUrl={workVersionsUrl} align="end">
-              <div className="text-xs text-gray-600 dark:text-gray-400">
-                Created: {formatDate(latestVersion.date_created)}
-              </div>
-            </WorkVersionTimelineHoverCard>
+            <div className="text-xs text-gray-600 dark:text-gray-400">
+              Created: {formatDate(latestVersion.date_created)}
+            </div>
           )}
+
+          <WorkVersionTimelineHoverCard versionsUrl={workVersionsUrl} align="end" side="left">
+            <button
+              type="button"
+              className="mt-2 inline-flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400"
+            >
+              <History className="size-3.5 shrink-0" aria-hidden />
+              Timeline
+            </button>
+          </WorkVersionTimelineHoverCard>
         </div>
       </div>
     </div>

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -1,5 +1,14 @@
 import { Link } from 'react-router';
-import { formatDate, formatToNow, primitives, ui } from '@curvenote/scms-core';
+import {
+  formatDate,
+  formatToNow,
+  primitives,
+  ui,
+  WorkVersionTimelineHoverCard,
+  SubmissionVersionTimelineHoverCard,
+  workVersionsTimelineUrl,
+  submissionVersionsTimelineUrl,
+} from '@curvenote/scms-core';
 import { ExternalLink } from 'lucide-react';
 import type { dbGetWorksAndSubmissionVersions } from './db.server';
 
@@ -34,6 +43,8 @@ export function WorkListItem({
   const hasSlug = work.submissions.some(
     (submission) => submission.slugs && submission.slugs.length > 0,
   );
+
+  const workVersionsUrl = workVersionsTimelineUrl(work.id);
 
   return (
     <div className="px-6 py-4">
@@ -124,32 +135,36 @@ export function WorkListItem({
                 if (!latestNonDraftSubmissionVersion || !workflow) return null;
 
                 return (
-                  <ui.SubmissionVersionBadge
+                  <SubmissionVersionTimelineHoverCard
                     key={`submission-badge-${submission.id}`}
-                    submissionVersion={{
-                      id: latestNonDraftSubmissionVersion.id,
-                      status: latestNonDraftSubmissionVersion.status,
-                      submission: {
-                        id: submission.id,
-                        collection: {
-                          workflow: submission.collection.workflow,
+                    versionsUrl={submissionVersionsTimelineUrl(submission.site.name, submission.id)}
+                  >
+                    <ui.SubmissionVersionBadge
+                      submissionVersion={{
+                        id: latestNonDraftSubmissionVersion.id,
+                        status: latestNonDraftSubmissionVersion.status,
+                        submission: {
+                          id: submission.id,
+                          collection: {
+                            workflow: submission.collection.workflow,
+                          },
+                          site: {
+                            name: submission.site.name,
+                            title: submission.site.title,
+                            metadata: submission.site.metadata,
+                          },
                         },
-                        site: {
-                          name: submission.site.name,
-                          title: submission.site.title,
-                          metadata: submission.site.metadata,
-                        },
-                      },
-                    }}
-                    workflows={{ [submission.collection.workflow]: workflow }}
-                    basePath={`/app/works/${work.id}`}
-                    workVersionId={
-                      latestNonDraftSubmissionVersion.work_version?.id || latestVersion?.id || ''
-                    }
-                    showSite
-                    showLink={false}
-                    variant="outline"
-                  />
+                      }}
+                      workflows={{ [submission.collection.workflow]: workflow }}
+                      basePath={`/app/works/${work.id}`}
+                      workVersionId={
+                        latestNonDraftSubmissionVersion.work_version?.id || latestVersion?.id || ''
+                      }
+                      showSite
+                      showLink={false}
+                      variant="outline"
+                    />
+                  </SubmissionVersionTimelineHoverCard>
                 );
               })}
           </div>
@@ -159,25 +174,31 @@ export function WorkListItem({
         <div className="flex flex-col flex-shrink-0 items-center self-stretch w-48 pt-[1px]">
           <div className="flex flex-wrap gap-2 justify-center mb-2 w-full">
             {activityTime && (
-              <primitives.Chip
-                className="text-gray-500 border-[1px] border-gray-200 dark:border-gray-500 dark:text-gray-500"
-                title={`Last activity was ${activityTime}`}
-              >
-                Activity {activityTime}
-              </primitives.Chip>
+              <WorkVersionTimelineHoverCard versionsUrl={workVersionsUrl} align="end">
+                <primitives.Chip
+                  className="text-gray-500 border-[1px] border-gray-200 dark:border-gray-500 dark:text-gray-500"
+                  title={`Last activity was ${activityTime}`}
+                >
+                  Activity {activityTime}
+                </primitives.Chip>
+              </WorkVersionTimelineHoverCard>
             )}
           </div>
 
           {/* Published Date */}
           {publishedDate && (
-            <div className="text-xs text-gray-600 dark:text-gray-400">
-              Published: {formatDate(publishedDate)}
-            </div>
+            <WorkVersionTimelineHoverCard versionsUrl={workVersionsUrl} align="end">
+              <div className="text-xs text-gray-600 dark:text-gray-400">
+                Published: {formatDate(publishedDate)}
+              </div>
+            </WorkVersionTimelineHoverCard>
           )}
           {!publishedDate && latestVersion && (
-            <div className="text-xs text-gray-600 dark:text-gray-400">
-              Created: {formatDate(latestVersion.date_created)}
-            </div>
+            <WorkVersionTimelineHoverCard versionsUrl={workVersionsUrl} align="end">
+              <div className="text-xs text-gray-600 dark:text-gray-400">
+                Created: {formatDate(latestVersion.date_created)}
+              </div>
+            </WorkVersionTimelineHoverCard>
           )}
         </div>
       </div>

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -138,6 +138,7 @@ export function WorkListItem({
                   <SubmissionVersionTimelineHoverCard
                     key={`submission-badge-${submission.id}`}
                     versionsUrl={submissionVersionsTimelineUrl(submission.site.name, submission.id)}
+                    title={`Submissions at ${submission.site.title || submission.site.name}`}
                   >
                     <ui.SubmissionVersionBadge
                       submissionVersion={{
@@ -199,6 +200,7 @@ export function WorkListItem({
             workId={work.id}
             align="end"
             side="left"
+            title="Work Timeline"
           >
             <button
               type="button"

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -137,10 +137,7 @@ export function WorkListItem({
                 return (
                   <SubmissionVersionTimelineHoverCard
                     key={`submission-badge-${submission.id}`}
-                    versionsUrl={submissionVersionsTimelineUrl(
-                      submission.site.name,
-                      submission.id,
-                    )}
+                    versionsUrl={submissionVersionsTimelineUrl(submission.site.name, submission.id)}
                   >
                     <ui.SubmissionVersionBadge
                       submissionVersion={{

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -194,7 +194,12 @@ export function WorkListItem({
             </div>
           )}
 
-          <WorkVersionTimelineHoverCard versionsUrl={workVersionsUrl} align="end" side="left">
+          <WorkVersionTimelineHoverCard
+            versionsUrl={workVersionsUrl}
+            workId={work.id}
+            align="end"
+            side="left"
+          >
             <button
               type="button"
               className="mt-2 inline-flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400"

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -9,7 +9,7 @@ import {
   workVersionsTimelineUrl,
   submissionVersionsTimelineUrl,
 } from '@curvenote/scms-core';
-import { ExternalLink, History } from 'lucide-react';
+import { ExternalLink, Timeline } from 'lucide-react';
 import type { dbGetWorksAndSubmissionVersions } from './db.server';
 
 export type WorkCardDBO = Awaited<ReturnType<typeof dbGetWorksAndSubmissionVersions>>[0];
@@ -199,7 +199,7 @@ export function WorkListItem({
               type="button"
               className="mt-2 inline-flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400"
             >
-              <History className="size-3.5 shrink-0" aria-hidden />
+              <Timeline className="size-3.5 shrink-0" aria-hidden />
               Timeline
             </button>
           </WorkVersionTimelineHoverCard>

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -5,7 +5,9 @@ import {
   primitives,
   ui,
   WorkVersionTimelineHoverCard,
+  SubmissionVersionTimelineHoverCard,
   workVersionsTimelineUrl,
+  submissionVersionsTimelineUrl,
 } from '@curvenote/scms-core';
 import { ExternalLink, History } from 'lucide-react';
 import type { dbGetWorksAndSubmissionVersions } from './db.server';
@@ -133,32 +135,39 @@ export function WorkListItem({
                 if (!latestNonDraftSubmissionVersion || !workflow) return null;
 
                 return (
-                  <ui.SubmissionVersionBadge
+                  <SubmissionVersionTimelineHoverCard
                     key={`submission-badge-${submission.id}`}
-                    submissionVersion={{
-                      id: latestNonDraftSubmissionVersion.id,
-                      status: latestNonDraftSubmissionVersion.status,
-                      submission: {
-                        id: submission.id,
-                        collection: {
-                          workflow: submission.collection.workflow,
+                    versionsUrl={submissionVersionsTimelineUrl(
+                      submission.site.name,
+                      submission.id,
+                    )}
+                  >
+                    <ui.SubmissionVersionBadge
+                      submissionVersion={{
+                        id: latestNonDraftSubmissionVersion.id,
+                        status: latestNonDraftSubmissionVersion.status,
+                        submission: {
+                          id: submission.id,
+                          collection: {
+                            workflow: submission.collection.workflow,
+                          },
+                          site: {
+                            name: submission.site.name,
+                            title: submission.site.title,
+                            metadata: submission.site.metadata,
+                          },
                         },
-                        site: {
-                          name: submission.site.name,
-                          title: submission.site.title,
-                          metadata: submission.site.metadata,
-                        },
-                      },
-                    }}
-                    workflows={{ [submission.collection.workflow]: workflow }}
-                    basePath={`/app/works/${work.id}`}
-                    workVersionId={
-                      latestNonDraftSubmissionVersion.work_version?.id || latestVersion?.id || ''
-                    }
-                    showSite
-                    showLink={false}
-                    variant="outline"
-                  />
+                      }}
+                      workflows={{ [submission.collection.workflow]: workflow }}
+                      basePath={`/app/works/${work.id}`}
+                      workVersionId={
+                        latestNonDraftSubmissionVersion.work_version?.id || latestVersion?.id || ''
+                      }
+                      showSite
+                      showLink={false}
+                      variant="outline"
+                    />
+                  </SubmissionVersionTimelineHoverCard>
                 );
               })}
           </div>

--- a/platform/scms/package.template.json
+++ b/platform/scms/package.template.json
@@ -149,7 +149,7 @@
     "isbot": "^5",
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.3",
-    "lucide-react": "^0.564.0",
+    "lucide-react": "^1.18.0",
     "myst-to-react": "^0.17.1",
     "nprogress": "^0.2.0",
     "p-limit": "^3.1.0",

--- a/prisma/scripts/seed-scipy-work-4-timeline.mts
+++ b/prisma/scripts/seed-scipy-work-4-timeline.mts
@@ -69,7 +69,7 @@ for (let index = 0; index < TOTAL_WORK_VERSIONS; index += 1) {
         date_modified: dateCreated,
         canonical: true,
         draft: false,
-        tags: ['v20'],
+        tags: [],
       },
     });
     continue;
@@ -90,7 +90,7 @@ for (let index = 0; index < TOTAL_WORK_VERSIONS; index += 1) {
       cdn: template.cdn,
       cdn_key: template.cdn_key,
       canonical: false,
-      tags: [`v${index + 1}`],
+      tags: [],
     },
   });
 }

--- a/prisma/scripts/seed-scipy-work-4-timeline.mts
+++ b/prisma/scripts/seed-scipy-work-4-timeline.mts
@@ -1,0 +1,171 @@
+/**
+ * One-off dev seed: 20 work versions + 12 submission versions for timeline popover testing.
+ *
+ *   npx tsx prisma/scripts/seed-scipy-work-4-timeline.mts
+ */
+import { getLowLevelPrismaClient } from '@curvenote/scms-db';
+import { uuidv7 as uuid } from 'uuidv7';
+
+const WORK_ID = '019b8eee-306f-7cd6-80e4-720da4aa1559';
+const EXISTING_WORK_VERSION_ID = '019b8eee-306f-7cd6-80e4-720e3f5810d8';
+const SUBMISSION_ID = '019eb721-25f3-7042-8964-751893c88bec';
+const EXISTING_SUBMISSION_VERSION_ID = '019eb721-25f3-7042-8964-75176dadc63c';
+const SUBMITTED_BY_ID = 'mVkwApbQbKQ0ClO9A8ixYOP74JV2';
+
+const TOTAL_WORK_VERSIONS = 20;
+const TOTAL_SUBMISSION_VERSIONS = 12;
+
+/** Work version indices (0 = oldest) that receive a submission version. */
+const SUBMISSION_WORK_VERSION_INDICES = [0, 2, 4, 6, 8, 10, 12, 14, 16, 17, 18, 19];
+
+const SUBMISSION_STATUSES: Array<{
+  status: string;
+  published: boolean;
+}> = [
+  { status: 'PUBLISHED', published: true },
+  { status: 'PENDING', published: false },
+  { status: 'REJECTED', published: false },
+  { status: 'PUBLISHED', published: true },
+  { status: 'PENDING', published: false },
+  { status: 'UNPUBLISHED', published: false },
+  { status: 'PUBLISHED', published: true },
+  { status: 'PENDING', published: false },
+  { status: 'RETRACTED', published: true },
+  { status: 'PUBLISHED', published: true },
+  { status: 'PENDING', published: false },
+  { status: 'PUBLISHED', published: true },
+];
+
+function monthOffset(base: Date, monthsAgo: number): string {
+  const d = new Date(base);
+  d.setUTCMonth(d.getUTCMonth() - monthsAgo);
+  return d.toISOString();
+}
+
+const prisma = await getLowLevelPrismaClient();
+
+const template = await prisma.workVersion.findUniqueOrThrow({
+  where: { id: EXISTING_WORK_VERSION_ID },
+});
+
+const latestDate = new Date(template.date_created);
+const oldestMonthsAgo = TOTAL_WORK_VERSIONS - 1;
+
+const workVersionIds: string[] = new Array(TOTAL_WORK_VERSIONS);
+
+for (let index = 0; index < TOTAL_WORK_VERSIONS; index += 1) {
+  const monthsAgo = oldestMonthsAgo - index;
+  const dateCreated = monthOffset(latestDate, monthsAgo);
+  const isLatest = index === TOTAL_WORK_VERSIONS - 1;
+  const id = isLatest ? EXISTING_WORK_VERSION_ID : uuid();
+
+  workVersionIds[index] = id;
+
+  if (isLatest) {
+    await prisma.workVersion.update({
+      where: { id },
+      data: {
+        date_created: dateCreated,
+        date_modified: dateCreated,
+        canonical: true,
+        draft: false,
+        tags: ['v20'],
+      },
+    });
+    continue;
+  }
+
+  await prisma.workVersion.create({
+    data: {
+      id,
+      work_id: WORK_ID,
+      date_created: dateCreated,
+      date_modified: dateCreated,
+      draft: index >= TOTAL_WORK_VERSIONS - 2,
+      title: template.title,
+      description: template.description,
+      authors: template.authors,
+      author_details: template.author_details,
+      date: isLatest ? template.date : null,
+      cdn: template.cdn,
+      cdn_key: template.cdn_key,
+      canonical: false,
+      tags: [`v${index + 1}`],
+    },
+  });
+}
+
+await prisma.work.update({
+  where: { id: WORK_ID },
+  data: {
+    date_modified: template.date_created,
+  },
+});
+
+let submissionVersionIndex = 0;
+
+for (const workIndex of SUBMISSION_WORK_VERSION_INDICES) {
+  const spec = SUBMISSION_STATUSES[submissionVersionIndex];
+  const tag = `v${submissionVersionIndex + 1}`;
+  const workVersionId = workVersionIds[workIndex]!;
+  const wv = await prisma.workVersion.findUniqueOrThrow({ where: { id: workVersionId } });
+  const datePublished = spec.published ? wv.date ?? wv.date_created : null;
+
+  if (submissionVersionIndex === TOTAL_SUBMISSION_VERSIONS - 1) {
+    await prisma.submissionVersion.update({
+      where: { id: EXISTING_SUBMISSION_VERSION_ID },
+      data: {
+        work_version_id: workVersionId,
+        date_created: wv.date_created,
+        date_modified: wv.date_modified,
+        date_published: datePublished,
+        status: spec.status,
+        tags: [tag],
+      },
+    });
+  } else {
+    await prisma.submissionVersion.create({
+      data: {
+        id: uuid(),
+        submission_id: SUBMISSION_ID,
+        work_version_id: workVersionId,
+        submitted_by_id: SUBMITTED_BY_ID,
+        date_created: wv.date_created,
+        date_modified: wv.date_modified,
+        date_published: datePublished,
+        status: spec.status,
+        tags: [tag],
+      },
+    });
+  }
+
+  submissionVersionIndex += 1;
+}
+
+const latestPublished = await prisma.submissionVersion.findFirst({
+  where: { submission_id: SUBMISSION_ID, status: 'PUBLISHED' },
+  orderBy: { date_created: 'desc' },
+});
+
+await prisma.submission.update({
+  where: { id: SUBMISSION_ID },
+  data: {
+    date_published: latestPublished?.date_published ?? null,
+    date_modified: latestPublished?.date_modified ?? template.date_created,
+  },
+});
+
+const counts = await prisma.$transaction([
+  prisma.workVersion.count({ where: { work_id: WORK_ID } }),
+  prisma.submissionVersion.count({ where: { submission_id: SUBMISSION_ID } }),
+]);
+
+console.log('✅ Timeline test data ready');
+console.log(`   Work ID: ${WORK_ID}`);
+console.log(`   Submission ID: ${SUBMISSION_ID}`);
+console.log(`   Work versions: ${counts[0]} (expected ${TOTAL_WORK_VERSIONS})`);
+console.log(`   Submission versions: ${counts[1]} (expected ${TOTAL_SUBMISSION_VERSIONS})`);
+console.log(`   Work timeline: /app/works/${WORK_ID}/versions`);
+console.log(`   Submission timeline: /app/sites/scipy/submissions/${SUBMISSION_ID}/versions`);
+
+await prisma.$disconnect();

--- a/prisma/scripts/strip-work-version-v-tags.mts
+++ b/prisma/scripts/strip-work-version-v-tags.mts
@@ -1,0 +1,42 @@
+/**
+ * Remove vN-style tags (e.g. v1, v2) from WorkVersion.tags.
+ * Submission versions keep their version tags; work versions should not.
+ *
+ * Usage:
+ *   DATABASE_URL=... npx tsx prisma/scripts/strip-work-version-v-tags.mts
+ */
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const updated = await prisma.$executeRaw`
+    UPDATE "WorkVersion" w
+    SET tags = COALESCE(filtered.tags, '{}')
+    FROM (
+      SELECT
+        id,
+        array_agg(t ORDER BY ord) FILTER (WHERE t !~* '^v[0-9]+$') AS tags
+      FROM "WorkVersion",
+        unnest(tags) WITH ORDINALITY AS u(t, ord)
+      GROUP BY id
+    ) filtered
+    WHERE w.id = filtered.id
+      AND w.tags IS DISTINCT FROM COALESCE(filtered.tags, '{}')
+  `;
+
+  const [{ count }] = await prisma.$queryRaw<{ count: bigint }[]>`
+    SELECT count(*)::bigint AS count
+    FROM "WorkVersion"
+    WHERE EXISTS (SELECT 1 FROM unnest(tags) t WHERE t ~* '^v[0-9]+$')
+  `;
+
+  console.log(`Updated ${updated} work version(s). Remaining vN tags on work versions: ${count}`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
The version popover we released a few weeks ago was partialy baked, we have now worked through the edge cases and made this available on work and submission listings.

Authors - My Works
<img width="442" height="444" alt="Monosnap StatusIndicator 2026-06-13 10-58-17" src="https://github.com/user-attachments/assets/f6a2b2cb-ab7d-4b46-ac05-7f1e6f8b4964" />

Site Admins - All Submissions
<img width="421" height="491" alt="Monosnap StatusIndicator 2026-06-13 10-59-16" src="https://github.com/user-attachments/assets/1f663f62-6630-43e2-9784-8d22e3ef88cc" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Submission versions JSON shape changes from a bare `versions` array to a trimmed timeline envelope, which could break any undocumented consumers; otherwise this is listing UI plus scoped read loaders with tenancy checks and unit tests.
> 
> **Overview**
> Completes the version timeline hover experience on **My Works** and **site submissions** listings by centralizing the UI in `@curvenote/scms-core` and tightening the JSON APIs used for lazy load.
> 
> **Shared core** — Sites-local `VersionTimelineHoverCard` and `useSubmissionVersionTimeline` are removed in favor of `VersionTimelineHoverCard`, `SubmissionVersionTimelineHoverCard`, `WorkVersionTimelineHoverCard`, row renderers, `useVersionTimeline` (cache + background revalidate), URL helpers, and server-side `trimSubmissionVersionTimeline` / `trimWorkVersionTimeline` (max **8** visible entries, dashed **gap** rows, **see all** link).
> 
> **API contract** — `GET …/submissions/:submissionId/versions` now returns `TrimmedVersionTimeline` instead of `{ versions: [] }`; loaders apply trim + `seeAllHref`. New `GET /app/works/:workId/versions` loads work revisions with linked submission site chips (`date_modified`, workflow `statusTags`). Submission DB mapping adds `date_modified` and `statusTags`.
> 
> **Listings** — Submissions: status badge, version tag, and published/retracted chips open the shared submission timeline. Works: submission badges and a new **Timeline** control open work vs submission timelines respectively.
> 
> Also bumps `lucide-react` to ^1.18.0, tweaks work details revision label (`rN`), drops debug `title` on `SubmissionVersionBadge`, and adds optional dev/maintenance scripts for timeline seed data and stripping `vN` tags from work versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d37e9a44be6ebde608b064774d7e36ec4c2e71ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->