### PR TITLE
Fix local Pooler

### DIFF
--- a/.changeset/soft-pools-wait.md
+++ b/.changeset/soft-pools-wait.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-db': patch
+---
+
+Tune the Prisma PostgreSQL pool for Vercel function concurrency.

--- a/packages/scms-db/src/index.ts
+++ b/packages/scms-db/src/index.ts
@@ -66,13 +66,13 @@ function makeClient(connectionString?: string, dbCACertificate?: string): Prisma
     );
   }
 
-  // One connection per process — matches Supabase/PgBouncer transaction pooler limits on serverless.
+  // Small per-process pool for Vercel warm-instance concurrency; Supabase still handles backend pooling.
   const pool = new Pool({
     connectionString: dbUrl,
     ssl: dbCACertificate ? { ca: dbCACertificate } : undefined,
-    max: 1,
+    max: 5,
     idleTimeoutMillis: 20_000,
-    connectionTimeoutMillis: 10_000,
+    connectionTimeoutMillis: 30_000,
   });
 
   const adapter = new PrismaPg(pool);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default connection pooling for all serverless DB access; higher per-instance `max` can increase total connections under concurrent warm instances, though backend pooler limits still apply.
> 
> **Overview**
> **Raises the per-process `pg` pool limits** in `makeClient` so a single warm Vercel instance can run more than one DB operation at a time without serializing on a single connection.
> 
> `max` goes from **1 → 5**, and `connectionTimeoutMillis` from **10s → 30s**; the inline comment now describes this as a small per-process pool for Vercel concurrency while Supabase/PgBouncer still pools on the backend. A patch changeset records the `@curvenote/scms-db` release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9ed0f6a58de6aa1472eb5f9e290723ca686fc7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->