### PR TITLE
🔗 Relax overaggressive DOI coercion

### DIFF
--- a/.changeset/tender-bars-hunt.md
+++ b/.changeset/tender-bars-hunt.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/cli': patch
+---
+
+Relax overaggressive DOI coercion


### PR DESCRIPTION
This consumes the MyST change which stops links to URLs with DOIs in their path from converting to citations. Only links to DOI urls are converted now.