### PR TITLE
🚧 Maintenance mode for check services

### DIFF
--- a/.app-config.schema.yml
+++ b/.app-config.schema.yml
@@ -206,6 +206,7 @@ properties:
       - sessionSecret
       - analyticsSecret
       - handshakeSigningSecret
+      - queueConsumerSecret
       - previewSigningSecret
       - jwtSigningSecret
       - checkSASecretKeyfile
@@ -243,6 +244,13 @@ properties:
       handshakeSigningSecret:
         type: string
         secret: true
+      queueConsumerSecret:
+        type: string
+        secret: true
+        description: >-
+          Bearer token secret for POST /v1/jobs/push-to-drain. The app sends this
+          when waking the queue drain handler after enqueue; the route rejects
+          requests without a matching Authorization header.
       previewSigningSecret:
         type: string
         secret: true

--- a/.changeset/check-maintenance-mode.md
+++ b/.changeset/check-maintenance-mode.md
@@ -1,0 +1,7 @@
+---
+'@curvenote/scms-core': minor
+---
+
+Add check service maintenance mode. Admins can toggle a per-service maintenance state (stored on the extension config Object row) that blocks outbound check actions and new job starts while leaving webhooks and in-flight jobs running. Provides shared building blocks: maintenance types/parsers, server guards, a `CheckMaintenanceProvider` with `useCheckMaintenanceBlocked`/`useAnyCheckMaintenanceBlocked` hooks, a `CheckMaintenanceAdminPanel`, and a `MaintenanceTooltip` that surfaces over disabled controls.
+
+On the work upload flow, a selected check whose service is under maintenance no longer blocks submission: it is skipped (not initiated) and the work is created as though it was never selected, with an informational note shown next to Continue.

--- a/packages/scms-core/src/components/checks/MaintenanceTooltip.tsx
+++ b/packages/scms-core/src/components/checks/MaintenanceTooltip.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import type { ReactElement } from 'react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js';
+
+type MaintenanceTooltipProps = {
+  enabled: boolean;
+  message: string;
+  children: ReactElement;
+};
+
+export function MaintenanceTooltip({ enabled, message, children }: MaintenanceTooltipProps) {
+  if (!enabled) return children;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent sideOffset={4}>{message}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/scms-core/src/components/checks/MaintenanceTooltip.tsx
+++ b/packages/scms-core/src/components/checks/MaintenanceTooltip.tsx
@@ -12,9 +12,14 @@ type MaintenanceTooltipProps = {
 export function MaintenanceTooltip({ enabled, message, children }: MaintenanceTooltipProps) {
   if (!enabled) return children;
 
+  // A disabled button does not emit pointer events, so the tooltip would never
+  // open if the trigger were the (disabled) child itself. Wrap it in a span that
+  // always receives pointer events and acts as the trigger.
   return (
     <Tooltip>
-      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipTrigger asChild>
+        <span className="inline-block">{children}</span>
+      </TooltipTrigger>
       <TooltipContent sideOffset={4}>{message}</TooltipContent>
     </Tooltip>
   );

--- a/packages/scms-core/src/components/ui/checks/index.ts
+++ b/packages/scms-core/src/components/ui/checks/index.ts
@@ -1,2 +1,3 @@
 export * from './CheckItemLegend.js';
 export * from './CheckItemPunchcard.js';
+export * from '../checks/MaintenanceTooltip.js';

--- a/packages/scms-core/src/components/ui/checks/index.ts
+++ b/packages/scms-core/src/components/ui/checks/index.ts
@@ -1,3 +1,3 @@
 export * from './CheckItemLegend.js';
 export * from './CheckItemPunchcard.js';
-export * from '../checks/MaintenanceTooltip.js';
+export * from '../../checks/MaintenanceTooltip.js';

--- a/packages/scms-core/src/components/upload/UploadCheckOptionCard.tsx
+++ b/packages/scms-core/src/components/upload/UploadCheckOptionCard.tsx
@@ -5,6 +5,7 @@ import { useFetcher } from 'react-router';
 import { cn } from '../../utils/cn.js';
 import { Card } from '../primitives/Card.js';
 import { toastError } from '../ui/toast.js';
+import { MaintenanceTooltip } from '../ui/checks/index.js';
 import type { ClientExtensionCheckService } from '../../modules/extensions/types.js';
 import { DefaultUploadCheckOptionContent } from './DefaultUploadCheckOptionContent.js';
 import { uploadCheckCardClassName } from './uploadCheckCardStyles.js';
@@ -15,6 +16,8 @@ export interface UploadCheckOptionCardProps {
   enabled: boolean;
   disabled?: boolean;
   invalid?: boolean;
+  /** When set, the card is wrapped in a maintenance tooltip. */
+  maintenanceMessage?: string;
   /** Optional service logo URL (e.g. text integrity manifest from Object store). */
   logoUrl?: string;
 }
@@ -25,6 +28,7 @@ export function UploadCheckOptionCard({
   enabled,
   disabled = false,
   invalid = false,
+  maintenanceMessage,
   logoUrl,
 }: UploadCheckOptionCardProps) {
   const fetcher = useFetcher();
@@ -52,29 +56,32 @@ export function UploadCheckOptionCard({
   }, [fetcher.state, fetcher.data]);
 
   return (
-    <Card
-      lift
-      className={cn(
-        'h-full',
-        uploadCheckCardClassName({ enabled, disabled, invalid, busy: isBusy }),
-      )}
-      onClick={() => {
-        if (enabled) {
-          void setEnabled(false);
-        }
-      }}
-    >
-      <Inner
-        workVersionId={workVersionId}
-        enabled={enabled}
-        disabled={disabled}
-        invalid={invalid}
-        setEnabled={setEnabled}
-        toggleBusy={isBusy}
-        name={service.name}
-        description={service.description}
-        logoUrl={logoUrl}
-      />
-    </Card>
+    <MaintenanceTooltip enabled={Boolean(maintenanceMessage)} message={maintenanceMessage ?? ''}>
+      <Card
+        lift
+        className={cn(
+          'h-full',
+          uploadCheckCardClassName({ enabled, disabled, invalid, busy: isBusy }),
+        )}
+        onClick={() => {
+          if (maintenanceMessage) return;
+          if (enabled) {
+            void setEnabled(false);
+          }
+        }}
+      >
+        <Inner
+          workVersionId={workVersionId}
+          enabled={enabled}
+          disabled={disabled}
+          invalid={invalid}
+          setEnabled={setEnabled}
+          toggleBusy={isBusy}
+          name={service.name}
+          description={service.description}
+          logoUrl={logoUrl}
+        />
+      </Card>
+    </MaintenanceTooltip>
   );
 }

--- a/packages/scms-core/src/modules/extensions/CheckMaintenanceAdminPanel.tsx
+++ b/packages/scms-core/src/modules/extensions/CheckMaintenanceAdminPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useFetcher } from 'react-router';
-import { ui } from '../../components/ui/index.js';
+import * as ui from '../../components/ui/index.js';
 import type { CheckMaintenanceRecord } from './check-maintenance.js';
 
 type ActionData = {

--- a/packages/scms-core/src/modules/extensions/CheckMaintenanceAdminPanel.tsx
+++ b/packages/scms-core/src/modules/extensions/CheckMaintenanceAdminPanel.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useFetcher } from 'react-router';
+import { ui } from '../../components/ui/index.js';
+import type { CheckMaintenanceRecord } from './check-maintenance.js';
+
+type ActionData = {
+  error?: { type: string; message: string };
+  success?: boolean;
+};
+
+type Props = {
+  intent: string;
+  maintenance?: CheckMaintenanceRecord | null;
+  serviceLabel: string;
+};
+
+export function CheckMaintenanceAdminPanel({ intent, maintenance, serviceLabel }: Props) {
+  const fetcher = useFetcher<ActionData>();
+  const [enabled, setEnabled] = useState(maintenance?.enabled === true);
+  const [message, setMessage] = useState(maintenance?.message ?? '');
+  const isSubmitting = fetcher.state !== 'idle';
+
+  useEffect(() => {
+    setEnabled(maintenance?.enabled === true);
+    setMessage(maintenance?.message ?? '');
+  }, [maintenance?.enabled, maintenance?.message]);
+
+  useEffect(() => {
+    if (fetcher.state !== 'idle' || !fetcher.data) return;
+    if (fetcher.data.error?.message) {
+      ui.toastError(fetcher.data.error.message);
+      return;
+    }
+    if (fetcher.data.success) {
+      ui.toastSuccess(
+        enabled
+          ? `${serviceLabel} marked under maintenance`
+          : `${serviceLabel} maintenance cleared`,
+      );
+    }
+  }, [fetcher.state, fetcher.data, enabled, serviceLabel]);
+
+  return (
+    <div className="p-4 space-y-4 rounded-md border border-border">
+      <div>
+        <h3 className="text-sm font-medium">Maintenance mode</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          When enabled, users cannot run checks or trigger outbound calls to {serviceLabel}.
+          In-flight jobs and webhooks continue processing.
+        </p>
+      </div>
+
+      <fetcher.Form method="post" className="space-y-4">
+        <input type="hidden" name="intent" value={intent} />
+        <input type="hidden" name="enabled" value={enabled ? 'true' : 'false'} />
+        <input type="hidden" name="message" value={message} />
+
+        <label className="flex gap-2 items-center text-sm">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            disabled={isSubmitting}
+          />
+          Under maintenance
+        </label>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor={`${intent}-maintenance-message`}>
+            Tooltip message (optional)
+          </label>
+          <ui.TextField
+            id={`${intent}-maintenance-message`}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="This service is temporarily unavailable for maintenance."
+            disabled={isSubmitting}
+            className="w-full"
+          />
+        </div>
+
+        <ui.StatefulButton
+          type="submit"
+          size="sm"
+          busy={isSubmitting}
+          overlayBusy
+          disabled={isSubmitting}
+        >
+          Save maintenance settings
+        </ui.StatefulButton>
+      </fetcher.Form>
+
+      {maintenance?.updatedAt ? (
+        <p className="text-xs text-muted-foreground">
+          Last updated {new Date(maintenance.updatedAt).toLocaleString()}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/scms-core/src/modules/extensions/CheckMaintenanceAdminPanel.tsx
+++ b/packages/scms-core/src/modules/extensions/CheckMaintenanceAdminPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useFetcher } from 'react-router';
 import * as ui from '../../components/ui/index.js';
 import type { CheckMaintenanceRecord } from './check-maintenance.js';
@@ -21,6 +21,7 @@ export function CheckMaintenanceAdminPanel({ intent, maintenance, serviceLabel }
   const [enabled, setEnabled] = useState(maintenance?.enabled === true);
   const [message, setMessage] = useState(maintenance?.message ?? '');
   const isSubmitting = fetcher.state !== 'idle';
+  const handledDataRef = useRef<ActionData | null>(null);
 
   useEffect(() => {
     setEnabled(maintenance?.enabled === true);
@@ -29,6 +30,8 @@ export function CheckMaintenanceAdminPanel({ intent, maintenance, serviceLabel }
 
   useEffect(() => {
     if (fetcher.state !== 'idle' || !fetcher.data) return;
+    if (handledDataRef.current === fetcher.data) return;
+    handledDataRef.current = fetcher.data;
     if (fetcher.data.error?.message) {
       ui.toastError(fetcher.data.error.message);
       return;

--- a/packages/scms-core/src/modules/extensions/CheckMaintenanceAdminPanel.tsx
+++ b/packages/scms-core/src/modules/extensions/CheckMaintenanceAdminPanel.tsx
@@ -75,7 +75,7 @@ export function CheckMaintenanceAdminPanel({ intent, maintenance, serviceLabel }
             id={`${intent}-maintenance-message`}
             value={message}
             onChange={(e) => setMessage(e.target.value)}
-            placeholder="This service is temporarily unavailable for maintenance."
+            placeholder="Service is temporarily down for maintenance"
             disabled={isSubmitting}
             className="w-full"
           />

--- a/packages/scms-core/src/modules/extensions/check-maintenance.ts
+++ b/packages/scms-core/src/modules/extensions/check-maintenance.ts
@@ -1,0 +1,105 @@
+import type { Context } from '../../backend/types.js';
+import type { ExtensionCheckHandleActionResult, ServerExtension } from './types.js';
+import { getExtensionCheckServicesFromServerConfig } from './checks.js';
+
+export const DEFAULT_CHECK_MAINTENANCE_MESSAGE =
+  'This service is temporarily unavailable for maintenance.';
+
+export type CheckMaintenanceRecord = {
+  enabled: boolean;
+  message?: string;
+  updatedAt?: string;
+  updatedByUserId?: string;
+};
+
+export type CheckMaintenanceState = {
+  underMaintenance: boolean;
+  message: string;
+};
+
+export function parseCheckMaintenanceRecord(raw: unknown): CheckMaintenanceRecord | undefined {
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const record = raw as Record<string, unknown>;
+  if (record.enabled !== true) return undefined;
+  const message =
+    typeof record.message === 'string' && record.message.trim() !== ''
+      ? record.message.trim()
+      : undefined;
+  return {
+    enabled: true,
+    ...(message ? { message } : {}),
+    ...(typeof record.updatedAt === 'string' ? { updatedAt: record.updatedAt } : {}),
+    ...(typeof record.updatedByUserId === 'string'
+      ? { updatedByUserId: record.updatedByUserId }
+      : {}),
+  };
+}
+
+export function parseCheckMaintenanceFromConfig(
+  config: Record<string, unknown> | undefined,
+): CheckMaintenanceState | undefined {
+  if (!config) return undefined;
+  const record = parseCheckMaintenanceRecord(config.maintenance);
+  if (!record) return undefined;
+  return {
+    underMaintenance: true,
+    message: record.message ?? DEFAULT_CHECK_MAINTENANCE_MESSAGE,
+  };
+}
+
+export function checkMaintenanceActionError(message?: string): ExtensionCheckHandleActionResult {
+  return {
+    error: {
+      type: 'maintenance',
+      message: message ?? DEFAULT_CHECK_MAINTENANCE_MESSAGE,
+    },
+    status: 503,
+  };
+}
+
+export function maintenanceGuardFromConfig(
+  config: Record<string, unknown>,
+): ExtensionCheckHandleActionResult | undefined {
+  const state = parseCheckMaintenanceFromConfig(config);
+  if (!state) return undefined;
+  return checkMaintenanceActionError(state.message);
+}
+
+export function getConfiguredCheckServiceIds(
+  serverConfig: AppConfig,
+  extensions: ServerExtension[],
+): string[] {
+  return getExtensionCheckServicesFromServerConfig(serverConfig, extensions).map((s) => s.id);
+}
+
+export async function loadCheckMaintenanceByServiceId(
+  ctx: Context,
+  extensions: ServerExtension[],
+  checkServiceId: string,
+): Promise<CheckMaintenanceState | undefined> {
+  for (const ext of extensions) {
+    const services = ext.getChecks?.() ?? [];
+    if (!services.some((service) => service.id === checkServiceId)) continue;
+    const config = ext.getExtensionConfiguration
+      ? await ext.getExtensionConfiguration(ctx)
+      : undefined;
+    return parseCheckMaintenanceFromConfig(config);
+  }
+  return undefined;
+}
+
+export async function loadCheckMaintenanceByServiceIds(
+  ctx: Context,
+  extensions: ServerExtension[],
+  checkServiceIds: string[],
+): Promise<Record<string, CheckMaintenanceState>> {
+  const entries = await Promise.all(
+    checkServiceIds.map(async (id) => {
+      const state = await loadCheckMaintenanceByServiceId(ctx, extensions, id);
+      return state ? ([id, state] as const) : null;
+    }),
+  );
+  return Object.fromEntries(
+    entries.filter((entry): entry is [string, CheckMaintenanceState] => !!entry),
+  );
+}

--- a/packages/scms-core/src/modules/extensions/check-maintenance.ts
+++ b/packages/scms-core/src/modules/extensions/check-maintenance.ts
@@ -1,9 +1,7 @@
 import type { Context } from '../../backend/types.js';
 import type { ExtensionCheckHandleActionResult, ServerExtension } from './types.js';
-import { getExtensionCheckServicesFromServerConfig } from './checks.js';
 
-export const DEFAULT_CHECK_MAINTENANCE_MESSAGE =
-  'Service is temporarily down for maintenance';
+export const DEFAULT_CHECK_MAINTENANCE_MESSAGE = 'Service is temporarily down for maintenance';
 
 export type CheckMaintenanceRecord = {
   enabled: boolean;
@@ -65,11 +63,35 @@ export function maintenanceGuardFromConfig(
   return checkMaintenanceActionError(state.message);
 }
 
-export function getConfiguredCheckServiceIds(
-  serverConfig: AppConfig,
+export async function loadCheckMaintenanceByServiceIds(
+  ctx: Context,
   extensions: ServerExtension[],
-): string[] {
-  return getExtensionCheckServicesFromServerConfig(serverConfig, extensions).map((s) => s.id);
+  checkServiceIds: string[],
+): Promise<Record<string, CheckMaintenanceState>> {
+  const requested = new Set(checkServiceIds);
+  if (requested.size === 0) return {};
+
+  const result: Record<string, CheckMaintenanceState> = {};
+
+  await Promise.all(
+    extensions.map(async (ext) => {
+      const services = ext.getChecks?.() ?? [];
+      const matchingIds = services.map((service) => service.id).filter((id) => requested.has(id));
+      if (matchingIds.length === 0) return;
+
+      const config = ext.getExtensionConfiguration
+        ? await ext.getExtensionConfiguration(ctx)
+        : undefined;
+      const state = parseCheckMaintenanceFromConfig(config);
+      if (!state) return;
+
+      for (const id of matchingIds) {
+        result[id] = state;
+      }
+    }),
+  );
+
+  return result;
 }
 
 export async function loadCheckMaintenanceByServiceId(
@@ -77,29 +99,6 @@ export async function loadCheckMaintenanceByServiceId(
   extensions: ServerExtension[],
   checkServiceId: string,
 ): Promise<CheckMaintenanceState | undefined> {
-  for (const ext of extensions) {
-    const services = ext.getChecks?.() ?? [];
-    if (!services.some((service) => service.id === checkServiceId)) continue;
-    const config = ext.getExtensionConfiguration
-      ? await ext.getExtensionConfiguration(ctx)
-      : undefined;
-    return parseCheckMaintenanceFromConfig(config);
-  }
-  return undefined;
-}
-
-export async function loadCheckMaintenanceByServiceIds(
-  ctx: Context,
-  extensions: ServerExtension[],
-  checkServiceIds: string[],
-): Promise<Record<string, CheckMaintenanceState>> {
-  const entries = await Promise.all(
-    checkServiceIds.map(async (id) => {
-      const state = await loadCheckMaintenanceByServiceId(ctx, extensions, id);
-      return state ? ([id, state] as const) : null;
-    }),
-  );
-  return Object.fromEntries(
-    entries.filter((entry): entry is [string, CheckMaintenanceState] => !!entry),
-  );
+  const byId = await loadCheckMaintenanceByServiceIds(ctx, extensions, [checkServiceId]);
+  return byId[checkServiceId];
 }

--- a/packages/scms-core/src/modules/extensions/check-maintenance.ts
+++ b/packages/scms-core/src/modules/extensions/check-maintenance.ts
@@ -3,7 +3,7 @@ import type { ExtensionCheckHandleActionResult, ServerExtension } from './types.
 import { getExtensionCheckServicesFromServerConfig } from './checks.js';
 
 export const DEFAULT_CHECK_MAINTENANCE_MESSAGE =
-  'This service is temporarily unavailable for maintenance.';
+  'Service is temporarily down for maintenance';
 
 export type CheckMaintenanceRecord = {
   enabled: boolean;

--- a/packages/scms-core/src/modules/extensions/index.ts
+++ b/packages/scms-core/src/modules/extensions/index.ts
@@ -2,6 +2,8 @@ export * from './analytics.js';
 export * from './ExtensionAdminCard.js';
 export * from './ServiceLogo.js';
 export * from './checks.js';
+export * from './check-maintenance.js';
+export * from './CheckMaintenanceAdminPanel.js';
 export * from './email-templates.js';
 export * from './icons.js';
 export * from './navigation.js';

--- a/packages/scms-core/src/providers/CheckMaintenanceProvider.tsx
+++ b/packages/scms-core/src/providers/CheckMaintenanceProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, use, useMemo } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 import {
   DEFAULT_CHECK_MAINTENANCE_MESSAGE,
   type CheckMaintenanceState,
@@ -18,11 +18,13 @@ export function CheckMaintenanceProvider({
   children: React.ReactNode;
 }) {
   const value = useMemo(() => maintenanceByServiceId, [maintenanceByServiceId]);
-  return <CheckMaintenanceContext value={value}>{children}</CheckMaintenanceContext>;
+  return (
+    <CheckMaintenanceContext.Provider value={value}>{children}</CheckMaintenanceContext.Provider>
+  );
 }
 
 export function useCheckMaintenance(checkServiceId: string): CheckMaintenanceState | undefined {
-  const context = use(CheckMaintenanceContext);
+  const context = useContext(CheckMaintenanceContext);
   return context?.[checkServiceId];
 }
 
@@ -41,7 +43,7 @@ export function useAnyCheckMaintenanceBlocked(checkServiceIds: string[]): {
   blocked: boolean;
   message: string;
 } {
-  const context = use(CheckMaintenanceContext);
+  const context = useContext(CheckMaintenanceContext);
   for (const id of checkServiceIds) {
     const state = context?.[id];
     if (state?.underMaintenance) {

--- a/packages/scms-core/src/providers/CheckMaintenanceProvider.tsx
+++ b/packages/scms-core/src/providers/CheckMaintenanceProvider.tsx
@@ -52,3 +52,16 @@ export function useAnyCheckMaintenanceBlocked(checkServiceIds: string[]): {
   }
   return { blocked: false, message: DEFAULT_CHECK_MAINTENANCE_MESSAGE };
 }
+
+/**
+ * Filter a list of check service ids down to those that are not under
+ * maintenance. Mirrors the server's `dispatchableChecks`: checks under
+ * maintenance are dropped (not initiated) rather than blocking submission.
+ */
+export function useChecksNotUnderMaintenance(checkServiceIds: string[]): string[] {
+  const context = useContext(CheckMaintenanceContext);
+  return useMemo(
+    () => checkServiceIds.filter((id) => context?.[id]?.underMaintenance !== true),
+    [checkServiceIds, context],
+  );
+}

--- a/packages/scms-core/src/providers/CheckMaintenanceProvider.tsx
+++ b/packages/scms-core/src/providers/CheckMaintenanceProvider.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { createContext, use, useMemo } from 'react';
+import {
+  DEFAULT_CHECK_MAINTENANCE_MESSAGE,
+  type CheckMaintenanceState,
+} from '../modules/extensions/check-maintenance.js';
+
+export type CheckMaintenanceByServiceId = Record<string, CheckMaintenanceState>;
+
+const CheckMaintenanceContext = createContext<CheckMaintenanceByServiceId | undefined>(undefined);
+
+export function CheckMaintenanceProvider({
+  maintenanceByServiceId,
+  children,
+}: {
+  maintenanceByServiceId: CheckMaintenanceByServiceId;
+  children: React.ReactNode;
+}) {
+  const value = useMemo(() => maintenanceByServiceId, [maintenanceByServiceId]);
+  return <CheckMaintenanceContext value={value}>{children}</CheckMaintenanceContext>;
+}
+
+export function useCheckMaintenance(checkServiceId: string): CheckMaintenanceState | undefined {
+  const context = use(CheckMaintenanceContext);
+  return context?.[checkServiceId];
+}
+
+export function useCheckMaintenanceBlocked(checkServiceId: string): {
+  blocked: boolean;
+  message: string;
+} {
+  const state = useCheckMaintenance(checkServiceId);
+  return {
+    blocked: state?.underMaintenance === true,
+    message: state?.message ?? DEFAULT_CHECK_MAINTENANCE_MESSAGE,
+  };
+}
+
+export function useAnyCheckMaintenanceBlocked(checkServiceIds: string[]): {
+  blocked: boolean;
+  message: string;
+} {
+  const context = use(CheckMaintenanceContext);
+  for (const id of checkServiceIds) {
+    const state = context?.[id];
+    if (state?.underMaintenance) {
+      return { blocked: true, message: state.message };
+    }
+  }
+  return { blocked: false, message: DEFAULT_CHECK_MAINTENANCE_MESSAGE };
+}

--- a/packages/scms-core/src/providers/index.ts
+++ b/packages/scms-core/src/providers/index.ts
@@ -1,3 +1,4 @@
 export * from './ThemeProvider.js';
 export * from './MyUserProvider.js';
 export * from './DeploymentProvider.js';
+export * from './CheckMaintenanceProvider.js';

--- a/packages/scms-core/src/utils/workVersionMetadata.spec.ts
+++ b/packages/scms-core/src/utils/workVersionMetadata.spec.ts
@@ -8,6 +8,7 @@ import {
   hasPdfInMetadata,
   isDocxOrPdfFile,
   resolveUploadCheckCardState,
+  hasMaintenanceEnabledUploadChecks,
 } from './workVersionMetadata.js';
 
 describe('workVersionMetadata', () => {
@@ -107,5 +108,24 @@ describe('workVersionMetadata', () => {
       disabled: false,
       invalid: true,
     });
+    expect(
+      resolveUploadCheckCardState({ eligible: true, enabled: false, underMaintenance: true }),
+    ).toEqual({
+      disabled: true,
+      invalid: false,
+    });
+  });
+
+  it('hasMaintenanceEnabledUploadChecks detects enabled services under maintenance', () => {
+    expect(
+      hasMaintenanceEnabledUploadChecks(['checks-text-integrity'], {
+        'checks-text-integrity': { underMaintenance: true, message: 'Down' },
+      }),
+    ).toBe(true);
+    expect(
+      hasMaintenanceEnabledUploadChecks(['checks-text-integrity'], {
+        proofig: { underMaintenance: true, message: 'Down' },
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/scms-core/src/utils/workVersionMetadata.spec.ts
+++ b/packages/scms-core/src/utils/workVersionMetadata.spec.ts
@@ -119,12 +119,12 @@ describe('workVersionMetadata', () => {
   it('hasMaintenanceEnabledUploadChecks detects enabled services under maintenance', () => {
     expect(
       hasMaintenanceEnabledUploadChecks(['checks-text-integrity'], {
-        'checks-text-integrity': { underMaintenance: true, message: 'Down' },
+        'checks-text-integrity': { underMaintenance: true },
       }),
     ).toBe(true);
     expect(
       hasMaintenanceEnabledUploadChecks(['checks-text-integrity'], {
-        proofig: { underMaintenance: true, message: 'Down' },
+        proofig: { underMaintenance: true },
       }),
     ).toBe(false);
   });

--- a/packages/scms-core/src/utils/workVersionMetadata.ts
+++ b/packages/scms-core/src/utils/workVersionMetadata.ts
@@ -47,10 +47,15 @@ export function isDocxOrPdfFile(entry: FileEntryLike): boolean {
 export function resolveUploadCheckCardState({
   eligible,
   enabled,
+  underMaintenance = false,
 }: {
   eligible: boolean;
   enabled: boolean;
+  underMaintenance?: boolean;
 }): { disabled: boolean; invalid: boolean } {
+  if (underMaintenance) {
+    return { disabled: true, invalid: false };
+  }
   if (eligible) {
     return { disabled: false, invalid: false };
   }
@@ -78,6 +83,14 @@ export function hasInvalidEnabledUploadChecks(
     }
   }
   return false;
+}
+
+/** True when any enabled check is under maintenance. */
+export function hasMaintenanceEnabledUploadChecks(
+  enabledCheckIds: string[],
+  maintenanceByServiceId: Record<string, { underMaintenance?: boolean }>,
+): boolean {
+  return enabledCheckIds.some((id) => maintenanceByServiceId[id]?.underMaintenance === true);
 }
 
 /**

--- a/platform/scms/.app-config.secrets.test.yml
+++ b/platform/scms/.app-config.secrets.test.yml
@@ -9,6 +9,7 @@ api:
   sessionSecret: qwerty
   analyticsSecret: qwerty
   handshakeSigningSecret: qwerty
+  queueConsumerSecret: qwerty
   previewSigningSecret: qwerty
   jwtSigningSecret: qwerty
   checkSASecretKeyfile: '{}'

--- a/platform/scms/.env.sample
+++ b/platform/scms/.env.sample
@@ -3,10 +3,12 @@ APP_CONFIG_ENV=development
 VITE_APP_CONFIG_ENV=development
 VITE_APP_CONFIG_DIRECTORY='.'
 VITE_APP_CONFIG_SCHEMA_DIRECTORY='../../'
+# Local dev only — Prisma CLI / migrations. Runtime DB URL comes from app-config (api.databaseUrl).
 DATABASE_URL=postgresql://journals:curvenote@localhost:5432/journals?statement_cache_size=0
-# Job queue provider: mock (default in development) | vercel (opt-in; requires vercel link + env pull)
+# Local dev only — job queue provider (default mock in development). Staging/prod use app-config + Vercel env.
 #QUEUES_PROVIDER=mock
-# Mock queue loopback consumer URL (default: http://localhost:${VITE_PORT}/v1/jobs/mock-push)
+# Local dev only — mock queue loopback URL (default: http://localhost:${VITE_PORT}/v1/jobs/mock-push)
 #MOCK_QUEUE_CONSUMER_URL=http://localhost:3031/v1/jobs/mock-push
+# Queue drain auth (push-to-drain Bearer token) lives in app-config: api.queueConsumerSecret
 # Log every Prisma SQL query to the dev server console (ignored in production):
 #PRISMA_DEBUG_QUERIES=true

--- a/platform/scms/README.md
+++ b/platform/scms/README.md
@@ -30,7 +30,9 @@ npm run dev
 
 ### Job queue local development
 
-By default, local development uses an **in-process mock queue** (`QUEUES_PROVIDER=mock`). Jobs enqueued via `enqueueAndDispatchJob` are delivered asynchronously via **HTTP POST to `/v1/jobs/mock-push`** (dev-only loopback route) — no Vercel account, OIDC token, or second terminal required.
+By default, local development uses an **in-process mock queue** (`QUEUES_PROVIDER=mock`, set via `.env` only — not app-config). Jobs enqueued via `enqueueAndDispatchJob` are delivered asynchronously via **HTTP POST to `/v1/jobs/mock-push`** (dev-only loopback route) — no Vercel account or second terminal required.
+
+**Queue drain auth:** `api.queueConsumerSecret` in app-config (e.g. `.app-config.secrets.development.yml` locally, deploy-curvenote secrets YAML on staging/prod) secures the unified **`POST /v1/jobs/push-to-drain`** wake-up route. Job execution still uses the **handshake JWT** inside the queue message.
 
 On Vercel preview/production, the queue consumer is **`api/job-queue-consumer.ts`** (push trigger in `vercel.ts`), not the mock-push route. deploy-curvenote notes: `deploy/deploy-curvenote.md`.
 

--- a/platform/scms/app/routes/app/platform.extensions/ExtensionAdminTabContent.tsx
+++ b/platform/scms/app/routes/app/platform.extensions/ExtensionAdminTabContent.tsx
@@ -1,0 +1,56 @@
+import {
+  getExtensionIcon,
+  ExtensionAdminCardFallback,
+  type ClientExtension,
+} from '@curvenote/scms-core';
+
+type ExtensionMeta = {
+  name: string;
+  capabilities: string[];
+};
+
+type Props = {
+  extensionId: string;
+  extension: ExtensionMeta;
+  safeConfig: Record<string, unknown> | undefined;
+  clientExtensions: ClientExtension[];
+};
+
+export function ExtensionAdminTabContent({
+  extensionId,
+  extension,
+  safeConfig,
+  clientExtensions,
+}: Props) {
+  const ExtensionIcon = getExtensionIcon(clientExtensions, extensionId);
+  const clientExt = clientExtensions.find((e) => e.id.toLowerCase() === extensionId.toLowerCase());
+  const AdminCardComponent = clientExt?.getExtensionAdminCard?.();
+
+  if (safeConfig === undefined) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No admin configuration is available for this extension.
+      </p>
+    );
+  }
+
+  if (AdminCardComponent) {
+    return (
+      <AdminCardComponent
+        name={extensionId}
+        extension={extension}
+        record={safeConfig}
+        ExtensionIcon={ExtensionIcon}
+      />
+    );
+  }
+
+  return (
+    <ExtensionAdminCardFallback
+      name={extensionId}
+      extension={extension}
+      record={safeConfig}
+      ExtensionIcon={ExtensionIcon}
+    />
+  );
+}

--- a/platform/scms/app/routes/app/platform.extensions/ExternalSitesTab.tsx
+++ b/platform/scms/app/routes/app/platform.extensions/ExternalSitesTab.tsx
@@ -1,0 +1,88 @@
+import { ui, primitives } from '@curvenote/scms-core';
+import type { Route } from './+types/route';
+
+type Site = Route.ComponentProps['loaderData']['sites'][number];
+
+export function ExternalSitesTab({ sites }: { sites: Site[] }) {
+  if (sites.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No external sites are configured in this deployment.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {sites.map((site) => (
+        <primitives.Card key={site.id} lift>
+          <div className="p-6">
+            <div className="flex justify-between items-start mb-4">
+              <div>
+                <h2 className="text-xl font-semibold">{site.title}</h2>
+                <p className="mt-1 text-sm text-muted-foreground">{site.description}</p>
+              </div>
+              <div className="text-sm text-muted-foreground">
+                {site.private ? 'Private' : 'Public'} • {site.restricted ? 'Restricted' : 'Open'}{' '}
+                Access
+              </div>
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-2">
+              <div>
+                <h3 className="mb-2 text-sm font-medium">Domains</h3>
+                <div className="flex flex-wrap gap-2">
+                  {site.domains.map((domain) => (
+                    <ui.Badge key={domain.id} variant="default">
+                      {domain.hostname}
+                    </ui.Badge>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <h3 className="mb-2 text-sm font-medium">Default Workflow</h3>
+                <p className="text-sm text-muted-foreground">{site.default_workflow}</p>
+              </div>
+
+              <div>
+                <h3 className="mb-2 text-sm font-medium">Submission Kinds</h3>
+                <div className="flex flex-wrap gap-2">
+                  {site.submissionKinds.map((kind) => {
+                    const content = kind.content as { title?: string };
+                    return (
+                      <ui.Badge key={kind.id} variant="default">
+                        {content?.title || kind.name}
+                      </ui.Badge>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div>
+                <h3 className="mb-2 text-sm font-medium">Collections</h3>
+                <div className="flex flex-wrap gap-2">
+                  {site.collections.map((collection) => {
+                    const content = collection.content as { title?: string };
+                    return (
+                      <ui.Badge key={collection.id} variant="default">
+                        {content?.title || collection.name}
+                      </ui.Badge>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+
+            <details className="mt-6">
+              <summary className="text-sm font-medium cursor-pointer">Site Metadata</summary>
+              <pre className="overflow-auto p-4 mt-2 text-sm rounded-md bg-muted">
+                {JSON.stringify(site.metadata, null, 2)}
+              </pre>
+            </details>
+          </div>
+        </primitives.Card>
+      ))}
+    </div>
+  );
+}

--- a/platform/scms/app/routes/app/platform.extensions/route.tsx
+++ b/platform/scms/app/routes/app/platform.extensions/route.tsx
@@ -1,20 +1,20 @@
 import type { Route } from './+types/route';
 import { withAppPlatformAdminContext, getPrismaClient } from '@curvenote/scms-server';
 import {
-  ui,
-  primitives,
   PageFrame,
-  SectionWithHeading,
+  ui,
   useDeploymentConfig,
-  getExtensionIcon,
   sanitizeExtensionAdminConfig,
-  ExtensionAdminCardFallback,
 } from '@curvenote/scms-core';
 import { extensions } from '../../../extensions/client';
 import { extensions as serverExtensions } from '../../../extensions/server';
 import { data } from 'react-router';
 import { z } from 'zod';
 import { zfd } from 'zod-form-data';
+import { ExtensionAdminTabContent } from './ExtensionAdminTabContent';
+import { ExternalSitesTab } from './ExternalSitesTab';
+
+const EXTERNAL_SITES_TAB = 'external-sites';
 
 const extensionActionSchema = zfd.formData({
   intent: zfd.text(z.string().min(1, 'Intent is required')),
@@ -79,120 +79,50 @@ export async function action(args: Route.ActionArgs) {
   return data({ error: { type: 'general', message: 'Unknown intent' } }, { status: 400 });
 }
 
+function getExtensionTabLabel(extensionId: string): string {
+  const clientExt = extensions.find((e) => e.id.toLowerCase() === extensionId.toLowerCase());
+  return clientExt?.name ?? extensionId;
+}
+
 export default function ExtensionsPage({ loaderData }: Route.ComponentProps) {
   const { sites, extensionAdminConfigs } = loaderData;
 
   const deploymentConfig = useDeploymentConfig();
   const extensionsConfig = deploymentConfig.extensions ?? {};
+  const extensionEntries = Object.entries(extensionsConfig);
+  const defaultTab = extensionEntries[0]?.[0] ?? EXTERNAL_SITES_TAB;
 
   return (
-    <PageFrame title="Extensions">
-      <SectionWithHeading heading="Configured Extensions">
-        <div className="flex flex-col gap-4">
-          {Object.entries(extensionsConfig ?? {}).map(([name, extension]) => {
-            const ExtensionIcon = getExtensionIcon(extensions, name);
-            const clientExt = extensions.find((e) => e.id.toLowerCase() === name.toLowerCase());
-            const AdminCardComponent = clientExt?.getExtensionAdminCard?.();
-            const safeConfig = extensionAdminConfigs?.[name];
-
-            return (
-              <primitives.Card key={name} lift>
-                <div className="p-4">
-                  {safeConfig !== undefined && !AdminCardComponent && (
-                    <ExtensionAdminCardFallback
-                      name={name}
-                      extension={extension}
-                      record={safeConfig}
-                      ExtensionIcon={ExtensionIcon}
-                    />
-                  )}
-                  {safeConfig !== undefined && AdminCardComponent && (
-                    <AdminCardComponent
-                      name={name}
-                      extension={extension}
-                      record={safeConfig}
-                      ExtensionIcon={ExtensionIcon}
-                    />
-                  )}
-                </div>
-              </primitives.Card>
-            );
-          })}
-        </div>
-      </SectionWithHeading>
-      <SectionWithHeading heading="External Sites">
-        <div className="space-y-4">
-          {sites.map((site) => (
-            <primitives.Card key={site.id} lift>
-              <div className="p-6">
-                <div className="flex justify-between items-start mb-4">
-                  <div>
-                    <h2 className="text-xl font-semibold">{site.title}</h2>
-                    <p className="mt-1 text-sm text-muted-foreground">{site.description}</p>
-                  </div>
-                  <div className="text-sm text-muted-foreground">
-                    {site.private ? 'Private' : 'Public'} •{' '}
-                    {site.restricted ? 'Restricted' : 'Open'} Access
-                  </div>
-                </div>
-
-                <div className="grid gap-6 md:grid-cols-2">
-                  <div>
-                    <h3 className="mb-2 text-sm font-medium">Domains</h3>
-                    <div className="flex flex-wrap gap-2">
-                      {site.domains.map((domain) => (
-                        <ui.Badge key={domain.id} variant="default">
-                          {domain.hostname}
-                        </ui.Badge>
-                      ))}
-                    </div>
-                  </div>
-
-                  <div>
-                    <h3 className="mb-2 text-sm font-medium">Default Workflow</h3>
-                    <p className="text-sm text-muted-foreground">{site.default_workflow}</p>
-                  </div>
-
-                  <div>
-                    <h3 className="mb-2 text-sm font-medium">Submission Kinds</h3>
-                    <div className="flex flex-wrap gap-2">
-                      {site.submissionKinds.map((kind) => {
-                        const content = kind.content as { title?: string };
-                        return (
-                          <ui.Badge key={kind.id} variant="default">
-                            {content?.title || kind.name}
-                          </ui.Badge>
-                        );
-                      })}
-                    </div>
-                  </div>
-
-                  <div>
-                    <h3 className="mb-2 text-sm font-medium">Collections</h3>
-                    <div className="flex flex-wrap gap-2">
-                      {site.collections.map((collection) => {
-                        const content = collection.content as { title?: string };
-                        return (
-                          <ui.Badge key={collection.id} variant="default">
-                            {content?.title || collection.name}
-                          </ui.Badge>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
-
-                <details className="mt-6">
-                  <summary className="text-sm font-medium cursor-pointer">Site Metadata</summary>
-                  <pre className="overflow-auto p-4 mt-2 text-sm rounded-md bg-muted">
-                    {JSON.stringify(site.metadata, null, 2)}
-                  </pre>
-                </details>
-              </div>
-            </primitives.Card>
+    <PageFrame
+      title="Extensions"
+      subtitle="Manage extension configuration and external publishing sites"
+      className="mx-auto max-w-screen-lg"
+    >
+      <ui.Tabs defaultValue={defaultTab} className="space-y-2">
+        <ui.TabsList>
+          {extensionEntries.map(([extensionId]) => (
+            <ui.TabsTrigger key={extensionId} value={extensionId}>
+              {getExtensionTabLabel(extensionId)}
+            </ui.TabsTrigger>
           ))}
-        </div>
-      </SectionWithHeading>
+          <ui.TabsTrigger value={EXTERNAL_SITES_TAB}>External Sites</ui.TabsTrigger>
+        </ui.TabsList>
+
+        {extensionEntries.map(([extensionId, extension]) => (
+          <ui.TabsContent key={extensionId} value={extensionId} className="space-y-2">
+            <ExtensionAdminTabContent
+              extensionId={extensionId}
+              extension={extension}
+              safeConfig={extensionAdminConfigs?.[extensionId]}
+              clientExtensions={extensions}
+            />
+          </ui.TabsContent>
+        ))}
+
+        <ui.TabsContent value={EXTERNAL_SITES_TAB} className="space-y-2">
+          <ExternalSitesTab sites={sites} />
+        </ui.TabsContent>
+      </ui.Tabs>
     </PageFrame>
   );
 }

--- a/platform/scms/app/routes/app/settings.emails/route.tsx
+++ b/platform/scms/app/routes/app/settings.emails/route.tsx
@@ -1,7 +1,7 @@
 import type { Route } from './+types/route';
 import { redirect, useFetcher } from 'react-router';
 import { useState } from 'react';
-import { withAppContext, withAppScopedContext, unsubscribe } from '@curvenote/scms-server';
+import { withAppScopedContext, unsubscribe } from '@curvenote/scms-server';
 import {
   PageFrame,
   primitives,

--- a/platform/scms/app/routes/app/settings.linked-accounts/route.tsx
+++ b/platform/scms/app/routes/app/settings.linked-accounts/route.tsx
@@ -1,7 +1,6 @@
 import type { Route } from './+types/route';
 import { data, useSearchParams, useFetcher } from 'react-router';
 import {
-  withAppContext,
   withValidFormData,
   dbUpsertPendingLinkedAccount,
   withAppScopedContext,

--- a/platform/scms/app/routes/app/works.$workId.checks/RunCheckOnLatestVersionButton.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/RunCheckOnLatestVersionButton.tsx
@@ -1,12 +1,13 @@
 import { useFetcher } from 'react-router';
 import { GitBranch } from 'lucide-react';
-import { ui } from '@curvenote/scms-core';
+import { ui, useCheckMaintenanceBlocked } from '@curvenote/scms-core';
 
 type RunCheckOnLatestVersionButtonProps = {
   /** POST target (extension checksActionPath or platform fallback). */
   actionPath: string;
   /** Latest non-draft work version id to run the check against. */
   workVersionId: string;
+  checkServiceId: string;
 };
 
 /**
@@ -17,25 +18,31 @@ type RunCheckOnLatestVersionButtonProps = {
 export function RunCheckOnLatestVersionButton({
   actionPath,
   workVersionId,
+  checkServiceId,
 }: RunCheckOnLatestVersionButtonProps) {
   const fetcher = useFetcher();
   const isSubmitting = fetcher.state === 'submitting';
+  const { blocked, message } = useCheckMaintenanceBlocked(checkServiceId);
+
   return (
-    <fetcher.Form method="post" action={actionPath}>
-      <input type="hidden" name="workVersionId" value={workVersionId} />
-      <ui.StatefulButton
-        type="submit"
-        variant="default"
-        size="sm"
-        name="intent"
-        value="execute"
-        busy={isSubmitting}
-      >
-        <span className="flex gap-1 items-center">
-          <GitBranch className="w-3 h-3" aria-hidden />
-          Check Latest Version
-        </span>
-      </ui.StatefulButton>
-    </fetcher.Form>
+    <ui.MaintenanceTooltip enabled={blocked} message={message}>
+      <fetcher.Form method="post" action={actionPath}>
+        <input type="hidden" name="workVersionId" value={workVersionId} />
+        <ui.StatefulButton
+          type="submit"
+          variant="default"
+          size="sm"
+          name="intent"
+          value="execute"
+          busy={isSubmitting}
+          disabled={blocked}
+        >
+          <span className="flex gap-1 items-center">
+            <GitBranch className="w-3 h-3" aria-hidden />
+            Check Latest Version
+          </span>
+        </ui.StatefulButton>
+      </fetcher.Form>
+    </ui.MaintenanceTooltip>
   );
 }

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -345,6 +345,7 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
               <RunCheckOnLatestVersionButton
                 actionPath={service.checksActionPath ?? `${basePath}/checks`}
                 workVersionId={latestNonDraftWorkVersion.id}
+                checkServiceId={service.id}
               />
             ) : null;
 

--- a/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
@@ -46,22 +46,6 @@ type TimelineEntry =
       version: WorkVersionForDetailsClient;
     };
 
-/** Latest run id for each check `kind` across all versions (by `date_created`). */
-function getLatestCheckRunIdByKind(
-  checkServiceRunsByWorkVersionId: Record<string, CheckServiceRunRow[]>,
-): Record<string, string> {
-  const latestRunByKind: Record<string, CheckServiceRunRow> = {};
-  for (const runs of Object.values(checkServiceRunsByWorkVersionId)) {
-    for (const run of runs) {
-      const currentBest = latestRunByKind[run.kind];
-      if (!currentBest || run.date_created > currentBest.date_created) {
-        latestRunByKind[run.kind] = run;
-      }
-    }
-  }
-  return Object.fromEntries(Object.entries(latestRunByKind).map(([kind, run]) => [kind, run.id]));
-}
-
 /** Single entrypoint for timeline auto-expand behavior (easy to A/B later). */
 function shouldExpandByDefault(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/ContinueForm.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/ContinueForm.tsx
@@ -53,12 +53,10 @@ export function ContinueForm({ title, authors, metadata, checkServices }: Contin
     (f) => f.state !== 'idle' && f.formData?.get('intent') === 'toggle-check',
   );
 
+  // A selected check whose service is under maintenance does not block submission;
+  // it is simply skipped (not initiated) and the work is created without it.
   const disabled =
-    !hasTitle ||
-    !hasFiles ||
-    hasPendingToggleCheck ||
-    hasInvalidSelectedChecks ||
-    maintenanceBlocked;
+    !hasTitle || !hasFiles || hasPendingToggleCheck || hasInvalidSelectedChecks;
 
   const handleContinue = () => {
     const formData = new FormData();
@@ -70,8 +68,8 @@ export function ContinueForm({ title, authors, metadata, checkServices }: Contin
   };
 
   return (
-    <div className="flex gap-4 items-center mt-6">
-      <ui.MaintenanceTooltip enabled={maintenanceBlocked} message={maintenanceMessage}>
+    <div className="mt-6 space-y-2">
+      <div className="flex gap-4 items-center">
         <ui.StatefulButton
           type="button"
           busy={fetcher.state !== 'idle'}
@@ -80,10 +78,15 @@ export function ContinueForm({ title, authors, metadata, checkServices }: Contin
         >
           Continue
         </ui.StatefulButton>
-      </ui.MaintenanceTooltip>
-      <ui.Button variant="link" asChild>
-        <Link to={finishLaterHref}>Come back and finish this later</Link>
-      </ui.Button>
+        <ui.Button variant="link" asChild>
+          <Link to={finishLaterHref}>Come back and finish this later</Link>
+        </ui.Button>
+      </div>
+      {maintenanceBlocked ? (
+        <p className="text-sm text-muted-foreground">
+          {maintenanceMessage} This check will be skipped and can be run later.
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/ContinueForm.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/ContinueForm.tsx
@@ -1,6 +1,10 @@
 import { useEffect } from 'react';
 import { useFetcher, useFetchers, Link, useParams, useLocation } from 'react-router';
-import { ui, hasInvalidEnabledUploadChecks } from '@curvenote/scms-core';
+import {
+  ui,
+  hasInvalidEnabledUploadChecks,
+  useAnyCheckMaintenanceBlocked,
+} from '@curvenote/scms-core';
 import type { ExtensionCheckService, FileMetadataSection } from '@curvenote/scms-core';
 import type { WorkVersionMetadata, ChecksMetadataSection } from '@curvenote/scms-server';
 
@@ -42,12 +46,19 @@ export function ContinueForm({ title, authors, metadata, checkServices }: Contin
     enabledChecks,
     checkServices,
   );
+  const { blocked: maintenanceBlocked, message: maintenanceMessage } =
+    useAnyCheckMaintenanceBlocked(enabledChecks);
 
   const hasPendingToggleCheck = fetchers.some(
     (f) => f.state !== 'idle' && f.formData?.get('intent') === 'toggle-check',
   );
 
-  const disabled = !hasTitle || !hasFiles || hasPendingToggleCheck || hasInvalidSelectedChecks;
+  const disabled =
+    !hasTitle ||
+    !hasFiles ||
+    hasPendingToggleCheck ||
+    hasInvalidSelectedChecks ||
+    maintenanceBlocked;
 
   const handleContinue = () => {
     const formData = new FormData();
@@ -60,14 +71,16 @@ export function ContinueForm({ title, authors, metadata, checkServices }: Contin
 
   return (
     <div className="flex gap-4 items-center mt-6">
-      <ui.StatefulButton
-        type="button"
-        busy={fetcher.state !== 'idle'}
-        disabled={disabled}
-        onClick={handleContinue}
-      >
-        Continue
-      </ui.StatefulButton>
+      <ui.MaintenanceTooltip enabled={maintenanceBlocked} message={maintenanceMessage}>
+        <ui.StatefulButton
+          type="button"
+          busy={fetcher.state !== 'idle'}
+          disabled={disabled}
+          onClick={handleContinue}
+        >
+          Continue
+        </ui.StatefulButton>
+      </ui.MaintenanceTooltip>
       <ui.Button variant="link" asChild>
         <Link to={finishLaterHref}>Come back and finish this later</Link>
       </ui.Button>

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/ContinueForm.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/ContinueForm.tsx
@@ -46,8 +46,7 @@ export function ContinueForm({ title, authors, metadata, checkServices }: Contin
     enabledChecks,
     checkServices,
   );
-  const { blocked: maintenanceBlocked, message: maintenanceMessage } =
-    useAnyCheckMaintenanceBlocked(enabledChecks);
+  const { blocked: maintenanceBlocked } = useAnyCheckMaintenanceBlocked(enabledChecks);
 
   const hasPendingToggleCheck = fetchers.some(
     (f) => f.state !== 'idle' && f.formData?.get('intent') === 'toggle-check',
@@ -84,7 +83,8 @@ export function ContinueForm({ title, authors, metadata, checkServices }: Contin
       </div>
       {maintenanceBlocked ? (
         <p className="text-sm text-muted-foreground">
-          {maintenanceMessage} This check will be skipped and can be run later.
+          At least one service is temporarily down for maintenance. The affected check will be
+          skipped and can be run later.
         </p>
       ) : null}
     </div>

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/ContinueForm.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/ContinueForm.tsx
@@ -4,6 +4,7 @@ import {
   ui,
   hasInvalidEnabledUploadChecks,
   useAnyCheckMaintenanceBlocked,
+  useChecksNotUnderMaintenance,
 } from '@curvenote/scms-core';
 import type { ExtensionCheckService, FileMetadataSection } from '@curvenote/scms-core';
 import type { WorkVersionMetadata, ChecksMetadataSection } from '@curvenote/scms-server';
@@ -41,9 +42,14 @@ export function ContinueForm({ title, authors, metadata, checkServices }: Contin
     Object.keys(metadata.files).length > 0;
 
   const enabledChecks = metadata.checks?.enabled ?? [];
+  // Mirror the server's `confirm-work`: checks under maintenance are dropped
+  // (not initiated), so only validate compatibility for the dispatchable ones.
+  // A check that is both incompatible and under maintenance must not block
+  // submission, since the server would drop it and accept the work.
+  const dispatchableChecks = useChecksNotUnderMaintenance(enabledChecks);
   const hasInvalidSelectedChecks = hasInvalidEnabledUploadChecks(
     metadata,
-    enabledChecks,
+    dispatchableChecks,
     checkServices,
   );
   const { blocked: maintenanceBlocked } = useAnyCheckMaintenanceBlocked(enabledChecks);
@@ -54,8 +60,7 @@ export function ContinueForm({ title, authors, metadata, checkServices }: Contin
 
   // A selected check whose service is under maintenance does not block submission;
   // it is simply skipped (not initiated) and the work is created without it.
-  const disabled =
-    !hasTitle || !hasFiles || hasPendingToggleCheck || hasInvalidSelectedChecks;
+  const disabled = !hasTitle || !hasFiles || hasPendingToggleCheck || hasInvalidSelectedChecks;
 
   const handleContinue = () => {
     const formData = new FormData();

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/WorkUploadChecksForm.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/WorkUploadChecksForm.tsx
@@ -3,6 +3,7 @@ import {
   UploadCheckOptionCard,
   UPLOAD_CHECKS_GRID_CLASS,
   resolveUploadCheckCardState,
+  useCheckMaintenanceBlocked,
 } from '@curvenote/scms-core';
 import type { ChecksObject } from '@curvenote/scms-server';
 import { ArticleStructureUploadCheckCard } from './ArticleStructureUploadCheckCard';
@@ -16,6 +17,42 @@ interface WorkUploadChecksFormProps extends ChecksObject {
   textIntegrityLogoUrl?: string;
 }
 
+function UploadCheckServiceCard({
+  service,
+  workVersionId,
+  enabled,
+  metadata,
+  textIntegrityLogoUrl,
+}: {
+  service: ExtensionCheckService;
+  workVersionId: string;
+  enabled: boolean;
+  metadata: unknown;
+  textIntegrityLogoUrl?: string;
+}) {
+  const { blocked: underMaintenance, message: maintenanceMessage } = useCheckMaintenanceBlocked(
+    service.id,
+  );
+  const eligible = service.isUploadEligible?.(metadata) ?? true;
+  const { disabled, invalid } = resolveUploadCheckCardState({
+    eligible,
+    enabled,
+    underMaintenance,
+  });
+
+  return (
+    <UploadCheckOptionCard
+      service={service}
+      workVersionId={workVersionId}
+      enabled={enabled}
+      disabled={disabled}
+      invalid={invalid}
+      maintenanceMessage={underMaintenance ? maintenanceMessage : undefined}
+      logoUrl={service.id === 'checks-text-integrity' ? textIntegrityLogoUrl : undefined}
+    />
+  );
+}
+
 export function WorkUploadChecksForm({
   enabled,
   checkServices,
@@ -25,25 +62,16 @@ export function WorkUploadChecksForm({
 }: WorkUploadChecksFormProps) {
   return (
     <div className={UPLOAD_CHECKS_GRID_CLASS}>
-      {checkServices.map((service) => {
-        const isEnabled = enabled.includes(service.id as (typeof enabled)[number]);
-        const eligible = service.isUploadEligible?.(metadata) ?? true;
-        const { disabled, invalid } = resolveUploadCheckCardState({
-          eligible,
-          enabled: isEnabled,
-        });
-        return (
-          <UploadCheckOptionCard
-            key={service.id}
-            service={service}
-            workVersionId={workVersionId}
-            enabled={isEnabled}
-            disabled={disabled}
-            invalid={invalid}
-            logoUrl={service.id === 'checks-text-integrity' ? textIntegrityLogoUrl : undefined}
-          />
-        );
-      })}
+      {checkServices.map((service) => (
+        <UploadCheckServiceCard
+          key={service.id}
+          service={service}
+          workVersionId={workVersionId}
+          enabled={enabled.includes(service.id as (typeof enabled)[number])}
+          metadata={metadata}
+          textIntegrityLogoUrl={textIntegrityLogoUrl}
+        />
+      ))}
 
       <ArticleStructureUploadCheckCard />
     </div>

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/fetchPreviews.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/fetchPreviews.server.ts
@@ -226,6 +226,7 @@ export async function fetchDocxPreviews(
       }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { signedUrl: _drop, ...fileMeta } = file;
     previews.push({
       path,
@@ -284,6 +285,7 @@ export async function readDocxPreviewsFromObjectTable(metadata: {
       select: { data: true },
     });
     if (cached?.data == null || !isCachedAst(cached.data)) continue;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { signedUrl: _drop, ...fileMeta } = file;
     previews.push({
       path,

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
@@ -35,7 +35,6 @@ import {
   getExtensionCheckServicesFromClientConfig,
   getExtensionCheckServicesFromServerConfig,
   hasInvalidEnabledUploadChecks,
-  hasMaintenanceEnabledUploadChecks,
   loadCheckMaintenanceByServiceIds,
   CheckMaintenanceProvider,
   capitalize,
@@ -416,7 +415,22 @@ export async function action(args: Route.ActionArgs) {
           baseCtx.$config,
           serverExtensions,
         );
-        if (hasInvalidEnabledUploadChecks(currentMetadata, enabledChecks, uploadCheckServices)) {
+
+        // Checks whose service is under maintenance are not initiated. The work is
+        // created as though those checks were never selected; they can be run later
+        // once the service is back online.
+        const maintenanceByServiceId = await loadCheckMaintenanceByServiceIds(
+          baseCtx,
+          serverExtensions,
+          enabledChecks,
+        );
+        const dispatchableChecks = enabledChecks.filter(
+          (name) => !maintenanceByServiceId[name]?.underMaintenance,
+        );
+
+        if (
+          hasInvalidEnabledUploadChecks(currentMetadata, dispatchableChecks, uploadCheckServices)
+        ) {
           return data(
             {
               error: {
@@ -429,40 +443,19 @@ export async function action(args: Route.ActionArgs) {
           );
         }
 
-        const maintenanceByServiceId = await loadCheckMaintenanceByServiceIds(
-          baseCtx,
-          serverExtensions,
-          enabledChecks,
-        );
-        if (hasMaintenanceEnabledUploadChecks(enabledChecks, maintenanceByServiceId)) {
-          const blockedMessage =
-            Object.values(maintenanceByServiceId).find((state) => state.underMaintenance)
-              ?.message ??
-            'One or more selected checks are temporarily unavailable for maintenance.';
-          return data(
-            {
-              error: {
-                type: 'maintenance',
-                message: blockedMessage,
-              },
-            },
-            { status: 503 },
-          );
-        }
-
-        // Create check status objects for each enabled check
+        // Create check status objects for each dispatchable check
         const checkStatuses: Record<string, any> = {};
-        enabledChecks.forEach((name) => {
+        dispatchableChecks.forEach((name) => {
           checkStatuses[name] = {};
         });
 
-        // Update metadata with check statuses
+        // Update metadata with check statuses (maintenance checks are dropped)
         await safeWorkVersionJsonUpdate(workVersionId, (metadata?: Prisma.JsonValue) => {
           const meta = (metadata as Record<string, any>) || makeDefaultWorkVersionMetadata();
           return {
             ...meta,
             checks: {
-              enabled: enabledChecks,
+              enabled: dispatchableChecks,
               ...checkStatuses,
             },
           } as Prisma.JsonObject;
@@ -481,7 +474,7 @@ export async function action(args: Route.ActionArgs) {
         // Schedule each enabled check via its extension. Each check service is
         // responsible for creating its own checkServiceRun rows and jobs.
         // Require work:checks:dispatch scope before dispatching (same as work-integrity action).
-        if (enabledChecks.length > 0) {
+        if (dispatchableChecks.length > 0) {
           if (!userHasScope(baseCtx.user, scopes.app.works.checks.dispatch)) {
             return data(
               {
@@ -495,14 +488,14 @@ export async function action(args: Route.ActionArgs) {
           }
           waitUntil(
             dispatchEnabledChecksAfterUpload({
-              enabledChecks,
+              enabledChecks: dispatchableChecks,
               workVersionId,
               ctx: baseCtx,
             }).catch((error) => {
               console.error('[work-upload] background check dispatch failed', {
                 workId,
                 workVersionId,
-                enabledChecks,
+                enabledChecks: dispatchableChecks,
                 error,
               });
             }),
@@ -515,7 +508,7 @@ export async function action(args: Route.ActionArgs) {
         const shouldRedirect = redirectParam !== 'false';
         if (shouldRedirect) {
           const target =
-            enabledChecks.length > 0
+            dispatchableChecks.length > 0
               ? `/app/works/${workId}/checks?dispatching=1`
               : `/app/works/${workId}/details`;
           return redirect(target);

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
@@ -35,6 +35,9 @@ import {
   getExtensionCheckServicesFromClientConfig,
   getExtensionCheckServicesFromServerConfig,
   hasInvalidEnabledUploadChecks,
+  hasMaintenanceEnabledUploadChecks,
+  loadCheckMaintenanceByServiceIds,
+  CheckMaintenanceProvider,
   capitalize,
   scopes,
 } from '@curvenote/scms-core';
@@ -255,6 +258,16 @@ export async function loader(args: Route.LoaderArgs) {
 
   const textIntegrityLogoUrl = await getTextIntegrityLogoUrlFromObjectStore();
 
+  const uploadCheckServices = getExtensionCheckServicesFromServerConfig(
+    ctx.$config,
+    serverExtensions,
+  );
+  const maintenanceByServiceId = await loadCheckMaintenanceByServiceIds(
+    ctx,
+    serverExtensions,
+    uploadCheckServices.map((service) => service.id),
+  );
+
   return {
     workVersionId: work.version_id,
     cdnKey: work.cdn_key!,
@@ -270,6 +283,7 @@ export async function loader(args: Route.LoaderArgs) {
     extractedMetadata,
     hasMetadataPreviewScope,
     textIntegrityLogoUrl,
+    maintenanceByServiceId,
   };
 }
 
@@ -351,6 +365,27 @@ export async function action(args: Route.ActionArgs) {
         }
 
         const isChecked = checked === 'true';
+
+        if (isChecked) {
+          const maintenanceByServiceId = await loadCheckMaintenanceByServiceIds(
+            baseCtx,
+            serverExtensions,
+            [checkName],
+          );
+          const maintenance = maintenanceByServiceId[checkName];
+          if (maintenance?.underMaintenance) {
+            return data(
+              {
+                error: {
+                  type: 'maintenance',
+                  message: maintenance.message,
+                },
+              },
+              { status: 503 },
+            );
+          }
+        }
+
         return toggleWorkVersionCheck(workVersionId, checkName, isChecked);
       }
 
@@ -391,6 +426,27 @@ export async function action(args: Route.ActionArgs) {
               },
             },
             { status: 400 },
+          );
+        }
+
+        const maintenanceByServiceId = await loadCheckMaintenanceByServiceIds(
+          baseCtx,
+          serverExtensions,
+          enabledChecks,
+        );
+        if (hasMaintenanceEnabledUploadChecks(enabledChecks, maintenanceByServiceId)) {
+          const blockedMessage =
+            Object.values(maintenanceByServiceId).find((state) => state.underMaintenance)
+              ?.message ??
+            'One or more selected checks are temporarily unavailable for maintenance.';
+          return data(
+            {
+              error: {
+                type: 'maintenance',
+                message: blockedMessage,
+              },
+            },
+            { status: 503 },
           );
         }
 
@@ -623,6 +679,7 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
     previews = [],
     extractedMetadata,
     hasMetadataPreviewScope,
+    maintenanceByServiceId,
   } = loaderData;
   const { workVersionId } = useParams();
   const previewList: DocxPreviewItem[] = Array.isArray(previews) ? previews : [];
@@ -694,68 +751,70 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
     : 'Refreshing previews…';
 
   return (
-    <MainWrapper>
-      <PageFrame
-        title={pageTitle}
-        subtitle={pageSubtitle}
-        hasSecondaryNav={false}
-        className="space-y-16 max-w-none text-left"
-      >
-        <SectionWithHeading
-          heading="Upload your manuscript"
-          icon={<Upload className="w-5 h-5" />}
-          className="space-y-4 max-w-3xl"
+    <CheckMaintenanceProvider maintenanceByServiceId={maintenanceByServiceId}>
+      <MainWrapper>
+        <PageFrame
+          title={pageTitle}
+          subtitle={pageSubtitle}
+          hasSecondaryNav={false}
+          className="space-y-16 max-w-none text-left"
         >
-          <p className="text-md text-muted-foreground">
-            Upload one or more manuscript files (DOCX or PDF), up to 100 MB total. Individual check
-            services may have stricter limits.
-          </p>
-          <WorkFileUpload
-            cdnKey={cdnKey}
-            config={uploadConfig['manuscript']}
-            loadedFileMetadata={metadata as any}
-            onFilesSelected={suggestArticleTitleFromSelectedFiles}
-          />
-        </SectionWithHeading>
-        {hasMetadataPreviewScope ? (
-          <React.Suspense
-            fallback={<p className="text-sm text-muted-foreground">Loading DOCX previews…</p>}
+          <SectionWithHeading
+            heading="Upload your manuscript"
+            icon={<Upload className="w-5 h-5" />}
+            className="space-y-4 max-w-3xl"
           >
-            <MetadataPreviewSection
-              previewList={previewList}
-              isPreviewsLoading={isPreviewsLoading}
-              previewOverlayMessage={previewOverlayMessage}
-              extractedMetadata={extractedMetadata}
-              title={title}
-              authors={authors}
+            <p className="text-md text-muted-foreground">
+              Upload one or more manuscript files (DOCX or PDF), up to 100 MB total. Individual
+              check services may have stricter limits.
+            </p>
+            <WorkFileUpload
+              cdnKey={cdnKey}
+              config={uploadConfig['manuscript']}
+              loadedFileMetadata={metadata as any}
+              onFilesSelected={suggestArticleTitleFromSelectedFiles}
             />
-          </React.Suspense>
-        ) : (
-          <CaptureMetadataSection title={title} authors={authors} />
-        )}
-        <SectionWithHeading
-          heading="Select Checks to Run"
-          icon={<CheckSquare className="w-5 h-5" />}
-          className="space-y-4 max-w-5xl"
-        >
-          <p className="text-muted-foreground">
-            Choose which checks you'd like to run on your work.
-          </p>
-          <WorkUploadChecksForm
-            enabled={metadata.checks?.enabled || []}
-            checkServices={checkServices}
-            workVersionId={workVersionId!}
+          </SectionWithHeading>
+          {hasMetadataPreviewScope ? (
+            <React.Suspense
+              fallback={<p className="text-sm text-muted-foreground">Loading DOCX previews…</p>}
+            >
+              <MetadataPreviewSection
+                previewList={previewList}
+                isPreviewsLoading={isPreviewsLoading}
+                previewOverlayMessage={previewOverlayMessage}
+                extractedMetadata={extractedMetadata}
+                title={title}
+                authors={authors}
+              />
+            </React.Suspense>
+          ) : (
+            <CaptureMetadataSection title={title} authors={authors} />
+          )}
+          <SectionWithHeading
+            heading="Select Checks to Run"
+            icon={<CheckSquare className="w-5 h-5" />}
+            className="space-y-4 max-w-5xl"
+          >
+            <p className="text-muted-foreground">
+              Choose which checks you'd like to run on your work.
+            </p>
+            <WorkUploadChecksForm
+              enabled={metadata.checks?.enabled || []}
+              checkServices={checkServices}
+              workVersionId={workVersionId!}
+              metadata={metadata}
+              textIntegrityLogoUrl={loaderData.textIntegrityLogoUrl}
+            />
+          </SectionWithHeading>
+          <ContinueForm
+            title={title}
+            authors={authors}
             metadata={metadata}
-            textIntegrityLogoUrl={loaderData.textIntegrityLogoUrl}
+            checkServices={checkServices}
           />
-        </SectionWithHeading>
-        <ContinueForm
-          title={title}
-          authors={authors}
-          metadata={metadata}
-          checkServices={checkServices}
-        />
-      </PageFrame>
-    </MainWrapper>
+        </PageFrame>
+      </MainWrapper>
+    </CheckMaintenanceProvider>
   );
 }

--- a/platform/scms/app/routes/app/works.$workId.users/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.users/route.tsx
@@ -54,7 +54,7 @@ export async function action(args: Route.ActionArgs) {
 }
 
 export default function Users({ loaderData }: Route.ComponentProps) {
-  const { work, users } = loaderData;
+  const { users } = loaderData;
 
   return (
     <PageFrame title="Users" subtitle="Who can access this work?">

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -254,7 +254,6 @@ export const loader = async (args: LoaderFunctionArgs) => {
   const activities = await dbGetWorkActivities(ctx.work.id);
   const checkServiceRunsByWorkVersionId = await dbGetCheckServiceRunsByWorkVersionIds(versionIds);
 
-  const latestNonDraftVersion = versionsForClient.find((v) => !v.draft);
   const work = latestNonDraftWithMetadata
     ? worksLoaders.formatWorkDTO(ctx, ctx.work, latestNonDraftWithMetadata)
     : ctx.workDTO;

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -22,6 +22,9 @@ import {
   TrackEvent,
   getWorkflows,
   registerExtensionWorkflows,
+  getExtensionCheckServicesFromServerConfig,
+  loadCheckMaintenanceByServiceIds,
+  CheckMaintenanceProvider,
   scopes,
 } from '@curvenote/scms-core';
 import { buildMenu } from './menu';
@@ -258,6 +261,13 @@ export const loader = async (args: LoaderFunctionArgs) => {
   const usersDbo = await dbGetWorkUsers(ctx.work.id);
   const users = usersDbo ? dtoWorkUsers(usersDbo) : [];
 
+  const checkServices = getExtensionCheckServicesFromServerConfig(ctx.$config, serverExtensions);
+  const maintenanceByServiceId = await loadCheckMaintenanceByServiceIds(
+    ctx,
+    serverExtensions,
+    checkServices.map((service) => service.id),
+  );
+
   return {
     userScopes: ctx.scopes,
     workflows,
@@ -274,6 +284,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
     latestNonDraftContentCard,
     users,
     isOnUploadRoute,
+    maintenanceByServiceId,
   };
 };
 
@@ -298,33 +309,36 @@ export function shouldRevalidate({
 }
 
 export default function WorkLayout({ loaderData }: Route.ComponentProps) {
-  const { work, versions, submissions, userScopes, isOnUploadRoute } = loaderData;
+  const { work, versions, submissions, userScopes, isOnUploadRoute, maintenanceByServiceId } =
+    loaderData;
 
   const isDrafting = versions.length > 0 && versions.every((v) => v.draft);
   const showSecondaryNav = !isDrafting && !isOnUploadRoute;
   const menu = buildMenu(`/app/works/${work.id}`, isDrafting, submissions, userScopes);
 
   return (
-    <>
-      {showSecondaryNav && (
-        <SecondaryNav
-          contents={menu}
-          title={isDrafting ? 'Work Details' : undefined}
-          extensions={extensions}
-          detailsCard={
-            !isDrafting ? (
-              <WorkDetailsCard
-                title={work.title ?? ''}
-                authors={work.authors}
-                thumbnail={work.links.thumbnail}
-              />
-            ) : undefined
-          }
-        />
-      )}
-      <MainWrapper hasSecondaryNav={showSecondaryNav}>
-        <Outlet />
-      </MainWrapper>
-    </>
+    <CheckMaintenanceProvider maintenanceByServiceId={maintenanceByServiceId}>
+      <>
+        {showSecondaryNav && (
+          <SecondaryNav
+            contents={menu}
+            title={isDrafting ? 'Work Details' : undefined}
+            extensions={extensions}
+            detailsCard={
+              !isDrafting ? (
+                <WorkDetailsCard
+                  title={work.title ?? ''}
+                  authors={work.authors}
+                  thumbnail={work.links.thumbnail}
+                />
+              ) : undefined
+            }
+          />
+        )}
+        <MainWrapper hasSecondaryNav={showSecondaryNav}>
+          <Outlet />
+        </MainWrapper>
+      </>
+    </CheckMaintenanceProvider>
   );
 }

--- a/platform/scms/tests/integration/helpers/mocks.ts
+++ b/platform/scms/tests/integration/helpers/mocks.ts
@@ -21,6 +21,7 @@ export function createMockConfig() {
       previewSigningSecret: 'test-secret',
       handshakeIssuer: 'test-issuer',
       handshakeSigningSecret: 'test-secret',
+      queueConsumerSecret: 'test-secret',
       submissionsServiceAccount: { id: 'test-id' },
     },
   };


### PR DESCRIPTION
Enables platform admins to lock check services in response to service outages and provider downtime.

<img width="1800" height="1848" alt="image" src="https://github.com/user-attachments/assets/6dd4afc2-00ab-466b-afd3-49cea5c18ce7" />

<img width="2130" height="1184" alt="image" src="https://github.com/user-attachments/assets/2a870117-bd4e-43b2-b4af-336d774b80bf" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes work upload confirmation, check dispatch filtering, and user-facing run-check actions; misconfigured `queueConsumerSecret` will break queue drain wake-ups in all environments.
> 
> **Overview**
> Adds **per-check-service maintenance mode** so platform admins can flag outages on extension config (via shared `check-maintenance` helpers, `CheckMaintenanceAdminPanel`, and server guards that return **503** with type `maintenance`). Work routes load maintenance state and expose it through **`CheckMaintenanceProvider`**; upload cards and **Check Latest Version** disable actions with **`MaintenanceTooltip`** messaging.
> 
> **Upload confirm** now treats maintenance-selected checks like the server: they are **dropped from `dispatchableChecks`** (not enqueued), metadata is saved without them, and Continue stays enabled with an informational note; enabling a check via toggle while under maintenance is rejected.
> 
> Also makes **`api.queueConsumerSecret`** a required app-config secret for **`POST /v1/jobs/push-to-drain`** Bearer auth (test config + README/.env.sample updates), and refactors **Platform → Extensions** into per-extension tabs plus an External Sites tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0852a19297d5df7ad62f1e0be2c29a1baeced854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->