### PR TITLE
✅ Add exports-exist check; improve word-count check messages

### DIFF
--- a/.changeset/sharp-actors-yawn.md
+++ b/.changeset/sharp-actors-yawn.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/check-implementations': patch
+'@curvenote/check-definitions': patch
+---
+
+Add exports-exist check

--- a/.changeset/small-owls-win.md
+++ b/.changeset/small-owls-win.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/check-implementations': patch
+---
+
+Add filename to word-count check message

--- a/packages/check-definitions/src/submission.ts
+++ b/packages/check-definitions/src/submission.ts
@@ -179,4 +179,10 @@ export const submissionRuleChecks: CheckDefinition[] = [
     ],
     tags: [CheckTags.content],
   },
+  {
+    id: 'exports-exist',
+    title: 'Exports Exist',
+    purpose: 'ensure all declared export output files exist after build',
+    tags: [CheckTags.build, CheckTags.export],
+  },
 ];

--- a/packages/check-implementations/src/submission/exports-exist.ts
+++ b/packages/check-implementations/src/submission/exports-exist.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { collectExportOptions, filterPages, loadProjectFromDisk } from 'myst-cli';
+import { ExportFormats } from 'myst-frontmatter';
+import { getCheckDefinition } from '@curvenote/check-definitions';
+import type { CheckInterface } from '../types.js';
+import { fail, pass } from '../utils.js';
+
+export const exportsExist: CheckInterface = {
+  ...getCheckDefinition('exports-exist'),
+  validate: async (session) => {
+    const project = await loadProjectFromDisk(session);
+    const files = filterPages(project).map((page) => page.file);
+    const exports = await collectExportOptions(session, files, Object.values(ExportFormats), {
+      projectPath: project.path,
+    });
+    if (exports.length === 0) return [];
+    return exports.map((exp) => {
+      const { output, format, $file: file } = exp;
+      const displayOutput = path.relative(process.cwd(), output) || output;
+      if (fs.existsSync(output)) {
+        return pass(`${displayOutput} (${format})`, {
+          file,
+          nice: `Export "${displayOutput}" exists 📦`,
+        });
+      }
+      return fail(`Missing export: ${displayOutput} (${format})`, {
+        file,
+        help: 'Run "curvenote build --all" to build declared exports, or check your export configuration',
+      });
+    });
+  },
+};
+
+export const exportsExistRules = [exportsExist];

--- a/packages/check-implementations/src/submission/index.ts
+++ b/packages/check-implementations/src/submission/index.ts
@@ -1,6 +1,7 @@
 export * from './abstract.js';
 export * from './authors.js';
 export * from './data-availability.js';
+export * from './exports-exist.js';
 export * from './figure-count.js';
 export * from './keywords.js';
 export * from './links.js';
@@ -9,6 +10,7 @@ import { abstractRules } from './abstract.js';
 import { authorRules } from './authors.js';
 import { dataAvailabilityRules } from './data-availability.js';
 import { doiCheckRules } from './doi.js';
+import { exportsExistRules } from './exports-exist.js';
 import { figureCountRules } from './figure-count.js';
 import { keywordsRules } from './keywords.js';
 import { linksRules } from './links.js';
@@ -23,4 +25,5 @@ export const submissionRuleChecks = [
   ...doiCheckRules,
   ...wordCountRules,
   ...figureCountRules,
+  ...exportsExistRules,
 ];

--- a/packages/check-implementations/src/submission/word-count.ts
+++ b/packages/check-implementations/src/submission/word-count.ts
@@ -83,28 +83,33 @@ export const wordCount: CheckInterface = {
       });
     }
     const length = count(toWordCountText(content, { figures, footnotes }), 'words', {});
+    const filename = path.basename(file);
     if (length > max) {
-      return fail(`${upper(part ?? 'document')} is too long: ${length}/${max} words`, {
+      const message = part
+        ? `Shorten your ${part} from "${filename}" to less than ${max} words`
+        : `Shorten your document "${filename}" to less than ${max} words`;
+      return fail(message, {
         file,
         position: content.position,
         help: `Shorten your ${part ?? 'document'} to less than ${max} words`,
       });
     }
     if (length < min) {
-      return fail(`${upper(part ?? 'document')} is too short: ${length}/${min} words`, {
+      const message = part
+        ? `Increase the length of your ${part} from "${filename}" to more than ${min} words`
+        : `Increase the length of your document "${filename}" to more than ${min} words`;
+      return fail(message, {
         file,
         position: content.position,
         help: `Increase the length of your ${part ?? 'document'} to more than ${min} words`,
       });
     }
-    return pass(
-      `${upper(part ?? 'document')} is correct length (${length}${max == null ? '' : `/${max}`} words)`,
-      {
-        file,
-        position: content.position,
-        nice: `${upper(part ?? 'document')} is a good length 🔢`,
-      },
-    );
+    const subject = part ? `${upper(part)} from "${filename}"` : `Document "${filename}"`;
+    return pass(`${subject} is correct length (${length}${max == null ? '' : `/${max}`} words)`, {
+      file,
+      position: content.position,
+      nice: `${upper(part ?? 'document')} is a good length 🔢`,
+    });
   },
 };
 


### PR DESCRIPTION
<img width="587" height="124" alt="image" src="https://github.com/user-attachments/assets/a967c03f-6a6c-4f02-b0e2-43b25577ad7a" />

- `exports-exist` simply checks that all declared export output files exist.
- `word-count` now declares the counted file in the message.