### PR TITLE
fix/defensive work lookup

### DIFF
--- a/.changeset/kind-sides-return.md
+++ b/.changeset/kind-sides-return.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-server': patch
+---
+
+Defensive changes on published work lookup for different slug and id shapes

--- a/packages/scms-server/src/backend/loaders/sites/submissions/published/resolve.server.test.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/published/resolve.server.test.ts
@@ -1,0 +1,59 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { fetchPublishedSubmissionVersionId } from './resolve.server.js';
+
+const queryRaw = vi.fn();
+
+vi.mock('../../../../prisma.server.js', () => ({
+  getPrismaClient: vi.fn(async () => ({
+    $queryRaw: queryRaw,
+  })),
+}));
+
+function queryText(callIndex: number): string {
+  return String(queryRaw.mock.calls[callIndex][0]);
+}
+
+describe('fetchPublishedSubmissionVersionId', () => {
+  beforeEach(() => {
+    queryRaw.mockReset();
+  });
+
+  test('falls back to slug lookup when a UUID-shaped work id lookup misses', async () => {
+    queryRaw.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: 'slug-version-id' }]);
+
+    const id = await fetchPublishedSubmissionVersionId(
+      'site-id',
+      '550e8400-e29b-41d4-a716-446655440000',
+    );
+
+    expect(id).toBe('slug-version-id');
+    expect(queryRaw).toHaveBeenCalledTimes(2);
+    expect(queryText(0)).toContain('FROM "WorkVersion"');
+    expect(queryText(1)).toContain('FROM "Slug"');
+  });
+
+  test('falls back to work id lookup when a slug-shaped slug lookup misses', async () => {
+    queryRaw.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: 'work-version-id' }]);
+
+    const id = await fetchPublishedSubmissionVersionId('site-id', 'legacy-work-id');
+
+    expect(id).toBe('work-version-id');
+    expect(queryRaw).toHaveBeenCalledTimes(2);
+    expect(queryText(0)).toContain('FROM "Slug"');
+    expect(queryText(1)).toContain('FROM "WorkVersion"');
+  });
+
+  test('does not run fallback lookup after preferred lookup succeeds', async () => {
+    queryRaw.mockResolvedValueOnce([{ id: 'preferred-version-id' }]);
+
+    const id = await fetchPublishedSubmissionVersionId(
+      'site-id',
+      '550e8400-e29b-41d4-a716-446655440000',
+    );
+
+    expect(id).toBe('preferred-version-id');
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    expect(queryText(0)).toContain('FROM "WorkVersion"');
+  });
+});

--- a/packages/scms-server/src/backend/loaders/sites/submissions/published/resolve.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/published/resolve.server.ts
@@ -61,9 +61,13 @@ export async function fetchPublishedSubmissionVersionId(
   workIdOrSlug: string,
 ): Promise<string | null> {
   if (looksLikeUUID(workIdOrSlug)) {
-    return fetchPublishedSubmissionVersionIdByWorkId(siteId, workIdOrSlug);
+    const id = await fetchPublishedSubmissionVersionIdByWorkId(siteId, workIdOrSlug);
+    if (id) return id;
+    return fetchPublishedSubmissionVersionIdBySlug(siteId, workIdOrSlug);
   }
-  return fetchPublishedSubmissionVersionIdBySlug(siteId, workIdOrSlug);
+  const id = await fetchPublishedSubmissionVersionIdBySlug(siteId, workIdOrSlug);
+  if (id) return id;
+  return fetchPublishedSubmissionVersionIdByWorkId(siteId, workIdOrSlug);
 }
 
 export async function hydratePublishedSubmissionVersion<


### PR DESCRIPTION
- **🧭 Resolve published work fallback**
- **📕**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow resolver change with tests; worst case is one extra indexed query on miss, with no auth or data-mutation impact.
> 
> **Overview**
> **Published submission resolution** now tries a **secondary lookup** when the shape-based primary query finds nothing, so UUID-looking values can still match a **slug**, and non-UUID strings can still match a **work id** (e.g. legacy ids).
> 
> `fetchPublishedSubmissionVersionId` keeps the same preferred order (`looksLikeUUID` → work id first, otherwise slug first) but only runs the fallback when the first query returns null; successful hits still issue a single raw query.
> 
> Adds **Vitest coverage** for both fallback directions and for skipping fallback after a hit. Patch changeset for `@curvenote/scms-server`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f18a30faa607a9790e6f30e14acfc2e016a84a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->