### PR TITLE
🍟 Added version chip

### DIFF
--- a/.changeset/famous-planes-sink.md
+++ b/.changeset/famous-planes-sink.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms': patch
+---
+
+Added version chip to Version Timeline

--- a/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
@@ -172,12 +172,9 @@ function WorkVersionTimelineInner({
     a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
   );
 
-  const versionsByCreatedAsc = [...versions].sort((a, b) =>
-    a.date_created < b.date_created ? -1 : a.date_created > b.date_created ? 1 : 0,
-  );
   const versionNumberByVersionId: Record<string, number> = {};
-  versionsByCreatedAsc.forEach((ver, i) => {
-    versionNumberByVersionId[ver.id] = i + 1;
+  versionsByCreated.forEach((ver, i) => {
+    versionNumberByVersionId[ver.id] = versionsByCreated.length - i;
   });
 
   // Show all versions; draft versions display only their activities (and submissions), not the "Version created" row
@@ -194,18 +191,10 @@ function WorkVersionTimelineInner({
         const activitiesForVersion = activities.filter((a) => a.work_version_id === v.id);
         const checkRunsForVersion = checkServiceRunsByWorkVersionId[v.id] ?? [];
         const versionNumber = versionNumberByVersionId[v.id] ?? 0;
+        const versionTag = `v${versionNumber}`;
         const label = (
           <span className="flex gap-2 items-center">
-            <ui.TooltipProvider delayDuration={1000}>
-              <ui.Tooltip delayDuration={1000}>
-                <ui.TooltipTrigger asChild>
-                  <span className="cursor-default">r{versionNumber}</span>
-                </ui.TooltipTrigger>
-                <ui.TooltipContent side="top" className="text-sm">
-                  Revision {versionNumber}
-                </ui.TooltipContent>
-              </ui.Tooltip>
-            </ui.TooltipProvider>
+            <ui.VersionTagBadge tag={versionTag} title={`Version ${versionNumber}`} />
             <span className="text-sm text-muted-foreground">
               {formatDate(v.date_created, 'MMM d, yyyy HH:mm')}
             </span>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only timeline labeling refactor with no auth, data, or API changes.
> 
> **Overview**
> The work **Version Timeline** on work details now shows a **`VersionTagBadge`** (`v{n}`) next to each section’s timestamp, matching the version chip pattern used elsewhere (e.g. checks).
> 
> Version labels change from **“r{n}”** with a “Revision” tooltip to **`v{n}`** with title **“Version {n}”**. Version numbering is computed from the same descending-by-`date_created` list (newest gets the highest number) without a separate ascending sort pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebfa34b0dcad0cc03af5a7f9cd0412ca26f6f613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->