### PR TITLE
🏎️ works listing optimisation for search

### DIFF
--- a/.changeset/works-listing-dedicated-pool.md
+++ b/.changeset/works-listing-dedicated-pool.md
@@ -1,0 +1,18 @@
+---
+'@curvenote/scms-db': patch
+'@curvenote/scms-server': patch
+'@curvenote/scms': patch
+---
+
+Give the public works listing/search endpoint (`/api/v1/sites/:siteName/works`)
+its own dedicated database connection pool so its heavy listing/search/count
+queries draw from a separate connection budget and cannot exhaust the shared
+app-wide pool (and vice versa). `scms-db` now exposes
+`getNamedLowLevelPrismaClient(name, …)` for per-name isolated clients/pools, and
+`scms-server` adds `getWorksListingPrismaClient()` which uses the same database
+and identical per-pool tuning as the default client. The whole endpoint path,
+including the shared subject lookups, is routed through the dedicated pool.
+
+Note: each named pool adds up to its own `max` connections to the backend, so
+the total connection budget is now the sum across pools — size accordingly
+against the database / pooler limits.

--- a/.changeset/works-search-projection.md
+++ b/.changeset/works-search-projection.md
@@ -12,6 +12,14 @@ match runs only within a single site. Trigger-maintained from
 path; set `WORKS_SEARCH_PROJECTION_DISABLED=true` as a kill-switch to fall back
 to the legacy ILIKE path instantly without a redeploy.
 
+The rollout is split across three migrations so each step holds only a short
+lock: DDL (`…120000`), a separate idempotent backfill of existing rows
+(`…120050`), then the `CONCURRENTLY` GIN/btree indexes (`…120100`). If the
+backfill migration times out it can be completed manually via psql using the
+resumable, batched `prisma/scripts/backfill-submission-search.sql`, after which
+`prisma migrate resolve --applied …120050` lets the deploy continue to the
+indexes.
+
 The listing total now avoids the `Submission`/`SubmissionVersion` join count
 where possible: when search/subject already resolves an id set (and no
 collection/kind/date filter applies) the count is the id-set size, and an

--- a/.changeset/works-search-projection.md
+++ b/.changeset/works-search-projection.md
@@ -1,0 +1,12 @@
+---
+'@curvenote/scms-db': patch
+'@curvenote/scms': patch
+---
+
+Add a site/status-scoped `SubmissionSearch` projection for the public works
+listing free-text search. Searchable text (title, authors, DOIs, affiliations)
+is `unaccent`-normalised and matched with Postgres full-text search plus a
+pg_trgm fuzzy fallback, scoped by `site_id`/`status` first so the expensive
+match runs only within a single site. Trigger-maintained from
+`SubmissionVersion`/`WorkVersion`/`Work`. Opt-in behind `WORKS_SEARCH_PROJECTION`
+(default off, legacy ILIKE path unchanged) for benchmark-gated rollout.

--- a/.changeset/works-search-projection.md
+++ b/.changeset/works-search-projection.md
@@ -4,9 +4,17 @@
 ---
 
 Add a site/status-scoped `SubmissionSearch` projection for the public works
-listing free-text search. Searchable text (title, authors, DOIs, affiliations)
+listing free-text search. Searchable text (title, authors, DOI, affiliations)
 is `unaccent`-normalised and matched with Postgres full-text search plus a
 pg_trgm fuzzy fallback, scoped by `site_id`/`status` first so the expensive
 match runs only within a single site. Trigger-maintained from
-`SubmissionVersion`/`WorkVersion`/`Work`. Opt-in behind `WORKS_SEARCH_PROJECTION`
-(default off, legacy ILIKE path unchanged) for benchmark-gated rollout.
+`SubmissionVersion`/`WorkVersion`/`Work`. The projection is the default search
+path; set `WORKS_SEARCH_PROJECTION_DISABLED=true` as a kill-switch to fall back
+to the legacy ILIKE path instantly without a redeploy.
+
+The listing total now avoids the `Submission`/`SubmissionVersion` join count
+where possible: when search/subject already resolves an id set (and no
+collection/kind/date filter applies) the count is the id-set size, and an
+unfiltered browse count is served directly from the projection
+(`COUNT(DISTINCT submission_id)` via a new `(site_id, status, submission_id)`
+btree).

--- a/packages/scms-db/src/index.ts
+++ b/packages/scms-db/src/index.ts
@@ -17,11 +17,16 @@ import { PrismaClient } from './generated/client.js';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Pool } from 'pg';
 
-// Type-safe global cache (dev hot-reload & serverless runtime reuse)
+// Type-safe global cache (dev hot-reload & serverless runtime reuse). Keyed by
+// pool name so the process can hold more than one isolated client/pool (e.g. a
+// dedicated pool for a hot endpoint, see `getNamedLowLevelPrismaClient`).
 const g = globalThis as unknown as {
-  __prisma?: PrismaClient;
-  __prismaInit?: Promise<PrismaClient>;
+  __prismaClients?: Map<string, PrismaClient>;
+  __prismaInits?: Map<string, Promise<PrismaClient>>;
 };
+
+/** Cache key for the shared, app-wide default client/pool. */
+const DEFAULT_CLIENT_NAME = 'default';
 
 function isPrismaQueryDebugEnabled(): boolean {
   if (process.env.NODE_ENV === 'production') return false;
@@ -129,10 +134,43 @@ export async function getLowLevelPrismaClient(
   connectionString?: string,
   dbCACertificate?: string,
 ): Promise<PrismaClient> {
-  if (g.__prisma) return g.__prisma;
-  if (g.__prismaInit) return g.__prismaInit;
+  return getNamedLowLevelPrismaClient(DEFAULT_CLIENT_NAME, connectionString, dbCACertificate);
+}
 
-  g.__prismaInit = (async () => {
+/**
+ * Gets or creates a NAMED singleton PrismaClient instance, each backed by its
+ * own `pg.Pool`.
+ *
+ * Distinct names yield distinct clients/pools that do not share connections, so
+ * a heavy endpoint can be given a dedicated pool that cannot starve the shared
+ * `default` pool (and vice versa). Same name returns the same cached instance.
+ *
+ * All names built from the same `connectionString` talk to the same database
+ * with the same per-pool tuning (see `makeClient`); isolation is at the pool
+ * (connection-budget) level only. NOTE: each named pool adds up to its own `max`
+ * connections to the backend, so the total connection budget is the sum across
+ * names — size accordingly against the database / pooler limits.
+ *
+ * @param name - Cache key identifying the pool (e.g. `'default'`, `'works-listing'`).
+ * @param connectionString - Optional database connection string. Only used on
+ *                           the first call for a given `name`.
+ * @param dbCACertificate - Optional CA certificate. Only used on the first call
+ *                          for a given `name`.
+ */
+export async function getNamedLowLevelPrismaClient(
+  name: string,
+  connectionString?: string,
+  dbCACertificate?: string,
+): Promise<PrismaClient> {
+  const clients = (g.__prismaClients ??= new Map());
+  const inits = (g.__prismaInits ??= new Map());
+
+  const existing = clients.get(name);
+  if (existing) return existing;
+  const pending = inits.get(name);
+  if (pending) return pending;
+
+  const init = (async () => {
     try {
       const client = makeClient(connectionString, dbCACertificate);
 
@@ -141,16 +179,17 @@ export async function getLowLevelPrismaClient(
         await client.$connect();
       }
 
-      g.__prisma = client;
+      clients.set(name, client);
       return client;
     } catch (error) {
       // Clear the cached promise on failure to allow retries
-      g.__prismaInit = undefined;
+      inits.delete(name);
       throw error;
     }
   })();
 
-  return g.__prismaInit;
+  inits.set(name, init);
+  return init;
 }
 
 // Re-export types and the Prisma namespace from the generated client for server-side usage

--- a/packages/scms-server/src/backend/prisma.server.ts
+++ b/packages/scms-server/src/backend/prisma.server.ts
@@ -1,9 +1,12 @@
 // lib/prisma.server.ts
 // Re-export from @curvenote/scms-db for backward compatibility
 // This allows existing code to continue using getPrismaClient from this location
-import { getLowLevelPrismaClient } from '@curvenote/scms-db';
+import { getLowLevelPrismaClient, getNamedLowLevelPrismaClient } from '@curvenote/scms-db';
 import { getConfig } from '../app-config.server.js';
 import type { PrismaClient } from '@curvenote/scms-db';
+
+/** Cache key for the dedicated public works-listing pool (see {@link getWorksListingPrismaClient}). */
+const WORKS_LISTING_CLIENT_NAME = 'works-listing';
 
 /**
  * Gets the PrismaClient instance, using the database URL from app config.
@@ -19,4 +22,23 @@ import type { PrismaClient } from '@curvenote/scms-db';
 export async function getPrismaClient(): Promise<PrismaClient> {
   const config = await getConfig();
   return getLowLevelPrismaClient(config.api.databaseUrl, config.api.databaseCACertificate);
+}
+
+/**
+ * Gets a PrismaClient backed by a DEDICATED connection pool for the public works
+ * listing/search endpoint (`/api/v1/sites/:siteName/works`).
+ *
+ * Same database, same per-pool tuning as {@link getPrismaClient} (it resolves
+ * the same config), but a separate `pg.Pool` so this endpoint's heavy
+ * listing/search/count queries draw from their own connection budget and cannot
+ * exhaust the shared `default` pool that serves the rest of the app (and vice
+ * versa). See `getNamedLowLevelPrismaClient` for the connection-budget caveat.
+ */
+export async function getWorksListingPrismaClient(): Promise<PrismaClient> {
+  const config = await getConfig();
+  return getNamedLowLevelPrismaClient(
+    WORKS_LISTING_CLIENT_NAME,
+    config.api.databaseUrl,
+    config.api.databaseCACertificate,
+  );
 }

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
@@ -150,14 +150,15 @@ function buildListingWhere(
  * Whether the works search resolves ids via the `SubmissionSearch` projection
  * or the legacy global UNION/ILIKE path.
  *
- * Defaults OFF so the code ships dormant: existing behaviour is unchanged until
- * `WORKS_SEARCH_PROJECTION` is set to `true` / `1` / `on` in a target
- * environment. This is the rollout/benchmark control - enable it in staging to
- * run the benchmark gate, then in production once the in-DB ceiling is proven.
+ * Defaults ON: the projection is the shipped, tested, production path. The
+ * `WORKS_SEARCH_PROJECTION_DISABLED` env var is a kill-switch - set it to
+ * `true` / `1` / `on` to fall back to the legacy UNION/ILIKE search instantly
+ * (no redeploy) if the projection path misbehaves in a given environment.
  */
 function useSearchProjection(): boolean {
-  const flag = process.env.WORKS_SEARCH_PROJECTION?.toLowerCase();
-  return flag === 'true' || flag === '1' || flag === 'on';
+  const flag = process.env.WORKS_SEARCH_PROJECTION_DISABLED?.toLowerCase();
+  const disabled = flag === 'true' || flag === '1' || flag === 'on';
+  return !disabled;
 }
 
 /**
@@ -301,6 +302,40 @@ async function dbCountSubmissions(
 }
 
 /**
+ * Count listed submissions for a site/status directly from the
+ * `SubmissionSearch` projection.
+ *
+ * The projection holds one row per listed (PUBLISHED / IN_REVIEW) submission
+ * version with `(site_id, status, submission_id)` co-located, so
+ * `COUNT(DISTINCT submission_id)` over the narrow, pre-scoped table (served by
+ * the `SubmissionSearch_site_status_submission_idx` btree) equals the
+ * `COUNT(DISTINCT s.id)` that {@link dbCountSubmissions} computes over the
+ * `Submission` ⋈ `SubmissionVersion` join — without the join or the heap reads.
+ *
+ * Only valid for the unfiltered browse count (no collection / kind / date /
+ * search filters, which the projection does not carry) and only when the
+ * projection is the active search source ({@link useSearchProjection}).
+ */
+async function dbCountListedFromProjection(
+  siteId: string,
+  status: string,
+  tx?: Prisma.TransactionClient,
+  signal?: AbortSignal,
+): Promise<number> {
+  throwIfAborted(signal);
+  const prisma = await getPrismaClient();
+  throwIfAborted(signal);
+  const [{ count }] = await (tx ?? prisma).$queryRaw<[{ count: bigint }]>`
+    SELECT COUNT(DISTINCT submission_id) AS count
+    FROM "SubmissionSearch"
+    WHERE site_id = ${siteId}
+      AND status = ${status}
+  `;
+  throwIfAborted(signal);
+  return Number(count);
+}
+
+/**
  * List submissions (the latest version in the requested status per submission),
  * ordered by publication date.
  *
@@ -427,6 +462,32 @@ export async function dbListLatestPublishedSubmissions(
 
   if (isOffsetPaginationRequested(opts ?? {})) {
     throwIfAborted(signal);
+    // Pick the cheapest correct count strategy and run it alongside the page
+    // query (collection / kind / date are the only filters not already encoded
+    // in `filteredIds` or the projection, so their presence forces the join
+    // count):
+    //  1. result set already fully resolved (search / subject, no other filter)
+    //     -> the id-set size is the count, no DB round-trip.
+    //  2. unfiltered browse with the projection active -> count the narrow
+    //     `SubmissionSearch` table instead of the Submission/version join.
+    //  3. otherwise -> the join count with the same filters as the page query.
+    const hasJoinOnlyFilter = Boolean(where?.collection || where?.kind || where?.from || where?.to);
+    let countPromise: Promise<number>;
+    if (filteredIds != null && !hasJoinOnlyFilter) {
+      countPromise = Promise.resolve(filteredIds.length);
+    } else if (filteredIds == null && !hasJoinOnlyFilter && useSearchProjection()) {
+      countPromise = dbCountListedFromProjection(ctx.site.id, status, undefined, signal);
+    } else {
+      countPromise = dbCountSubmissions(
+        ctx.site.id,
+        collectionName,
+        status,
+        where?.kind,
+        extras,
+        undefined,
+        signal,
+      );
+    }
     const [items, total] = await Promise.all([
       dbQuerySubmissions(
         ctx.site.id,
@@ -437,15 +498,7 @@ export async function dbListLatestPublishedSubmissions(
         undefined,
         signal,
       ),
-      dbCountSubmissions(
-        ctx.site.id,
-        collectionName,
-        status,
-        where?.kind,
-        extras,
-        undefined,
-        signal,
-      ),
+      countPromise,
     ]);
     throwIfAborted(signal);
     return { items, total };

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
@@ -147,22 +147,38 @@ function buildListingWhere(
 }
 
 /**
- * Resolve submission ids matching a free-text `q` by ILIKE-substring across
- * work-version title / authors / DOI, work-level DOI, and (when
- * {@link isAffiliationSearchEnabled} allows) affiliation names in metadata.
+ * Whether the works search resolves ids via the `SubmissionSearch` projection
+ * or the legacy global UNION/ILIKE path.
  *
- * Roots at `WorkVersion` via a UNION of single-predicate branches so each arm
- * can use its pg_trgm GIN index (`20260526223800`,
- * `20260610120000_add_work_version_affiliations_trgm_index`), then joins back
- * through `SubmissionVersion` to `Submission` scoped by `site_id`. Only
- * submission versions in the listing's requested `status` are considered (same
- * as {@link fetchSubmissionIdsBySubject} and {@link buildListingWhere}), which
- * avoids join fan-out on draft/unpublished history and keeps search aligned with
- * the version shown in results.
+ * Defaults OFF so the code ships dormant: existing behaviour is unchanged until
+ * `WORKS_SEARCH_PROJECTION` is set to `true` / `1` / `on` in a target
+ * environment. This is the rollout/benchmark control - enable it in staging to
+ * run the benchmark gate, then in production once the in-DB ceiling is proven.
+ */
+function useSearchProjection(): boolean {
+  const flag = process.env.WORKS_SEARCH_PROJECTION?.toLowerCase();
+  return flag === 'true' || flag === '1' || flag === 'on';
+}
+
+/**
+ * Resolve submission ids matching a free-text `q`.
  *
- * `immutable_array_to_string(authors, ' ')` and
- * `work_version_affiliations_search_text(metadata)` MUST match their expression
- * indexes exactly for the planner to use them.
+ * Default path queries the `SubmissionSearch` projection (migration
+ * `20260625120000`), which co-locates `site_id` + `status` + `submission_id`
+ * with `unaccent`-normalised searchable text. The scoped filter is applied
+ * first, then matching is full-text (`@@`, token / word-gap correct, handles
+ * "alice schmeul" -> "alice n. schmeul") OR pg_trgm word_similarity (`<%`, typo
+ * tolerance). The query term is normalised with the same `immutable_unaccent`
+ * wrapper used to build the stored columns so accents match symmetrically.
+ *
+ * Legacy path (behind {@link useSearchProjection}) roots at `WorkVersion` via a
+ * UNION of single-predicate ILIKE branches, each using its pg_trgm GIN index
+ * (`20260526223800`, `20260610120000`), then joins back through
+ * `SubmissionVersion` to `Submission` scoped by `site_id`.
+ *
+ * Either way only submission versions in the requested `status` are considered
+ * (same as {@link fetchSubmissionIdsBySubject} and {@link buildListingWhere}),
+ * keeping search aligned with the version shown in results.
  */
 async function dbSearchSubmissionIds(
   siteId: string,
@@ -174,6 +190,22 @@ async function dbSearchSubmissionIds(
   throwIfAborted(signal);
   const prisma = await getPrismaClient();
   throwIfAborted(signal);
+
+  if (useSearchProjection()) {
+    const rows = await (tx ?? prisma).$queryRaw<{ submission_id: string }[]>`
+      SELECT DISTINCT submission_id
+      FROM "SubmissionSearch"
+      WHERE site_id = ${siteId}
+        AND status = ${status}
+        AND (
+          search_tsv @@ websearch_to_tsquery('simple', immutable_unaccent(${q}))
+          OR immutable_unaccent(${q}) <% search_text
+        )
+    `;
+    throwIfAborted(signal);
+    return rows.map((r) => r.submission_id);
+  }
+
   const pattern = `%${escapeIlikePattern(q)}%`;
   const matchingWorkVersionBranches: Prisma.Sql[] = [
     Prisma.sql`SELECT wv.id FROM "WorkVersion" wv WHERE wv.title ILIKE ${pattern}`,

--- a/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
+++ b/platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts
@@ -1,5 +1,5 @@
 import {
-  getPrismaClient,
+  getWorksListingPrismaClient,
   fetchWorkVersionSubjects,
   fetchSubmissionIdsBySubject,
   isAffiliationSearchEnabled,
@@ -189,7 +189,7 @@ async function dbSearchSubmissionIds(
   signal?: AbortSignal,
 ): Promise<string[]> {
   throwIfAborted(signal);
-  const prisma = await getPrismaClient();
+  const prisma = await getWorksListingPrismaClient();
   throwIfAborted(signal);
 
   if (useSearchProjection()) {
@@ -260,7 +260,7 @@ async function dbCountSubmissions(
   signal?: AbortSignal,
 ): Promise<number> {
   throwIfAborted(signal);
-  const prisma = await getPrismaClient();
+  const prisma = await getWorksListingPrismaClient();
   throwIfAborted(signal);
   const joins: Prisma.Sql[] = [
     Prisma.sql`
@@ -323,7 +323,7 @@ async function dbCountListedFromProjection(
   signal?: AbortSignal,
 ): Promise<number> {
   throwIfAborted(signal);
-  const prisma = await getPrismaClient();
+  const prisma = await getWorksListingPrismaClient();
   throwIfAborted(signal);
   const [{ count }] = await (tx ?? prisma).$queryRaw<[{ count: bigint }]>`
     SELECT COUNT(DISTINCT submission_id) AS count
@@ -359,7 +359,7 @@ async function dbQuerySubmissions(
   const skip = opts?.limit ? (opts?.page ?? 0) * opts?.limit : undefined;
   const take = opts?.limit;
   const { submissionInnerSelect, submissionVersionSelect } = getListingSelects();
-  const prisma = await getPrismaClient();
+  const prisma = await getWorksListingPrismaClient();
   throwIfAborted(signal);
   const submissions = await (tx ?? prisma).submission.findMany({
     skip,
@@ -422,7 +422,10 @@ export async function dbListLatestPublishedSubmissions(
   throwIfAborted(signal);
   let subjectIds: string[] | undefined;
   if (where?.subject) {
-    subjectIds = await fetchSubmissionIdsBySubject(ctx.site.id, where.subject, status);
+    // Route the shared subject lookup through this endpoint's dedicated pool too,
+    // so the whole request path stays isolated from the default pool.
+    const worksClient = await getWorksListingPrismaClient();
+    subjectIds = await fetchSubmissionIdsBySubject(ctx.site.id, where.subject, status, worksClient);
   }
   throwIfAborted(signal);
   const filteredIds = intersectSubmissionIds(searchIds, subjectIds);
@@ -438,7 +441,7 @@ export async function dbListLatestPublishedSubmissions(
     // when filtering on collection, we need to first check if the workflow
     // on the collection is visible for the state[status] being queried
     throwIfAborted(signal);
-    const prisma = await getPrismaClient();
+    const prisma = await getWorksListingPrismaClient();
     throwIfAborted(signal);
     const collection = await prisma.collection.findFirst({
       where: {
@@ -550,7 +553,11 @@ export async function listPublishedWorks(
   throwIfAborted(signal);
   if (!dbo) throw error404();
   throwIfAborted(signal);
-  const subjects = await fetchWorkVersionSubjects(dbo.items.map((row) => row.work_version.id));
+  const worksClient = await getWorksListingPrismaClient();
+  const subjects = await fetchWorkVersionSubjects(
+    dbo.items.map((row) => row.work_version.id),
+    worksClient,
+  );
   throwIfAborted(signal);
   return formatSiteWorkDTOFromSubmissions(ctx, dbo, where, { ...opts, subjects });
 }

--- a/platform/scms/package.template.json
+++ b/platform/scms/package.template.json
@@ -25,7 +25,7 @@
     "dev:db:reset": "npx prisma migrate reset --config=../../prisma.config.ts; npm run dev:db:seed",
     "dev:db:seed": "tsx ../../prisma/seed.mts",
     "dev:db:migrate": "npx prisma migrate dev --config=../../prisma.config.ts",
-    "test:db:reset": "dotenv -e .env.test -- npx prisma db push --force-reset --config=../../prisma.config.ts; dotenv -e .env.test -- tsx ../../prisma/seed.test.mts",
+    "test:db:reset": "dotenv -e .env.test -- npx prisma migrate reset --force --config=../../prisma.test.config.ts",
     "config": "cd ../.. && npm run config",
     "compile": "NODE_ENV=development react-router typegen; tsc --noEmit",
     "optimize": "vite optimize",

--- a/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
@@ -315,15 +315,33 @@ describe('site works listing — delivered package (limit=10)', () => {
   });
 });
 
-describe('site works listing — search / sort / date filters', () => {
+/**
+ * Legacy UNION/ILIKE search path, pinned on via the
+ * `WORKS_SEARCH_PROJECTION_DISABLED` kill-switch.
+ *
+ * The projection is the default search path (see the block below); this guards
+ * the fallback that the kill-switch restores. These cases rely on exact
+ * substring semantics over a set of near-identical seeds (`Benchmark work NN`,
+ * `Author NA`), which the projection's fuzzy trigram clause would broaden, so
+ * they belong to the legacy path. The non-search `sort` / `date` / `subject`
+ * filters here are path-independent and exercised under the fallback too.
+ */
+describe('site works listing — legacy search (kill-switch) / sort / date filters', () => {
   let testData: TestData;
   let seeds: SeedWork[];
+  const PRIOR_FLAG = process.env.WORKS_SEARCH_PROJECTION_DISABLED;
 
   beforeEach(async () => {
+    process.env.WORKS_SEARCH_PROJECTION_DISABLED = 'true';
     testData = await createTestData('ADMIN' as SiteRole);
     await attachDefaultDomain(testData);
     seeds = await seedPublishedWorks(testData, TOTAL_PUBLISHED);
     await seedDraftWorks(testData, 2);
+  });
+
+  afterAll(() => {
+    if (PRIOR_FLAG === undefined) delete process.env.WORKS_SEARCH_PROJECTION_DISABLED;
+    else process.env.WORKS_SEARCH_PROJECTION_DISABLED = PRIOR_FLAG;
   });
 
   test('q matches a title substring', async () => {
@@ -610,31 +628,39 @@ describe('site works listing — search / sort / date filters', () => {
 });
 
 /**
- * Search via the `SubmissionSearch` projection (model A: full-text + pg_trgm
- * fuzzy, unaccent-normalised), enabled with `WORKS_SEARCH_PROJECTION=true`.
+ * Search via the `SubmissionSearch` projection (full-text + pg_trgm fuzzy,
+ * unaccent-normalised) — the default search path.
  *
- * These assert the wins the projection is built for over the legacy ILIKE path:
+ * The kill-switch (`WORKS_SEARCH_PROJECTION_DISABLED`) is explicitly cleared so
+ * this block always runs the default path regardless of test ordering. These
+ * assert the wins the projection is built for over the legacy ILIKE path:
  * token/word-gap recall (middle initials), diacritic-insensitive matching, and
  * the same site/status scoping. The projection rows are maintained by the DB
  * triggers from migration `20260625120000`, so plain Prisma seeds populate it.
  */
-describe('site works listing — search via projection', () => {
+describe('site works listing — search via projection (default)', () => {
   let testData: TestData;
-  const PRIOR_FLAG = process.env.WORKS_SEARCH_PROJECTION;
+  const PRIOR_FLAG = process.env.WORKS_SEARCH_PROJECTION_DISABLED;
 
   beforeEach(async () => {
-    process.env.WORKS_SEARCH_PROJECTION = 'true';
+    delete process.env.WORKS_SEARCH_PROJECTION_DISABLED;
     testData = await createTestData('ADMIN' as SiteRole);
   });
 
   afterAll(() => {
-    if (PRIOR_FLAG === undefined) delete process.env.WORKS_SEARCH_PROJECTION;
-    else process.env.WORKS_SEARCH_PROJECTION = PRIOR_FLAG;
+    if (PRIOR_FLAG === undefined) delete process.env.WORKS_SEARCH_PROJECTION_DISABLED;
+    else process.env.WORKS_SEARCH_PROJECTION_DISABLED = PRIOR_FLAG;
   });
 
   async function seedSearchWork(
     data: TestData,
-    opts: { title: string; authors: string[]; status?: string },
+    opts: {
+      title: string;
+      authors: string[];
+      status?: string;
+      doi?: string;
+      affiliations?: string[];
+    },
   ): Promise<{ workId: string }> {
     const prisma = await getPrismaClient();
     const now = new Date().toISOString();
@@ -646,6 +672,7 @@ describe('site works listing — search via projection', () => {
         id: workId,
         date_created: now,
         date_modified: now,
+        doi: opts.doi,
         created_by: { connect: { id: data.userId } },
       },
     });
@@ -656,6 +683,14 @@ describe('site works listing — search via projection', () => {
         date_modified: now,
         title: opts.title,
         authors: opts.authors,
+        doi: opts.doi,
+        metadata: opts.affiliations
+          ? {
+              'frontmatter.myst': {
+                affiliations: opts.affiliations.map((name, i) => ({ id: `a${i}`, name })),
+              },
+            }
+          : undefined,
         work: { connect: { id: workId } },
       },
     });
@@ -756,6 +791,42 @@ describe('site works listing — search via projection', () => {
     expect(dto.items).toHaveLength(0);
   });
 
+  test('matches a DOI token', async () => {
+    const { workId } = await seedSearchWork(testData, {
+      title: 'Paper with a doi',
+      authors: ['Frank Castle'],
+      doi: '10.5555/projection-doi-xyz',
+    });
+    await seedSearchWork(testData, { title: 'No doi here', authors: ['Jean Grey'] });
+
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'projection-doi-xyz' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(1);
+    expect(dto.items[0].id).toBe(workId);
+  });
+
+  test('matches an affiliation name from work version metadata', async () => {
+    const { workId } = await seedSearchWork(testData, {
+      title: 'Affiliated work',
+      authors: ['Ororo Munroe'],
+      affiliations: ['Xavier Institute for Higher Learning'],
+    });
+    await seedSearchWork(testData, { title: 'Unaffiliated', authors: ['Logan Howlett'] });
+
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'Xavier Institute' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(1);
+    expect(dto.items[0].id).toBe(workId);
+  });
+
   test('returns empty for a non-matching query', async () => {
     await seedSearchWork(testData, { title: 'Something', authors: ['Someone'] });
     const dto = await listPublishedWorks(
@@ -765,6 +836,22 @@ describe('site works listing — search via projection', () => {
       { page: 0, limit: 500 },
     );
     expect(dto.total).toBe(0);
+  });
+
+  test('unfiltered browse total counts listed submissions via the projection', async () => {
+    await seedSearchWork(testData, { title: 'Listed one', authors: ['Aa Bb'] });
+    await seedSearchWork(testData, { title: 'Listed two', authors: ['Cc Dd'] });
+    await seedSearchWork(testData, { title: 'Listed three', authors: ['Ee Ff'] });
+    // A draft-only submission must not be counted.
+    await seedSearchWork(testData, {
+      title: 'Draft only',
+      authors: ['Gg Hh'],
+      status: 'DRAFT',
+    });
+
+    const dto = await listPublishedWorks(testData.context, [], {}, { page: 0, limit: 10 });
+    expect(dto.total).toBe(3);
+    expect(dto.items).toHaveLength(3);
   });
 });
 

--- a/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
+++ b/platform/scms/tests/integration/workflow/site-works-listing.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { describe, test, expect, beforeEach } from 'vitest';
+import { describe, test, expect, beforeEach, afterAll } from 'vitest';
 import type { SiteRole } from '@curvenote/scms-db';
 import { getPrismaClient } from '@curvenote/scms-server';
 import { concatSiteWorkTags } from '@curvenote/common';
@@ -606,6 +606,165 @@ describe('site works listing — search / sort / date filters', () => {
     await expect(
       listPublishedWorks(testData.context, [], { to: '2024-13-45' }, { page: 0, limit: 500 }),
     ).rejects.toThrow();
+  });
+});
+
+/**
+ * Search via the `SubmissionSearch` projection (model A: full-text + pg_trgm
+ * fuzzy, unaccent-normalised), enabled with `WORKS_SEARCH_PROJECTION=true`.
+ *
+ * These assert the wins the projection is built for over the legacy ILIKE path:
+ * token/word-gap recall (middle initials), diacritic-insensitive matching, and
+ * the same site/status scoping. The projection rows are maintained by the DB
+ * triggers from migration `20260625120000`, so plain Prisma seeds populate it.
+ */
+describe('site works listing — search via projection', () => {
+  let testData: TestData;
+  const PRIOR_FLAG = process.env.WORKS_SEARCH_PROJECTION;
+
+  beforeEach(async () => {
+    process.env.WORKS_SEARCH_PROJECTION = 'true';
+    testData = await createTestData('ADMIN' as SiteRole);
+  });
+
+  afterAll(() => {
+    if (PRIOR_FLAG === undefined) delete process.env.WORKS_SEARCH_PROJECTION;
+    else process.env.WORKS_SEARCH_PROJECTION = PRIOR_FLAG;
+  });
+
+  async function seedSearchWork(
+    data: TestData,
+    opts: { title: string; authors: string[]; status?: string },
+  ): Promise<{ workId: string }> {
+    const prisma = await getPrismaClient();
+    const now = new Date().toISOString();
+    const workId = uuidv7();
+    const workVersionId = uuidv7();
+    const submissionId = uuidv7();
+    await prisma.work.create({
+      data: {
+        id: workId,
+        date_created: now,
+        date_modified: now,
+        created_by: { connect: { id: data.userId } },
+      },
+    });
+    await prisma.workVersion.create({
+      data: {
+        id: workVersionId,
+        date_created: now,
+        date_modified: now,
+        title: opts.title,
+        authors: opts.authors,
+        work: { connect: { id: workId } },
+      },
+    });
+    await prisma.submission.create({
+      data: {
+        id: submissionId,
+        date_created: now,
+        date_modified: now,
+        date_published: '2024-02-01',
+        site: { connect: { id: data.siteId } },
+        work: { connect: { id: workId } },
+        kind: { connect: { id: data.kindId } },
+        collection: { connect: { id: data.collectionId } },
+        submitted_by: { connect: { id: data.userId } },
+      },
+    });
+    await prisma.submissionVersion.create({
+      data: {
+        id: uuidv7(),
+        date_created: now,
+        date_modified: now,
+        date_published: '2024-02-01',
+        status: opts.status ?? 'PUBLISHED',
+        submission: { connect: { id: submissionId } },
+        work_version: { connect: { id: workVersionId } },
+        submitted_by: { connect: { id: data.userId } },
+      },
+    });
+    return { workId };
+  }
+
+  test('matches across a middle-initial gap ("alice schmeul" -> "Alice N. Schmeul")', async () => {
+    const { workId } = await seedSearchWork(testData, {
+      title: 'A study of things',
+      authors: ['Alice N. Schmeul', 'Bob Jones'],
+    });
+    await seedSearchWork(testData, {
+      title: 'An unrelated paper',
+      authors: ['Carol Danvers'],
+    });
+
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'alice schmeul' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(1);
+    expect(dto.items[0].id).toBe(workId);
+  });
+
+  test('matches diacritics insensitively ("jose muller" -> "José Müller")', async () => {
+    const { workId } = await seedSearchWork(testData, {
+      title: 'Accented authors',
+      authors: ['José Müller'],
+    });
+
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'jose muller' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(1);
+    expect(dto.items[0].id).toBe(workId);
+  });
+
+  test('matches a title token', async () => {
+    const { workId } = await seedSearchWork(testData, {
+      title: 'Quantum entanglement in birds',
+      authors: ['Dana Scully'],
+    });
+
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'entanglement' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(1);
+    expect(dto.items[0].id).toBe(workId);
+  });
+
+  test('a published listing ignores draft-only versions in the projection', async () => {
+    await seedSearchWork(testData, {
+      title: 'Hidden draft work zzz-unique',
+      authors: ['Erik Lehnsherr'],
+      status: 'DRAFT',
+    });
+
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'zzz-unique' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(0);
+    expect(dto.items).toHaveLength(0);
+  });
+
+  test('returns empty for a non-matching query', async () => {
+    await seedSearchWork(testData, { title: 'Something', authors: ['Someone'] });
+    const dto = await listPublishedWorks(
+      testData.context,
+      [],
+      { q: 'no-such-term-qqq' },
+      { page: 0, limit: 500 },
+    );
+    expect(dto.total).toBe(0);
   });
 });
 

--- a/prisma/schema/migrations/20260625120000_add_submission_search_projection/migration.sql
+++ b/prisma/schema/migrations/20260625120000_add_submission_search_projection/migration.sql
@@ -19,10 +19,21 @@
 -- `unaccent`-normalised so accented and unaccented spellings match symmetrically
 -- (e.g. "muller" <-> "Müller").
 --
--- The compound GIN indexes (needing `btree_gin` for the scalar leading keys and
--- `gin_trgm_ops` for fuzzy text) are created CONCURRENTLY in the follow-on
--- migration `20260625120100_add_submission_search_indexes` so the large index
--- builds do not hold a long lock inside this migration's transaction.
+-- This migration installs DDL ONLY (extensions, helper functions, the
+-- `SubmissionSearch` table and its maintenance triggers). It is intentionally
+-- atomic and fast so it can be rolled back cleanly. The one-time backfill of
+-- existing rows lives in the follow-on migration
+-- `20260625120050_backfill_submission_search`, and the compound GIN indexes
+-- (needing `btree_gin` for the scalar leading keys and `gin_trgm_ops` for fuzzy
+-- text) are created CONCURRENTLY in `20260625120100_add_submission_search_indexes`
+-- so neither the large backfill nor the large index builds hold a long lock
+-- inside this migration's transaction.
+--
+-- Ordering rationale (DDL -> backfill -> indexes): backfilling before the GIN
+-- indexes exist means the bulk insert does not pay per-row index maintenance,
+-- and if the backfill times out the operator completes it on an unindexed table
+-- (see the runbook in the backfill migration) before the indexes are built once
+-- over the full table.
 
 SET statement_timeout = 0;
 
@@ -193,33 +204,6 @@ AFTER UPDATE OF doi ON "Work"
 FOR EACH ROW WHEN (OLD.doi IS DISTINCT FROM NEW.doi)
 EXECUTE FUNCTION submission_search_tg_work();
 
--- Backfill existing listed submission versions. statement_timeout is disabled
--- above; on very large tables run this in id-ranged batches instead if it risks
--- a long lock.
-INSERT INTO "SubmissionSearch" (
-  submission_version_id, submission_id, site_id, status, search_text, search_tsv
-)
-SELECT
-  sv.id,
-  sv.submission_id,
-  s.site_id,
-  sv.status,
-  txt.search_text,
-  to_tsvector('simple', txt.search_text)
-FROM "SubmissionVersion" sv
-JOIN "Submission" s ON s.id = sv.submission_id
-JOIN "WorkVersion" wv ON wv.id = sv.work_version_id
-JOIN "Work" w ON w.id = wv.work_id
-CROSS JOIN LATERAL (
-  SELECT immutable_unaccent(
-    concat_ws(
-      ' ',
-      wv.title,
-      immutable_array_to_string(wv.authors, ' '),
-      COALESCE(wv.doi, w.doi),
-      work_version_affiliations_search_text(wv.metadata)
-    )
-  ) AS search_text
-) txt
-WHERE sv.status IN ('PUBLISHED', 'IN_REVIEW')
-ON CONFLICT (submission_version_id) DO NOTHING;
+-- Backfill of existing rows is performed in the follow-on migration
+-- `20260625120050_backfill_submission_search` (kept separate so a slow backfill
+-- can be completed manually via psql without re-running this DDL).

--- a/prisma/schema/migrations/20260625120000_add_submission_search_projection/migration.sql
+++ b/prisma/schema/migrations/20260625120000_add_submission_search_projection/migration.sql
@@ -1,0 +1,226 @@
+-- Search projection for the public works listing free-text search.
+--
+-- The previous search (`dbSearchSubmissionIds` in
+-- platform/scms/app/routes/api/v1.sites.$siteName.works/db.server.ts) resolved
+-- matching submission ids with a UNION of ILIKE branches over `WorkVersion` /
+-- `Work` ACROSS ALL TENANTS, then joined back to `SubmissionVersion` /
+-- `Submission` to apply the selective `site_id` + `status` filter LAST. On large
+-- multi-tenant data (600k+ work versions) common author/affiliation terms
+-- produced huge global candidate sets before the site filter pruned them.
+--
+-- This projection co-locates the selective keys (`site_id`, `status`,
+-- `submission_id`) with the searchable text for every LISTED submission version
+-- (PUBLISHED / IN_REVIEW only), so the scoped filter is applied FIRST and the
+-- text match (FTS + pg_trgm fuzzy) runs only within a single site's rows.
+--
+-- Searchable text is built from the same sources as the old ILIKE branches
+-- (WorkVersion.title / authors / doi, Work.doi, affiliation names from
+-- WorkVersion.metadata) and is `unaccent`-normalised so accented and
+-- unaccented spellings match symmetrically (e.g. "muller" <-> "Müller").
+--
+-- The compound GIN indexes (needing `btree_gin` for the scalar leading keys and
+-- `gin_trgm_ops` for fuzzy text) are created CONCURRENTLY in the follow-on
+-- migration `20260625120100_add_submission_search_indexes` so the large index
+-- builds do not hold a long lock inside this migration's transaction.
+
+SET statement_timeout = 0;
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS btree_gin;
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+-- IMMUTABLE unaccent wrapper. The stock `unaccent(text)` is STABLE (it resolves
+-- a dictionary at runtime), so it cannot be used in stored/generated
+-- expressions or expression indexes. Pinning the dictionary name lets us mark
+-- the wrapper IMMUTABLE, same pattern as `immutable_array_to_string`
+-- (migration `20260526223800`).
+CREATE OR REPLACE FUNCTION immutable_unaccent(text)
+  RETURNS text
+  LANGUAGE sql
+  IMMUTABLE
+  PARALLEL SAFE
+AS $$
+  SELECT unaccent('unaccent', $1)
+$$;
+
+-- Single source of truth for the searchable text of one work version. STABLE
+-- (reads tables); the per-row normalisation it calls is IMMUTABLE.
+CREATE OR REPLACE FUNCTION submission_search_text(p_work_version_id text)
+  RETURNS text
+  LANGUAGE sql
+  STABLE
+AS $$
+  SELECT immutable_unaccent(
+    concat_ws(
+      ' ',
+      wv.title,
+      immutable_array_to_string(wv.authors, ' '),
+      wv.doi,
+      w.doi,
+      work_version_affiliations_search_text(wv.metadata)
+    )
+  )
+  FROM "WorkVersion" wv
+  JOIN "Work" w ON w.id = wv.work_id
+  WHERE wv.id = p_work_version_id
+$$;
+
+CREATE TABLE "SubmissionSearch" (
+  "submission_version_id" TEXT PRIMARY KEY,
+  "submission_id"         TEXT NOT NULL,
+  "site_id"               TEXT NOT NULL,
+  "status"                TEXT NOT NULL,
+  "search_text"           TEXT NOT NULL DEFAULT '',
+  "search_tsv"            tsvector NOT NULL DEFAULT ''::tsvector,
+  CONSTRAINT "SubmissionSearch_submission_version_id_fkey"
+    FOREIGN KEY ("submission_version_id")
+    REFERENCES "SubmissionVersion"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Recompute (upsert/delete) the projection row for a single submission version.
+-- Idempotent; runs in the caller's transaction.
+CREATE OR REPLACE FUNCTION submission_search_refresh_sv(p_sv_id text)
+  RETURNS void
+  LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_status          text;
+  v_submission_id   text;
+  v_work_version_id text;
+  v_site_id         text;
+  v_text            text;
+BEGIN
+  SELECT sv.status, sv.submission_id, sv.work_version_id, s.site_id
+    INTO v_status, v_submission_id, v_work_version_id, v_site_id
+  FROM "SubmissionVersion" sv
+  JOIN "Submission" s ON s.id = sv.submission_id
+  WHERE sv.id = p_sv_id;
+
+  -- Only listed statuses are projected; anything else is removed.
+  IF NOT FOUND OR v_status NOT IN ('PUBLISHED', 'IN_REVIEW') THEN
+    DELETE FROM "SubmissionSearch" WHERE submission_version_id = p_sv_id;
+    RETURN;
+  END IF;
+
+  v_text := submission_search_text(v_work_version_id);
+
+  INSERT INTO "SubmissionSearch" (
+    submission_version_id, submission_id, site_id, status, search_text, search_tsv
+  )
+  VALUES (
+    p_sv_id, v_submission_id, v_site_id, v_status, v_text, to_tsvector('simple', v_text)
+  )
+  ON CONFLICT (submission_version_id) DO UPDATE
+    SET submission_id = EXCLUDED.submission_id,
+        site_id       = EXCLUDED.site_id,
+        status        = EXCLUDED.status,
+        search_text   = EXCLUDED.search_text,
+        search_tsv    = EXCLUDED.search_tsv;
+END;
+$$;
+
+-- Trigger glue ----------------------------------------------------------------
+
+-- SubmissionVersion: insert/delete + the columns that move a row in/out of the
+-- projection or change which work version it points at.
+CREATE OR REPLACE FUNCTION submission_search_tg_submission_version()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF (TG_OP = 'DELETE') THEN
+    DELETE FROM "SubmissionSearch" WHERE submission_version_id = OLD.id;
+    RETURN NULL;
+  END IF;
+  PERFORM submission_search_refresh_sv(NEW.id);
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER submission_search_sv_iud
+AFTER INSERT OR DELETE ON "SubmissionVersion"
+FOR EACH ROW EXECUTE FUNCTION submission_search_tg_submission_version();
+
+CREATE TRIGGER submission_search_sv_u
+AFTER UPDATE OF status, work_version_id, submission_id ON "SubmissionVersion"
+FOR EACH ROW EXECUTE FUNCTION submission_search_tg_submission_version();
+
+-- WorkVersion: text-bearing columns changed -> refresh every submission version
+-- that points at this work version.
+CREATE OR REPLACE FUNCTION submission_search_tg_work_version()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+AS $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT id FROM "SubmissionVersion" WHERE work_version_id = NEW.id
+  LOOP
+    PERFORM submission_search_refresh_sv(r.id);
+  END LOOP;
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER submission_search_wv_u
+AFTER UPDATE OF title, authors, doi, metadata ON "WorkVersion"
+FOR EACH ROW EXECUTE FUNCTION submission_search_tg_work_version();
+
+-- Work: doi changed -> refresh submission versions for all of the work's versions.
+CREATE OR REPLACE FUNCTION submission_search_tg_work()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+AS $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT sv.id
+    FROM "SubmissionVersion" sv
+    JOIN "WorkVersion" wv ON wv.id = sv.work_version_id
+    WHERE wv.work_id = NEW.id
+  LOOP
+    PERFORM submission_search_refresh_sv(r.id);
+  END LOOP;
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER submission_search_work_u
+AFTER UPDATE OF doi ON "Work"
+FOR EACH ROW WHEN (OLD.doi IS DISTINCT FROM NEW.doi)
+EXECUTE FUNCTION submission_search_tg_work();
+
+-- Backfill existing listed submission versions. statement_timeout is disabled
+-- above; on very large tables run this in id-ranged batches instead if it risks
+-- a long lock.
+INSERT INTO "SubmissionSearch" (
+  submission_version_id, submission_id, site_id, status, search_text, search_tsv
+)
+SELECT
+  sv.id,
+  sv.submission_id,
+  s.site_id,
+  sv.status,
+  txt.search_text,
+  to_tsvector('simple', txt.search_text)
+FROM "SubmissionVersion" sv
+JOIN "Submission" s ON s.id = sv.submission_id
+JOIN "WorkVersion" wv ON wv.id = sv.work_version_id
+JOIN "Work" w ON w.id = wv.work_id
+CROSS JOIN LATERAL (
+  SELECT immutable_unaccent(
+    concat_ws(
+      ' ',
+      wv.title,
+      immutable_array_to_string(wv.authors, ' '),
+      wv.doi,
+      w.doi,
+      work_version_affiliations_search_text(wv.metadata)
+    )
+  ) AS search_text
+) txt
+WHERE sv.status IN ('PUBLISHED', 'IN_REVIEW')
+ON CONFLICT (submission_version_id) DO NOTHING;

--- a/prisma/schema/migrations/20260625120000_add_submission_search_projection/migration.sql
+++ b/prisma/schema/migrations/20260625120000_add_submission_search_projection/migration.sql
@@ -14,9 +14,10 @@
 -- text match (FTS + pg_trgm fuzzy) runs only within a single site's rows.
 --
 -- Searchable text is built from the same sources as the old ILIKE branches
--- (WorkVersion.title / authors / doi, Work.doi, affiliation names from
--- WorkVersion.metadata) and is `unaccent`-normalised so accented and
--- unaccented spellings match symmetrically (e.g. "muller" <-> "Müller").
+-- (WorkVersion.title / authors, the work's DOI as WorkVersion.doi falling back
+-- to Work.doi, and affiliation names from WorkVersion.metadata) and is
+-- `unaccent`-normalised so accented and unaccented spellings match symmetrically
+-- (e.g. "muller" <-> "Müller").
 --
 -- The compound GIN indexes (needing `btree_gin` for the scalar leading keys and
 -- `gin_trgm_ops` for fuzzy text) are created CONCURRENTLY in the follow-on
@@ -55,8 +56,7 @@ AS $$
       ' ',
       wv.title,
       immutable_array_to_string(wv.authors, ' '),
-      wv.doi,
-      w.doi,
+      COALESCE(wv.doi, w.doi),
       work_version_affiliations_search_text(wv.metadata)
     )
   )
@@ -216,8 +216,7 @@ CROSS JOIN LATERAL (
       ' ',
       wv.title,
       immutable_array_to_string(wv.authors, ' '),
-      wv.doi,
-      w.doi,
+      COALESCE(wv.doi, w.doi),
       work_version_affiliations_search_text(wv.metadata)
     )
   ) AS search_text

--- a/prisma/schema/migrations/20260625120050_backfill_submission_search/migration.sql
+++ b/prisma/schema/migrations/20260625120050_backfill_submission_search/migration.sql
@@ -1,0 +1,74 @@
+-- One-time backfill of the SubmissionSearch projection for existing rows.
+--
+-- The DDL (table, helper functions, maintenance triggers) is created in the
+-- previous migration `20260625120000_add_submission_search_projection`. From the
+-- moment those triggers exist, every NEW / changed listed submission version is
+-- projected automatically; this migration only populates rows that already
+-- existed before the triggers were installed.
+--
+-- This is a single set-based, idempotent INSERT (`ON CONFLICT DO NOTHING`), so:
+--   * a partial run is impossible -- one statement either fully commits or fully
+--     rolls back, leaving the table empty if it times out; and
+--   * re-running it (here or in psql) only fills in rows still missing.
+--
+-- statement_timeout is disabled for the migration session below, but external
+-- wall-clock limits (CI step / connection pooler / deploy job) can still abort a
+-- very large backfill. If that happens this migration is marked FAILED and the
+-- index migration that follows does NOT run.
+--
+-- ============================================================================
+-- BREAK-GLASS RUNBOOK -- completing the backfill manually via psql
+-- ============================================================================
+-- If this migration times out during `prisma migrate deploy`:
+--
+--   1. Connect with psql using a DIRECT (non-pooled, session-mode) connection
+--      so server-side timeouts are under your control:
+--        psql "$DIRECT_DATABASE_URL"
+--
+--   2. Run the resumable, batched backfill (commits per batch, so progress
+--      survives an interruption and you can re-run to continue):
+--        \i prisma/scripts/backfill-submission-search.sql
+--
+--   3. Sanity-check completion (expect 0):
+--        SELECT count(*)
+--        FROM "SubmissionVersion" sv
+--        WHERE sv.status IN ('PUBLISHED','IN_REVIEW')
+--          AND NOT EXISTS (
+--            SELECT 1 FROM "SubmissionSearch" ss
+--            WHERE ss.submission_version_id = sv.id
+--          );
+--
+--   4. Tell Prisma this migration is done, then let deploy build the indexes:
+--        prisma migrate resolve --applied 20260625120050_backfill_submission_search
+--        prisma migrate deploy
+-- ============================================================================
+
+SET statement_timeout = 0;
+
+INSERT INTO "SubmissionSearch" (
+  submission_version_id, submission_id, site_id, status, search_text, search_tsv
+)
+SELECT
+  sv.id,
+  sv.submission_id,
+  s.site_id,
+  sv.status,
+  txt.search_text,
+  to_tsvector('simple', txt.search_text)
+FROM "SubmissionVersion" sv
+JOIN "Submission" s ON s.id = sv.submission_id
+JOIN "WorkVersion" wv ON wv.id = sv.work_version_id
+JOIN "Work" w ON w.id = wv.work_id
+CROSS JOIN LATERAL (
+  SELECT immutable_unaccent(
+    concat_ws(
+      ' ',
+      wv.title,
+      immutable_array_to_string(wv.authors, ' '),
+      COALESCE(wv.doi, w.doi),
+      work_version_affiliations_search_text(wv.metadata)
+    )
+  ) AS search_text
+) txt
+WHERE sv.status IN ('PUBLISHED', 'IN_REVIEW')
+ON CONFLICT (submission_version_id) DO NOTHING;

--- a/prisma/schema/migrations/20260625120100_add_submission_search_indexes/migration.sql
+++ b/prisma/schema/migrations/20260625120100_add_submission_search_indexes/migration.sql
@@ -31,3 +31,11 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS "SubmissionSearch_site_status_tsv_idx"
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "SubmissionSearch_site_status_trgm_idx"
   ON "SubmissionSearch" USING GIN (site_id, status, search_text gin_trgm_ops);
+
+-- Plain btree to serve the unfiltered browse count
+-- (`COUNT(DISTINCT submission_id) WHERE site_id = ? AND status = ?`) as an
+-- index-only scan, avoiding the `Submission` ⋈ `SubmissionVersion` join + DISTINCT
+-- on large sites. `submission_id` is included so the distinct count never touches
+-- the heap.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "SubmissionSearch_site_status_submission_idx"
+  ON "SubmissionSearch" (site_id, status, submission_id);

--- a/prisma/schema/migrations/20260625120100_add_submission_search_indexes/migration.sql
+++ b/prisma/schema/migrations/20260625120100_add_submission_search_indexes/migration.sql
@@ -1,0 +1,33 @@
+-- prisma-migrate-disable-next-transaction
+-- Compound GIN indexes for the works search projection
+-- (`SubmissionSearch`, migration `20260625120000_add_submission_search_projection`).
+--
+-- Both lead with the selective scalar keys `site_id` + `status` (via the
+-- `btree_gin` extension) so a single index scan applies the site/status filter
+-- and the text match together:
+--   - `search_tsv` GIN powers the full-text `@@` branch (token / word-gap correct).
+--   - `search_text gin_trgm_ops` GIN powers the `<%` word_similarity fuzzy branch.
+--
+-- CONCURRENTLY + no transaction: standard CREATE INDEX blocks writes and can
+-- exceed Supabase statement_timeout on large tables (P3018 / 57014); same
+-- constraint as `20260610120000_add_work_version_affiliations_trgm_index`.
+--
+-- These cannot be expressed in schema.prisma (multicolumn GIN + opclasses), so
+-- the model is declared without them and they live here as raw SQL; same
+-- pattern as `20260526223800_add_submission_search_trgm_indexes`.
+--
+-- Follow-on (separate migration, after this ships and bakes): once the
+-- projection fully replaces the legacy path, the per-column trigram indexes that
+-- existed only for that path become redundant and can be dropped to reclaim
+-- space -- `WorkVersion_title_trgm_idx`, `WorkVersion_doi_trgm_idx`,
+-- `WorkVersion_authors_trgm_idx`, `WorkVersion_affiliations_trgm_idx`,
+-- `Work_doi_trgm_idx`. Confirm zero usage via `pg_stat_user_indexes` first and
+-- keep the btree `doi` indexes (DOI resolution endpoint still needs them).
+
+SET statement_timeout = 0;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "SubmissionSearch_site_status_tsv_idx"
+  ON "SubmissionSearch" USING GIN (site_id, status, search_tsv);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "SubmissionSearch_site_status_trgm_idx"
+  ON "SubmissionSearch" USING GIN (site_id, status, search_text gin_trgm_ops);

--- a/prisma/schema/submission.prisma
+++ b/prisma/schema/submission.prisma
@@ -97,6 +97,7 @@ model SubmissionVersion {
   metadata            Json? // JSON metadata field for extensible data
   tags                String[]    @default([])
   occ                 Int         @default(0) // Optimistic concurrency control
+  searchProjection    SubmissionSearch?
 
   @@index([tags], type: Gin)
   /// Dedicated FK index for Submission → versions joins. Composite indexes on
@@ -116,6 +117,30 @@ model SubmissionVersion {
   /// (`sites.doi`). `work_version_id` is an FK with no implicit index in
   /// Postgres, so the lookup walked it unindexed.
   @@index([work_version_id])
+}
+
+/// Denormalised search projection for the public works listing free-text search
+/// (`dbSearchSubmissionIds` in `v1.sites.$siteName.works/db.server.ts`). One row
+/// per LISTED submission version (PUBLISHED / IN_REVIEW), co-locating the
+/// selective keys (`site_id`, `status`, `submission_id`) with the searchable
+/// text so the site/status filter is applied before the text match.
+///
+/// Created and maintained entirely in raw SQL (migration
+/// `20260625120000_add_submission_search_projection`): `search_text` /
+/// `search_tsv` are `unaccent`-normalised and kept fresh by triggers on
+/// `SubmissionVersion` / `WorkVersion` / `Work`. The compound GIN indexes
+/// `SubmissionSearch_site_status_tsv_idx` and `SubmissionSearch_site_status_trgm_idx`
+/// (btree_gin + gin_trgm_ops, CONCURRENTLY) are declared in migration
+/// `20260625120100_add_submission_search_indexes` and cannot be expressed here.
+/// The model exists so `migrate dev` does not treat the table as drift.
+model SubmissionSearch {
+  submission_version_id String                  @id
+  submission_id         String
+  site_id               String
+  status                String
+  search_text           String                  @default("")
+  search_tsv            Unsupported("tsvector")
+  submissionVersion     SubmissionVersion       @relation(fields: [submission_version_id], references: [id], onDelete: Cascade)
 }
 
 model Submission {

--- a/prisma/scripts/backfill-submission-search.sql
+++ b/prisma/scripts/backfill-submission-search.sql
@@ -1,0 +1,78 @@
+-- Resumable, batched backfill for the SubmissionSearch projection.
+--
+-- BREAK-GLASS ONLY. The normal backfill runs as migration
+-- `20260625120050_backfill_submission_search` (a single set-based INSERT). Use
+-- THIS script when that migration times out and you need to complete the
+-- backfill manually, in batches that commit incrementally so progress survives
+-- an interruption.
+--
+-- Usage (direct, session-mode connection so you control timeouts):
+--   psql "$DIRECT_DATABASE_URL" -f prisma/scripts/backfill-submission-search.sql
+-- or from an interactive psql session:
+--   \i prisma/scripts/backfill-submission-search.sql
+--
+-- Safe to run repeatedly: each batch is `ON CONFLICT DO NOTHING`, so already
+-- projected rows are skipped and only missing rows are inserted. Re-running
+-- after an interruption simply continues where it stopped.
+--
+-- After it reports "backfill complete", mark the migration applied and resume:
+--   prisma migrate resolve --applied 20260625120050_backfill_submission_search
+--   prisma migrate deploy
+
+SET statement_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+
+DO $$
+DECLARE
+  batch_size   integer := 5000;
+  inserted     integer;
+  total        bigint := 0;
+BEGIN
+  LOOP
+    -- Project the next batch of still-missing listed submission versions.
+    INSERT INTO "SubmissionSearch" (
+      submission_version_id, submission_id, site_id, status, search_text, search_tsv
+    )
+    SELECT
+      sv.id,
+      sv.submission_id,
+      s.site_id,
+      sv.status,
+      txt.search_text,
+      to_tsvector('simple', txt.search_text)
+    FROM "SubmissionVersion" sv
+    JOIN "Submission" s ON s.id = sv.submission_id
+    JOIN "WorkVersion" wv ON wv.id = sv.work_version_id
+    JOIN "Work" w ON w.id = wv.work_id
+    CROSS JOIN LATERAL (
+      SELECT immutable_unaccent(
+        concat_ws(
+          ' ',
+          wv.title,
+          immutable_array_to_string(wv.authors, ' '),
+          COALESCE(wv.doi, w.doi),
+          work_version_affiliations_search_text(wv.metadata)
+        )
+      ) AS search_text
+    ) txt
+    WHERE sv.status IN ('PUBLISHED', 'IN_REVIEW')
+      AND NOT EXISTS (
+        SELECT 1 FROM "SubmissionSearch" ss
+        WHERE ss.submission_version_id = sv.id
+      )
+    LIMIT batch_size
+    ON CONFLICT (submission_version_id) DO NOTHING;
+
+    GET DIAGNOSTICS inserted = ROW_COUNT;
+    total := total + inserted;
+
+    -- Commit each batch so progress persists if the session is interrupted.
+    COMMIT;
+
+    RAISE NOTICE 'backfilled % rows (running total %)', inserted, total;
+
+    EXIT WHEN inserted = 0;
+  END LOOP;
+
+  RAISE NOTICE 'backfill complete: % rows inserted', total;
+END $$;


### PR DESCRIPTION
building a projection table for fast doi, auther and affiliation searches, this is aiming for sub 2s searches in production

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large production DB migration (backfill, triggers, concurrent indexes) plus a new default search path; mis-timed deploy or projection drift could affect search correctness until the kill-switch is used.
> 
> **Overview**
> Optimizes the public **`GET /api/v1/sites/:siteName/works`** path with a **site-scoped search projection**, **cheaper totals**, and a **dedicated Postgres pool** so heavy listing traffic does not starve the rest of the app.
> 
> **`SubmissionSearch` projection (default search):** New trigger-maintained table holds `site_id`, `status`, and `unaccent`-normalized searchable text per listed (`PUBLISHED` / `IN_REVIEW`) submission version. Free-text `q` now filters by site/status first, then matches via **`websearch_to_tsquery`** plus **pg_trgm** fuzzy fallback. Rollout is three migrations (DDL → idempotent backfill → `CONCURRENTLY` GIN/btree indexes) with a batched psql backfill runbook if deploy times out. **`WORKS_SEARCH_PROJECTION_DISABLED=true`** restores the legacy global UNION/ILIKE path without redeploy.
> 
> **Counts:** Paginated listings pick a cheaper total when safe—resolved search/subject id-set length, projection `COUNT(DISTINCT submission_id)` for unfiltered browse, otherwise the existing join count.
> 
> **Connection isolation:** `getNamedLowLevelPrismaClient` in **`scms-db`** and **`getWorksListingPrismaClient`** in **`scms-server`** route the whole works listing DB path (search, count, page, subject lookups) through a separate **`works-listing`** pool (total DB connections ≈ sum of pool maxes).
> 
> Integration tests split **projection (default)** vs **legacy kill-switch** behavior; **`test:db:reset`** uses **`prisma migrate reset`** with **`prisma.test.config.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 594321178fdede0e1076527de706c7f2e0f5e51f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->