### PR TITLE
🏷️ quickly add version tags to sub version table

### DIFF
--- a/.changeset/smart-timers-branch.md
+++ b/.changeset/smart-timers-branch.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-sites-ext': patch
+---
+
+Show submission version tags as badges on submission detail version rows.

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/db.server.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/db.server.ts
@@ -17,6 +17,7 @@ import type {
 const submissionDetailVersionSelect = {
   id: true,
   status: true,
+  tags: true,
   date_created: true,
   date_published: true,
   job_id: true,
@@ -42,6 +43,7 @@ export type SubmissionDetailRow = {
   versions: {
     id: string;
     status: string;
+    tags: string[];
     date_created: string;
     date_published: string | null;
     job_id: string | null;

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/detail.format.server.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/detail.format.server.ts
@@ -66,6 +66,7 @@ function formatDetailVersion(
     date_created: formatDate(version.date_created),
     date_published: version.date_published ?? undefined,
     status: version.status,
+    tags: [...version.tags],
     transition: version.transition == null ? undefined : (version.transition as WorkflowTransition),
     submitted_by: {
       id: version.submitted_by.id,

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/types.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/types.ts
@@ -36,6 +36,7 @@ export type SubmissionDetailVersion = {
   date_created: string;
   date_published?: string;
   status: string;
+  tags?: string[];
   transition?: WorkflowTransition;
   submitted_by: { id: string; name: string };
   site_work: SubmissionDetailSiteWork;

--- a/packages/scms-core/src/components/VersionsListing.tsx
+++ b/packages/scms-core/src/components/VersionsListing.tsx
@@ -7,6 +7,7 @@ import { useFetcher } from 'react-router';
 import { SubmissionActionsDropdown } from './SubmissionActionsDropdown.js';
 import { ExternalLink } from 'lucide-react';
 import { useDeploymentConfig } from '../providers/DeploymentProvider.js';
+import { VersionTagBadge } from './ui/VersionTagBadge.js';
 
 export function VersionsListing({
   workflow,
@@ -63,6 +64,13 @@ export function VersionsListing({
                     </span>
                     <ExternalLink className="inline-block w-4 h-4 align-middle ml-[2px] mb-[3px]" />
                   </div>
+                  {item.tags?.length ? (
+                    <div className="flex flex-wrap gap-1">
+                      {item.tags.map((tag) => (
+                        <VersionTagBadge key={tag} tag={tag} titlePrefix="Version tag" />
+                      ))}
+                    </div>
+                  ) : null}
                   <div className="text-sm text-gray-500 dark:text-gray-400 w-max">
                     <span
                       className="inline-block mr-2"

--- a/packages/scms-core/src/components/VersionsListing.tsx
+++ b/packages/scms-core/src/components/VersionsListing.tsx
@@ -58,19 +58,15 @@ export function VersionsListing({
                 title="open a preview of this version"
               >
                 <div className="space-y-2 grow">
-                  <div>
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    {item.tags?.map((tag) => (
+                      <VersionTagBadge key={tag} tag={tag} titlePrefix="Version tag" />
+                    ))}
                     <span className="font-medium group-hover:underline">
                       {formatDistance(new Date(item.date_created), new Date(), { addSuffix: true })}
                     </span>
                     <ExternalLink className="inline-block w-4 h-4 align-middle ml-[2px] mb-[3px]" />
                   </div>
-                  {item.tags?.length ? (
-                    <div className="flex flex-wrap gap-1">
-                      {item.tags.map((tag) => (
-                        <VersionTagBadge key={tag} tag={tag} titlePrefix="Version tag" />
-                      ))}
-                    </div>
-                  ) : null}
                   <div className="text-sm text-gray-500 dark:text-gray-400 w-max">
                     <span
                       className="inline-block mr-2"


### PR DESCRIPTION
<img width="1842" height="480" alt="image" src="https://github.com/user-attachments/assets/5356cead-c145-4983-879a-84af95026f3e" />

a very quick stopgap ahead of moving the full timeline

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI and additive API fields; no workflow, auth, or persistence changes.
> 
> **Overview**
> Submission detail version rows now surface **version tags** as badges next to the relative “created” time, using the existing `VersionTagBadge` component in `VersionsListing`.
> 
> The submission detail loader and formatter **plumb `tags`** from `SubmissionVersion` through `SubmissionDetailVersion` (Prisma select, row types, and `formatDetailVersion`) so the UI receives the same tag strings already stored on versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 824d5f6e5c7577fee0749032f7d0c7c7db3f0665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->