### PR TITLE
⛨ expose check summaries

### DIFF
--- a/.changeset/quiet-checks-appear.md
+++ b/.changeset/quiet-checks-appear.md
@@ -3,4 +3,4 @@
 '@curvenote/scms-core': patch
 ---
 
-Show latest check run summaries on the My Works listing and add an extension slot for compact work list check summary content.
+Show latest check run summaries on the My Works listing and Work Timeline popover, and add an extension slot for compact work list check summary content.

--- a/.changeset/quiet-checks-appear.md
+++ b/.changeset/quiet-checks-appear.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms': patch
+'@curvenote/scms-core': patch
+---
+
+Show latest check run summaries on the My Works listing and add an extension slot for compact work list check summary content.

--- a/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
+++ b/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
@@ -8,6 +8,7 @@ import type {
   VersionTimelineEntry,
   WorkVersionTimelineEntry,
 } from '../types/versionTimeline.js';
+import type { ClientExtensionCheckService as ExtensionCheckService } from '../modules/extensions/types.js';
 import { useVersionTimeline } from '../hooks/useVersionTimeline.js';
 import { SubmissionVersionTimelineRow, WorkVersionTimelineRow } from './VersionTimelineRows.js';
 import { cn } from '../utils/cn.js';
@@ -150,6 +151,7 @@ export function VersionTimelineHoverCard<T extends { id: string }>({
   align = 'start',
   side = 'top',
   title = 'Versions',
+  contentClassName,
 }: VersionTimelineHoverCardProps<T>) {
   const [open, setOpen] = useState(false);
   const { data, loading, error } = useVersionTimeline<T>(versionsUrl, { open });
@@ -161,7 +163,12 @@ export function VersionTimelineHoverCard<T extends { id: string }>({
           {children}
         </span>
       </HoverCardTrigger>
-      <HoverCardContent align={align} side={side} sideOffset={8} className="w-80 p-3">
+      <HoverCardContent
+        align={align}
+        side={side}
+        sideOffset={8}
+        className={cn(contentClassName ?? 'w-80', 'p-3')}
+      >
         <div className="mb-2 flex items-center gap-1.5 border-b border-border pb-2 text-xs font-semibold text-foreground">
           <Timeline className="size-3.5 shrink-0" aria-hidden />
           <span>{title}</span>
@@ -192,6 +199,7 @@ export type VersionTimelineHoverCardProps<T extends { id: string }> = {
   align?: 'start' | 'center' | 'end';
   side?: 'top' | 'right' | 'bottom' | 'left';
   title?: string;
+  contentClassName?: string;
 };
 
 export function SubmissionVersionTimelineHoverCard({
@@ -221,8 +229,10 @@ export function WorkVersionTimelineHoverCard({
   align,
   side,
   title,
+  checkServices,
 }: Omit<VersionTimelineHoverCardProps<WorkVersionTimelineEntry>, 'renderRow'> & {
   workId?: string;
+  checkServices?: ExtensionCheckService[];
 }) {
   return (
     <VersionTimelineHoverCard<WorkVersionTimelineEntry>
@@ -230,7 +240,10 @@ export function WorkVersionTimelineHoverCard({
       align={align}
       side={side}
       title={title}
-      renderRow={(entry) => <WorkVersionTimelineRow entry={entry} workId={workId} />}
+      contentClassName="w-[calc(100vw-2rem)] max-w-[32rem]"
+      renderRow={(entry) => (
+        <WorkVersionTimelineRow entry={entry} workId={workId} checkServices={checkServices} />
+      )}
     >
       {children}
     </VersionTimelineHoverCard>

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -172,7 +172,7 @@ export function WorkVersionTimelineRow({
           const SummaryComponent = service.workListSummaryComponent;
           if (!SummaryComponent) return null;
           const chip = (
-            <span className="inline-flex h-5 max-w-full shrink-0 items-center gap-1 rounded-md border border-border bg-background px-1.5 text-[10px] text-foreground shadow-sm">
+            <span className="inline-flex h-5 max-w-full shrink-0 items-center gap-1 rounded-md border border-border bg-background px-1.5 text-[10px] text-foreground">
               <SummaryComponent
                 compact
                 metadata={metadata}

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -1,10 +1,22 @@
 import type { ReactNode } from 'react';
-import type { VersionTimelineEntry, WorkVersionTimelineEntry } from '../types/versionTimeline.js';
+import { Link } from 'react-router';
+import type {
+  VersionTimelineEntry,
+  WorkVersionTimelineCheckRun,
+  WorkVersionTimelineEntry,
+} from '../types/versionTimeline.js';
+import type { ClientExtensionCheckService } from '../modules/extensions/types.js';
 import { formatDate, formatDatetime } from '../utils/formatDate.js';
 import { getStatusDotClasses, getStatusRingClasses } from '../utils/status.js';
 import { cn } from '../utils/cn.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js';
 import { SubmissionVersionSiteChip } from './SubmissionVersionSiteChip.js';
+
+function serviceDataFromRun(run: WorkVersionTimelineCheckRun): unknown {
+  return run.data != null && typeof run.data === 'object' && 'serviceData' in run.data
+    ? (run.data as { serviceData?: unknown }).serviceData
+    : undefined;
+}
 
 export function VersionTimelineRowShell({
   dotStatus,
@@ -122,11 +134,27 @@ export function SubmissionVersionTimelineRow({ entry }: { entry: VersionTimeline
 export function WorkVersionTimelineRow({
   entry,
   workId,
+  checkServices = [],
 }: {
   entry: WorkVersionTimelineEntry;
   workId?: string;
+  checkServices?: ClientExtensionCheckService[];
 }) {
   const submissionVersions = entry.submissionVersions ?? [];
+  const serviceById = new Map(checkServices.map((service) => [service.id, service]));
+  const checkRuns = (entry.checkRuns ?? [])
+    .map((run) => ({ run, service: serviceById.get(run.kind), metadata: serviceDataFromRun(run) }))
+    .filter(
+      (
+        summary,
+      ): summary is {
+        run: WorkVersionTimelineCheckRun;
+        service: ClientExtensionCheckService;
+        metadata: unknown;
+      } =>
+        summary.service != null &&
+        (summary.service.isWorkListSummaryVisible?.(summary.metadata) ?? true),
+    );
 
   return (
     <VersionTimelineRowShell dotStatus={entry.draft ? 'DRAFT' : 'PUBLISHED'}>
@@ -139,6 +167,48 @@ export function WorkVersionTimelineRow({
             workId={workId}
           />
         ))}
+        {checkRuns.map(({ run, service, metadata }) => {
+          const SummaryComponent = service.workListSummaryComponent;
+          if (!SummaryComponent) return null;
+          const chip = (
+            <span className="inline-flex h-5 max-w-full shrink-0 items-center gap-1 rounded-md border border-border bg-background px-1.5 text-[10px] text-foreground shadow-sm">
+              <SummaryComponent
+                compact
+                metadata={metadata}
+                checkRunId={run.id}
+                workVersionId={run.work_version_id}
+                checkServiceId={service.id}
+                checkServiceName={service.name}
+                checkRunDateModified={run.date_modified}
+              />
+            </span>
+          );
+          return (
+            <Tooltip key={run.id}>
+              <TooltipTrigger asChild>
+                {workId ? (
+                  <Link
+                    to={`/app/works/${workId}/checks`}
+                    className="inline-flex min-w-0 items-center transition-opacity hover:opacity-80"
+                    aria-label={`${service.name} check summary`}
+                    onClick={(event) => event.stopPropagation()}
+                  >
+                    {chip}
+                  </Link>
+                ) : (
+                  <span className="inline-flex min-w-0 items-center cursor-default">{chip}</span>
+                )}
+              </TooltipTrigger>
+              <TooltipContent sideOffset={4}>
+                <span className="font-medium">{service.name}</span>
+                <span className="text-muted-foreground">
+                  {' '}
+                  · Check run · {formatDatetime(run.date_created)}
+                </span>
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
       </div>
       <p className="text-[11px] text-muted-foreground" title={formatDatetime(entry.date_modified)}>
         Modified: {formatDate(entry.date_modified)}

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -6,17 +6,15 @@ import type {
   WorkVersionTimelineEntry,
 } from '../types/versionTimeline.js';
 import type { ClientExtensionCheckService } from '../modules/extensions/types.js';
+import {
+  getCheckServiceRunServiceData,
+  isCheckWorkListSummaryVisible,
+} from '../modules/extensions/checks.js';
 import { formatDate, formatDatetime } from '../utils/formatDate.js';
 import { getStatusDotClasses, getStatusRingClasses } from '../utils/status.js';
 import { cn } from '../utils/cn.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js';
 import { SubmissionVersionSiteChip } from './SubmissionVersionSiteChip.js';
-
-function serviceDataFromRun(run: WorkVersionTimelineCheckRun): unknown {
-  return run.data != null && typeof run.data === 'object' && 'serviceData' in run.data
-    ? (run.data as { serviceData?: unknown }).serviceData
-    : undefined;
-}
 
 export function VersionTimelineRowShell({
   dotStatus,
@@ -143,7 +141,11 @@ export function WorkVersionTimelineRow({
   const submissionVersions = entry.submissionVersions ?? [];
   const serviceById = new Map(checkServices.map((service) => [service.id, service]));
   const checkRuns = (entry.checkRuns ?? [])
-    .map((run) => ({ run, service: serviceById.get(run.kind), metadata: serviceDataFromRun(run) }))
+    .map((run) => ({
+      run,
+      service: serviceById.get(run.kind),
+      metadata: getCheckServiceRunServiceData(run),
+    }))
     .filter(
       (
         summary,
@@ -152,8 +154,7 @@ export function WorkVersionTimelineRow({
         service: ClientExtensionCheckService;
         metadata: unknown;
       } =>
-        summary.service != null &&
-        (summary.service.isWorkListSummaryVisible?.(summary.metadata) ?? true),
+        summary.service != null && isCheckWorkListSummaryVisible(summary.service, summary.metadata),
     );
 
   return (

--- a/packages/scms-core/src/modules/extensions/checks.spec.ts
+++ b/packages/scms-core/src/modules/extensions/checks.spec.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from 'vitest';
 import {
   extensionChecksEnabledFromClientConfig,
   extensionChecksEnabledFromServerConfig,
+  getCheckServiceRunServiceData,
   getExtensionCheckServicesFromClientConfig,
   getExtensionCheckServicesFromServerConfig,
+  isCheckWorkListSummaryVisible,
 } from './checks.js';
 import type { ClientExtension, ServerExtension } from './types.js';
 
@@ -79,5 +81,35 @@ describe('extension checks config gates', () => {
       mockCheckExtension as ServerExtension,
     ]);
     expect(services).toEqual([]);
+  });
+});
+
+describe('check work-list summary helpers', () => {
+  it('extracts extension serviceData from check run data', () => {
+    const serviceData = { score: 73 };
+
+    expect(getCheckServiceRunServiceData({ data: { serviceData } })).toBe(serviceData);
+  });
+
+  it('returns undefined when check run data does not contain serviceData', () => {
+    expect(getCheckServiceRunServiceData({ data: null })).toBeUndefined();
+    expect(getCheckServiceRunServiceData({ data: 'ready' })).toBeUndefined();
+    expect(getCheckServiceRunServiceData({ data: { status: 'completed' } })).toBeUndefined();
+  });
+
+  it('defaults work-list summaries to visible unless the service predicate hides them', () => {
+    expect(isCheckWorkListSummaryVisible({}, { status: 'completed' })).toBe(true);
+    expect(
+      isCheckWorkListSummaryVisible(
+        { isWorkListSummaryVisible: (metadata) => metadata !== 'hide' },
+        'show',
+      ),
+    ).toBe(true);
+    expect(
+      isCheckWorkListSummaryVisible(
+        { isWorkListSummaryVisible: (metadata) => metadata !== 'hide' },
+        'hide',
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/scms-core/src/modules/extensions/checks.ts
+++ b/packages/scms-core/src/modules/extensions/checks.ts
@@ -1,5 +1,6 @@
 import type { ClientDeploymentConfig } from '../../providers/DeploymentProvider.js';
 import type {
+  ClientExtensionCheckService,
   ClientExtension,
   ExtensionCheckService,
   ExtensionConfig,
@@ -41,6 +42,23 @@ export function getExtensionCheckServicesFromClientConfig(
     services.push(...ext.getChecks());
   }
   return services;
+}
+
+export type CheckRunWithServiceData = {
+  data?: unknown | null;
+};
+
+export function getCheckServiceRunServiceData(run: CheckRunWithServiceData): unknown {
+  return run.data != null && typeof run.data === 'object' && 'serviceData' in run.data
+    ? (run.data as { serviceData?: unknown }).serviceData
+    : undefined;
+}
+
+export function isCheckWorkListSummaryVisible(
+  service: Pick<ClientExtensionCheckService, 'isWorkListSummaryVisible'>,
+  metadata: unknown,
+): boolean {
+  return service.isWorkListSummaryVisible?.(metadata) ?? true;
 }
 
 /**

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -224,6 +224,11 @@ export interface ExtensionCheckService {
    */
   workListSummaryComponent?: React.ComponentType<ExtensionCheckWorkListSummaryProps>;
   /**
+   * Optional visibility predicate for My Works list summaries. Return false for states that
+   * should not appear in the listing, such as failed/error runs.
+   */
+  isWorkListSummaryVisible?: (metadata: any) => boolean;
+  /**
    * Optional component mounted for each matching check run row on the work timeline even when the
    * tray is collapsed. Use for extension-specific side effects keyed off loader data.
    *

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -150,6 +150,24 @@ export type ExtensionCheckSectionSummaryTitleProps = {
   metadata: any;
 };
 
+/**
+ * Props for compact check summary content rendered inside platform-owned work-list rows.
+ * Extensions should render only the service-specific content (logo, score, status text/chip).
+ * The platform owns row layout, link behaviour, spacing, and version tags.
+ */
+export type ExtensionCheckWorkListSummaryProps = {
+  /** Check run `serviceData` (extension-defined shape). */
+  metadata: any;
+  checkRunId: string;
+  workVersionId: string;
+  /** Check service id from the run row (e.g. `proofig`). */
+  checkServiceId: string;
+  /** Display name from the registered check service. */
+  checkServiceName: string;
+  /** ISO timestamp from **check_service_run.date_modified**. */
+  checkRunDateModified: string;
+};
+
 /** Props for per-check upload option cards on the work upload page. */
 export interface UploadCheckOptionProps {
   workVersionId: string;
@@ -200,6 +218,11 @@ export interface ExtensionCheckService {
    * `{name}` segment; the platform always appends the word “checks” on the same line with spacing.
    */
   sectionSummaryTitleComponent?: React.ComponentType<ExtensionCheckSectionSummaryTitleProps>;
+  /**
+   * Optional compact content for My Works list rows. Platform supplies the containing row,
+   * right-alignment, link target, and version tag; extensions supply only the inner content.
+   */
+  workListSummaryComponent?: React.ComponentType<ExtensionCheckWorkListSummaryProps>;
   /**
    * Optional component mounted for each matching check run row on the work timeline even when the
    * tray is collapsed. Use for extension-specific side effects keyed off loader data.

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -166,6 +166,8 @@ export type ExtensionCheckWorkListSummaryProps = {
   checkServiceName: string;
   /** ISO timestamp from **check_service_run.date_modified**. */
   checkRunDateModified: string;
+  /** Render a smaller version for compact contexts like timeline popovers. */
+  compact?: boolean;
 };
 
 /** Props for per-check upload option cards on the work upload page. */

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -89,7 +89,7 @@ export type ExtensionCheckHandleActionResult = {
   status?: number;
   /** True when a hydrate/sync intent mutated check run data (skip revalidation when false). */
   updated?: boolean;
-  /** EULA gating (e.g. text integrity `eula-status` / `execute`). */
+  /** Optional acceptance gating for check execution flows. */
   requireEula?: boolean;
   requiresEula?: boolean;
   accepted?: boolean;
@@ -131,7 +131,7 @@ export type ExtensionCheckSectionActivityProps = {
 export type ExtensionCheckRunTimelineMountProps = {
   checkRunId: string;
   workVersionId: string;
-  /** Check service id from the run row (e.g. `proofig`). */
+  /** Check service id from the run row. */
   checkKind: string;
   metadata: unknown;
   /** POST target for check UI mutations. */
@@ -160,7 +160,7 @@ export type ExtensionCheckWorkListSummaryProps = {
   metadata: any;
   checkRunId: string;
   workVersionId: string;
-  /** Check service id from the run row (e.g. `proofig`). */
+  /** Check service id from the run row. */
   checkServiceId: string;
   /** Display name from the registered check service. */
   checkServiceName: string;
@@ -178,7 +178,7 @@ export interface UploadCheckOptionProps {
   disabled?: boolean;
   /** Check is selected but uploaded files no longer meet requirements. */
   invalid?: boolean;
-  /** Service manifest logo URL when available (e.g. text integrity Object config). */
+  /** Service manifest logo URL when available. */
   logoUrl?: string;
   /** Platform persists selection via `toggle-check` on the upload route. */
   setEnabled: (enabled: boolean) => Promise<void>;
@@ -191,7 +191,7 @@ export interface ExtensionCheckService {
   name: string; // Display name
   description: string; // Display description
   /**
-   * App-absolute path for extension-owned check actions (e.g. `/app/extensions/proofig/actions`).
+   * App-absolute path for extension-owned check actions.
    * When set, the platform uses this for `remoteStatusActionPath` on the checks page and work timeline.
    */
   checksActionPath?: string;

--- a/packages/scms-core/src/types/versionTimeline.ts
+++ b/packages/scms-core/src/types/versionTimeline.ts
@@ -27,12 +27,22 @@ export type WorkVersionTimelineSubmissionVersion = {
   };
 };
 
+export type WorkVersionTimelineCheckRun = {
+  id: string;
+  work_version_id: string;
+  kind: string;
+  date_created: string;
+  date_modified: string;
+  data: unknown;
+};
+
 export type WorkVersionTimelineEntry = {
   id: string;
   date_created: string;
   date_modified: string;
   draft: boolean;
   submissionVersions?: WorkVersionTimelineSubmissionVersion[];
+  checkRuns?: WorkVersionTimelineCheckRun[];
 };
 
 export type VersionTimelineDisplayItem<T> =

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -8,7 +8,7 @@ import {
   type ChecksMetadataSection,
 } from '@curvenote/scms-server';
 import type { FileMetadataSection } from '@curvenote/scms-core';
-import { Calendar } from 'lucide-react';
+import { GitBranch } from 'lucide-react';
 import {
   PageFrame,
   getBrandingFromMetaMatches,
@@ -215,9 +215,9 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
     return (
       <span className="inline-flex gap-2 items-center">
         <ui.VersionTagBadge
-          tag={formatDate(entry.versionDateCreated)}
+          tag={formatDate(entry.versionDateCreated, 'MMM dd, y HH:mm')}
           titlePrefix="Work version created"
-          icon={Calendar}
+          icon={GitBranch}
         />
         <DateWithPopover
           date={entry.run.date_modified}

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -216,11 +216,11 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
     const versionDate = formatDate(entry.versionDateCreated, 'MMM dd, y HH:mm');
     return (
       <span
-        className="inline-flex gap-1.5 items-center text-[11px] text-muted-foreground"
+        className="inline-flex gap-1.5 items-center text-xs text-muted-foreground"
         title={formatDatetime(entry.versionDateCreated)}
       >
-        <GitBranch className="size-3 shrink-0" aria-hidden />
-        <span>Work version: {versionDate}</span>
+        <GitBranch className="size-3.5 shrink-0" aria-hidden />
+        <span>{versionDate}</span>
       </span>
     );
   };
@@ -319,7 +319,7 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
                     />
                   </ui.CardContent>
                   {latest ? (
-                    <div className="flex justify-start px-6 py-2 border-t border-border">
+                    <div className="flex justify-start py-1.5 pr-6 pl-3 border-t border-border">
                       {renderWorkVersionDate(latest)}
                     </div>
                   ) : null}

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -23,25 +23,16 @@ import {
   ui,
 } from '@curvenote/scms-core';
 import { dbGetLatestNonDraftWorkVersion, formatWorkVersionDTO } from './db.server';
+import { dbGetCheckServiceRunsByWorkVersionIds } from '../works.$workId/db.server';
 import {
-  dbGetCheckServiceRunsByWorkVersionIds,
-  type CheckServiceRunRow,
-} from '../works.$workId/db.server';
+  getCheckRunSummaryByKind,
+  type ServiceRunEntry,
+} from '../works.$workId/checkServiceRunSummaries';
 import { extensions } from '../../../extensions/client';
 import { extensions as serverExtensions } from '../../../extensions/server';
 import { RunCheckOnLatestVersionButton } from './RunCheckOnLatestVersionButton';
 
 const DISPATCHING_SKELETON_MS = 1500;
-
-/** A check service run paired with the version context needed for display. */
-export type ServiceRunEntry = {
-  run: CheckServiceRunRow;
-  workVersionId: string;
-  /** Version number by date_created order (v1 = oldest). */
-  versionNumber: number;
-  /** ISO date for the work version (used for tooltip on the version tag). */
-  versionDateCreated: string;
-};
 
 export async function loader(args: Route.LoaderArgs) {
   const ctx = await withSecureWorkContext(args, [scopes.work.id.checks.read]);
@@ -69,50 +60,10 @@ export async function loader(args: Route.LoaderArgs) {
 
   const nonDraftVersionIds = nonDraftVersions.map((v) => v.id);
   const runsByVersionId = await dbGetCheckServiceRunsByWorkVersionIds(nonDraftVersionIds);
-
-  // Version numbering: v1 = oldest (by date_created).
-  // `nonDraftVersions` is ordered desc by date_created (latest first), so the highest number is first.
-  const versionNumberByWorkVersionId: Record<string, number> = {};
-  nonDraftVersions.forEach((v, i) => {
-    versionNumberByWorkVersionId[v.id] = nonDraftVersions.length - i;
-  });
-
-  // Build per-kind entries: for each version (newest → oldest) dedupe to that version's latest run
-  // of that kind, then sort each kind's list desc by run.date_created.
-  const entriesByKind: Record<string, ServiceRunEntry[]> = {};
-  for (const version of nonDraftVersions) {
-    const runs = runsByVersionId[version.id] ?? [];
-    const seenKind = new Set<string>();
-    for (const run of runs) {
-      if (seenKind.has(run.kind)) continue;
-      seenKind.add(run.kind);
-      const list = entriesByKind[run.kind] ?? [];
-      list.push({
-        run,
-        workVersionId: version.id,
-        versionNumber: versionNumberByWorkVersionId[version.id] ?? 0,
-        versionDateCreated: version.date_created,
-      });
-      entriesByKind[run.kind] = list;
-    }
-  }
-  for (const kind of Object.keys(entriesByKind)) {
-    entriesByKind[kind].sort((a, b) =>
-      a.run.date_created > b.run.date_created
-        ? -1
-        : a.run.date_created < b.run.date_created
-          ? 1
-          : 0,
-    );
-  }
-
-  const latestRunByServiceKind: Record<string, ServiceRunEntry> = {};
-  const previousRunsByServiceKind: Record<string, ServiceRunEntry[]> = {};
-  for (const [kind, list] of Object.entries(entriesByKind)) {
-    const [head, ...rest] = list;
-    latestRunByServiceKind[kind] = head;
-    previousRunsByServiceKind[kind] = rest;
-  }
+  const { latestRunByServiceKind, previousRunsByServiceKind } = getCheckRunSummaryByKind(
+    nonDraftVersions,
+    runsByVersionId,
+  );
 
   // -------------------------------------------------------------------------
   // TEMPORARY (stepping-stone): service-manifest fallback for kinds with no run.

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -16,6 +16,7 @@ import {
   scopes,
   getExtensionCheckServicesFromServerConfig,
   DateWithPopover,
+  formatDate,
   Timeline,
   TimelineSection,
   CheckServiceRunTimelineItem,
@@ -213,7 +214,12 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
     const emphasis = entry.workVersionId === latestNonDraftWorkVersion.id ? 'latest' : 'previous';
     return (
       <span className="inline-flex gap-2 items-center">
-        <ui.VersionTagBadge tag={`v${entry.versionNumber}`} emphasis={emphasis} />
+        <ui.VersionTagBadge
+          tag={formatDate(entry.versionDateCreated)}
+          titlePrefix="Work version created"
+          hideIcon
+          emphasis={emphasis}
+        />
         <DateWithPopover
           date={entry.run.date_modified}
           dateCreated={entry.run.date_created}

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -8,6 +8,7 @@ import {
   type ChecksMetadataSection,
 } from '@curvenote/scms-server';
 import type { FileMetadataSection } from '@curvenote/scms-core';
+import { Calendar } from 'lucide-react';
 import {
   PageFrame,
   getBrandingFromMetaMatches,
@@ -211,14 +212,12 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
   }, [showDispatchingState, revalidator]);
 
   const renderVersionTag = (entry: ServiceRunEntry) => {
-    const emphasis = entry.workVersionId === latestNonDraftWorkVersion.id ? 'latest' : 'previous';
     return (
       <span className="inline-flex gap-2 items-center">
         <ui.VersionTagBadge
           tag={formatDate(entry.versionDateCreated)}
           titlePrefix="Work version created"
-          hideIcon
-          emphasis={emphasis}
+          icon={Calendar}
         />
         <DateWithPopover
           date={entry.run.date_modified}

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -18,6 +18,7 @@ import {
   getExtensionCheckServicesFromServerConfig,
   DateWithPopover,
   formatDate,
+  formatDatetime,
   Timeline,
   TimelineSection,
   CheckServiceRunTimelineItem,
@@ -211,20 +212,15 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
     return () => window.clearInterval(interval);
   }, [showDispatchingState, revalidator]);
 
-  const renderVersionTag = (entry: ServiceRunEntry) => {
+  const renderWorkVersionDate = (entry: ServiceRunEntry) => {
+    const versionDate = formatDate(entry.versionDateCreated, 'MMM dd, y HH:mm');
     return (
-      <span className="inline-flex gap-2 items-center">
-        <ui.VersionTagBadge
-          tag={formatDate(entry.versionDateCreated, 'MMM dd, y HH:mm')}
-          titlePrefix="Work version created"
-          icon={GitBranch}
-        />
-        <DateWithPopover
-          date={entry.run.date_modified}
-          dateCreated={entry.run.date_created}
-          dateModified={entry.run.date_modified}
-          className="text-xs text-muted-foreground"
-        />
+      <span
+        className="inline-flex gap-1.5 items-center text-[11px] text-muted-foreground"
+        title={formatDatetime(entry.versionDateCreated)}
+      >
+        <GitBranch className="size-3 shrink-0" aria-hidden />
+        <span>Work version: {versionDate}</span>
       </span>
     );
   };
@@ -293,7 +289,6 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
             (fallbackManifest ? ({ manifest: fallbackManifest } as any) : undefined);
 
           const workVersionIdForActivity = latest?.workVersionId ?? latestNonDraftWorkVersion.id;
-          const tag = latest ? renderVersionTag(latest) : null;
           const isLatestRunOnLatestVersion =
             latest != null && latest.workVersionId === latestNonDraftWorkVersion.id;
           const headerAction =
@@ -307,7 +302,7 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
 
           return (
             <div key={service.id} className="space-y-4">
-              <HeaderComponent tag={tag} action={headerAction} metadata={serviceMetadata} />
+              <HeaderComponent tag={null} action={headerAction} metadata={serviceMetadata} />
               <div className="space-y-0">
                 <ui.Card>
                   <ui.CardContent className="pt-6">
@@ -323,13 +318,28 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
                       checkRunDateModified={latest?.run.date_modified}
                     />
                   </ui.CardContent>
+                  {latest ? (
+                    <div className="flex justify-start px-6 py-2 border-t border-border">
+                      {renderWorkVersionDate(latest)}
+                    </div>
+                  ) : null}
                 </ui.Card>
                 {previous.length > 0 && (
                   <Timeline className="ml-3" nested>
                     {previous.map((entry) => (
                       <TimelineSection
                         key={entry.workVersionId}
-                        label={renderVersionTag(entry)}
+                        label={
+                          <span className="inline-flex gap-2 items-center">
+                            {renderWorkVersionDate(entry)}
+                            <DateWithPopover
+                              date={entry.run.date_modified}
+                              dateCreated={entry.run.date_created}
+                              dateModified={entry.run.date_modified}
+                              className="text-xs text-muted-foreground"
+                            />
+                          </span>
+                        }
                         nested
                       >
                         <CheckServiceRunTimelineItem

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
@@ -16,12 +16,14 @@ const workflows = { SIMPLE: SIMPLE_PUBLIC_WORKFLOW };
 describe('dbLoadWorkVersionsTimeline', () => {
   let mockPrisma: {
     workVersion: { findMany: ReturnType<typeof vi.fn> };
+    checkServiceRun: { findMany: ReturnType<typeof vi.fn> };
   };
 
   beforeEach(async () => {
     vi.clearAllMocks();
     mockPrisma = {
       workVersion: { findMany: vi.fn() },
+      checkServiceRun: { findMany: vi.fn() },
     };
     const { getPrismaClient } = await import('@curvenote/scms-server');
     vi.mocked(getPrismaClient).mockResolvedValue(mockPrisma as never);
@@ -61,6 +63,35 @@ describe('dbLoadWorkVersionsTimeline', () => {
         submissionVersions: [],
       },
     ]);
+    mockPrisma.checkServiceRun.findMany.mockResolvedValue([
+      {
+        id: 'run-2',
+        kind: 'proofig',
+        date_created: '2026-05-02T10:00:00.000Z',
+        date_modified: '2026-05-02T10:05:00.000Z',
+        data: { serviceData: { status: 'latest' } },
+        work_version_id: 'wv-2',
+        created_by_id: null,
+      },
+      {
+        id: 'run-1',
+        kind: 'proofig',
+        date_created: '2026-05-02T09:00:00.000Z',
+        date_modified: '2026-05-02T09:05:00.000Z',
+        data: { serviceData: { status: 'older' } },
+        work_version_id: 'wv-2',
+        created_by_id: null,
+      },
+      {
+        id: 'run-3',
+        kind: 'checks-text-integrity',
+        date_created: '2026-05-01T10:00:00.000Z',
+        date_modified: '2026-05-01T10:05:00.000Z',
+        data: { serviceData: { status: 'text' } },
+        work_version_id: 'wv-1',
+        created_by_id: null,
+      },
+    ]);
 
     const result = await dbLoadWorkVersionsTimeline('work-1', workflows);
 
@@ -86,6 +117,16 @@ describe('dbLoadWorkVersionsTimeline', () => {
             },
           },
         ],
+        checkRuns: [
+          {
+            id: 'run-2',
+            work_version_id: 'wv-2',
+            kind: 'proofig',
+            date_created: '2026-05-02T10:00:00.000Z',
+            date_modified: '2026-05-02T10:05:00.000Z',
+            data: { serviceData: { status: 'latest' } },
+          },
+        ],
       },
       {
         id: 'wv-1',
@@ -93,6 +134,16 @@ describe('dbLoadWorkVersionsTimeline', () => {
         date_modified: '2026-05-01T00:00:00.000Z',
         draft: false,
         submissionVersions: [],
+        checkRuns: [
+          {
+            id: 'run-3',
+            work_version_id: 'wv-1',
+            kind: 'checks-text-integrity',
+            date_created: '2026-05-01T10:00:00.000Z',
+            date_modified: '2026-05-01T10:05:00.000Z',
+            data: { serviceData: { status: 'text' } },
+          },
+        ],
       },
     ]);
   });

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.spec.ts
@@ -66,7 +66,7 @@ describe('dbLoadWorkVersionsTimeline', () => {
     mockPrisma.checkServiceRun.findMany.mockResolvedValue([
       {
         id: 'run-2',
-        kind: 'proofig',
+        kind: 'service-a',
         date_created: '2026-05-02T10:00:00.000Z',
         date_modified: '2026-05-02T10:05:00.000Z',
         data: { serviceData: { status: 'latest' } },
@@ -75,7 +75,7 @@ describe('dbLoadWorkVersionsTimeline', () => {
       },
       {
         id: 'run-1',
-        kind: 'proofig',
+        kind: 'service-a',
         date_created: '2026-05-02T09:00:00.000Z',
         date_modified: '2026-05-02T09:05:00.000Z',
         data: { serviceData: { status: 'older' } },
@@ -84,7 +84,7 @@ describe('dbLoadWorkVersionsTimeline', () => {
       },
       {
         id: 'run-3',
-        kind: 'checks-text-integrity',
+        kind: 'service-b',
         date_created: '2026-05-01T10:00:00.000Z',
         date_modified: '2026-05-01T10:05:00.000Z',
         data: { serviceData: { status: 'text' } },
@@ -121,7 +121,7 @@ describe('dbLoadWorkVersionsTimeline', () => {
           {
             id: 'run-2',
             work_version_id: 'wv-2',
-            kind: 'proofig',
+            kind: 'service-a',
             date_created: '2026-05-02T10:00:00.000Z',
             date_modified: '2026-05-02T10:05:00.000Z',
             data: { serviceData: { status: 'latest' } },
@@ -138,7 +138,7 @@ describe('dbLoadWorkVersionsTimeline', () => {
           {
             id: 'run-3',
             work_version_id: 'wv-1',
-            kind: 'checks-text-integrity',
+            kind: 'service-b',
             date_created: '2026-05-01T10:00:00.000Z',
             date_modified: '2026-05-01T10:05:00.000Z',
             data: { serviceData: { status: 'text' } },

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
@@ -1,5 +1,6 @@
 import { getPrismaClient } from '@curvenote/scms-server';
 import type { WorkVersionTimelineEntry, Workflow } from '@curvenote/scms-core';
+import { dbGetCheckServiceRunsByWorkVersionIds } from '../works.$workId/db.server.js';
 
 function siteLogoFromMetadata(metadata: unknown): string | undefined {
   if (!metadata || typeof metadata !== 'object' || !('logo' in metadata)) {
@@ -47,6 +48,26 @@ function mapSubmissionVersions(
     .sort((a, b) => a.site.name.localeCompare(b.site.name));
 }
 
+function latestCheckRunsByKind(
+  runs: Awaited<ReturnType<typeof dbGetCheckServiceRunsByWorkVersionIds>>[string] = [],
+): WorkVersionTimelineEntry['checkRuns'] {
+  const seenKinds = new Set<string>();
+  return runs
+    .filter((run) => {
+      if (seenKinds.has(run.kind)) return false;
+      seenKinds.add(run.kind);
+      return true;
+    })
+    .map((run) => ({
+      id: run.id,
+      work_version_id: run.work_version_id,
+      kind: run.kind,
+      date_created: run.date_created,
+      date_modified: run.date_modified,
+      data: run.data,
+    }));
+}
+
 /**
  * All work versions for the version-timeline hover card (newest first).
  */
@@ -91,6 +112,8 @@ export async function dbLoadWorkVersionsTimeline(
       },
     },
   });
+  const workVersionIds = rows.map((row) => row.id);
+  const runsByVersionId = await dbGetCheckServiceRunsByWorkVersionIds(workVersionIds);
 
   return rows.map((row) => ({
     id: row.id,
@@ -98,5 +121,6 @@ export async function dbLoadWorkVersionsTimeline(
     date_modified: row.date_modified,
     draft: row.draft,
     submissionVersions: mapSubmissionVersions(row.submissionVersions, workflows),
+    checkRuns: latestCheckRunsByKind(runsByVersionId[row.id]),
   }));
 }

--- a/platform/scms/app/routes/app/works.$workId/checkServiceRunSummaries.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId/checkServiceRunSummaries.spec.ts
@@ -1,0 +1,72 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import type { CheckServiceRunRow } from './db.server';
+import { getCheckRunSummaryByKind } from './checkServiceRunSummaries';
+
+function run(
+  id: string,
+  kind: string,
+  workVersionId: string,
+  dateCreated: string,
+): CheckServiceRunRow {
+  return {
+    id,
+    kind,
+    work_version_id: workVersionId,
+    date_created: dateCreated,
+    date_modified: dateCreated,
+    data: { serviceData: { id } },
+    created_by_id: null,
+  };
+}
+
+describe('getCheckRunSummaryByKind', () => {
+  it('selects the latest run per kind across non-draft versions', () => {
+    const summary = getCheckRunSummaryByKind(
+      [
+        { id: 'wv-3', date_created: '2026-01-03T00:00:00.000Z' },
+        { id: 'wv-2', date_created: '2026-01-02T00:00:00.000Z' },
+        { id: 'wv-1', date_created: '2026-01-01T00:00:00.000Z' },
+      ],
+      {
+        'wv-3': [run('proofig-new', 'proofig', 'wv-3', '2026-01-05T00:00:00.000Z')],
+        'wv-2': [
+          run('text-integrity-new', 'checks-text-integrity', 'wv-2', '2026-01-04T00:00:00.000Z'),
+        ],
+        'wv-1': [
+          run('proofig-old', 'proofig', 'wv-1', '2026-01-02T12:00:00.000Z'),
+          run('text-integrity-old', 'checks-text-integrity', 'wv-1', '2026-01-01T12:00:00.000Z'),
+        ],
+      },
+    );
+
+    expect(summary.latestRunByServiceKind.proofig.run.id).toBe('proofig-new');
+    expect(summary.latestRunByServiceKind.proofig.versionNumber).toBe(3);
+    expect(summary.latestRunByServiceKind['checks-text-integrity'].run.id).toBe(
+      'text-integrity-new',
+    );
+    expect(summary.latestRunByServiceKind['checks-text-integrity'].versionNumber).toBe(2);
+    expect(summary.previousRunsByServiceKind.proofig).toHaveLength(1);
+  });
+
+  it('dedupes multiple same-kind runs on a version to the first row supplied', () => {
+    const summary = getCheckRunSummaryByKind(
+      [
+        { id: 'wv-2', date_created: '2026-01-02T00:00:00.000Z' },
+        { id: 'wv-1', date_created: '2026-01-01T00:00:00.000Z' },
+      ],
+      {
+        'wv-2': [
+          run('latest-on-version', 'proofig', 'wv-2', '2026-01-03T00:00:00.000Z'),
+          run('older-on-version', 'proofig', 'wv-2', '2026-01-02T12:00:00.000Z'),
+        ],
+        'wv-1': [run('older-version', 'proofig', 'wv-1', '2026-01-01T12:00:00.000Z')],
+      },
+    );
+
+    expect(summary.latestRunByServiceKind.proofig.run.id).toBe('latest-on-version');
+    expect(summary.previousRunsByServiceKind.proofig.map((entry) => entry.run.id)).toEqual([
+      'older-version',
+    ]);
+  });
+});

--- a/platform/scms/app/routes/app/works.$workId/checkServiceRunSummaries.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId/checkServiceRunSummaries.spec.ts
@@ -29,24 +29,20 @@ describe('getCheckRunSummaryByKind', () => {
         { id: 'wv-1', date_created: '2026-01-01T00:00:00.000Z' },
       ],
       {
-        'wv-3': [run('proofig-new', 'proofig', 'wv-3', '2026-01-05T00:00:00.000Z')],
-        'wv-2': [
-          run('text-integrity-new', 'checks-text-integrity', 'wv-2', '2026-01-04T00:00:00.000Z'),
-        ],
+        'wv-3': [run('service-a-new', 'service-a', 'wv-3', '2026-01-05T00:00:00.000Z')],
+        'wv-2': [run('service-b-new', 'service-b', 'wv-2', '2026-01-04T00:00:00.000Z')],
         'wv-1': [
-          run('proofig-old', 'proofig', 'wv-1', '2026-01-02T12:00:00.000Z'),
-          run('text-integrity-old', 'checks-text-integrity', 'wv-1', '2026-01-01T12:00:00.000Z'),
+          run('service-a-old', 'service-a', 'wv-1', '2026-01-02T12:00:00.000Z'),
+          run('service-b-old', 'service-b', 'wv-1', '2026-01-01T12:00:00.000Z'),
         ],
       },
     );
 
-    expect(summary.latestRunByServiceKind.proofig.run.id).toBe('proofig-new');
-    expect(summary.latestRunByServiceKind.proofig.versionNumber).toBe(3);
-    expect(summary.latestRunByServiceKind['checks-text-integrity'].run.id).toBe(
-      'text-integrity-new',
-    );
-    expect(summary.latestRunByServiceKind['checks-text-integrity'].versionNumber).toBe(2);
-    expect(summary.previousRunsByServiceKind.proofig).toHaveLength(1);
+    expect(summary.latestRunByServiceKind['service-a'].run.id).toBe('service-a-new');
+    expect(summary.latestRunByServiceKind['service-a'].versionNumber).toBe(3);
+    expect(summary.latestRunByServiceKind['service-b'].run.id).toBe('service-b-new');
+    expect(summary.latestRunByServiceKind['service-b'].versionNumber).toBe(2);
+    expect(summary.previousRunsByServiceKind['service-a']).toHaveLength(1);
   });
 
   it('dedupes multiple same-kind runs on a version to the first row supplied', () => {
@@ -57,15 +53,15 @@ describe('getCheckRunSummaryByKind', () => {
       ],
       {
         'wv-2': [
-          run('latest-on-version', 'proofig', 'wv-2', '2026-01-03T00:00:00.000Z'),
-          run('older-on-version', 'proofig', 'wv-2', '2026-01-02T12:00:00.000Z'),
+          run('latest-on-version', 'service-a', 'wv-2', '2026-01-03T00:00:00.000Z'),
+          run('older-on-version', 'service-a', 'wv-2', '2026-01-02T12:00:00.000Z'),
         ],
-        'wv-1': [run('older-version', 'proofig', 'wv-1', '2026-01-01T12:00:00.000Z')],
+        'wv-1': [run('older-version', 'service-a', 'wv-1', '2026-01-01T12:00:00.000Z')],
       },
     );
 
-    expect(summary.latestRunByServiceKind.proofig.run.id).toBe('latest-on-version');
-    expect(summary.previousRunsByServiceKind.proofig.map((entry) => entry.run.id)).toEqual([
+    expect(summary.latestRunByServiceKind['service-a'].run.id).toBe('latest-on-version');
+    expect(summary.previousRunsByServiceKind['service-a'].map((entry) => entry.run.id)).toEqual([
       'older-version',
     ]);
   });

--- a/platform/scms/app/routes/app/works.$workId/checkServiceRunSummaries.ts
+++ b/platform/scms/app/routes/app/works.$workId/checkServiceRunSummaries.ts
@@ -1,0 +1,75 @@
+import type { CheckServiceRunRow } from './db.server';
+
+export type WorkVersionForCheckRunSummary = {
+  id: string;
+  date_created: string;
+};
+
+/** A check service run paired with the version context needed for display. */
+export type ServiceRunEntry = {
+  run: CheckServiceRunRow;
+  workVersionId: string;
+  /** Version number by date_created order (v1 = oldest). */
+  versionNumber: number;
+  /** ISO date for the work version (used for tooltip on the version tag). */
+  versionDateCreated: string;
+};
+
+export type CheckRunSummaryByKind = {
+  latestRunByServiceKind: Record<string, ServiceRunEntry>;
+  previousRunsByServiceKind: Record<string, ServiceRunEntry[]>;
+};
+
+export function getCheckRunSummaryByKind(
+  nonDraftVersions: WorkVersionForCheckRunSummary[],
+  runsByVersionId: Record<string, CheckServiceRunRow[]>,
+): CheckRunSummaryByKind {
+  // Version numbering: v1 = oldest (by date_created).
+  // Callers pass versions newest-first, so the highest number is first.
+  const versionNumberByWorkVersionId: Record<string, number> = {};
+  nonDraftVersions.forEach((version, index) => {
+    versionNumberByWorkVersionId[version.id] = nonDraftVersions.length - index;
+  });
+
+  // For each version, keep only that version's latest run per kind, then sort
+  // each kind by run date so the newest run across all versions is first.
+  const entriesByKind: Record<string, ServiceRunEntry[]> = {};
+  for (const version of nonDraftVersions) {
+    const runs = runsByVersionId[version.id] ?? [];
+    const seenKind = new Set<string>();
+    for (const run of runs) {
+      if (seenKind.has(run.kind)) continue;
+      seenKind.add(run.kind);
+      const list = entriesByKind[run.kind] ?? [];
+      list.push({
+        run,
+        workVersionId: version.id,
+        versionNumber: versionNumberByWorkVersionId[version.id] ?? 0,
+        versionDateCreated: version.date_created,
+      });
+      entriesByKind[run.kind] = list;
+    }
+  }
+
+  for (const kind of Object.keys(entriesByKind)) {
+    entriesByKind[kind].sort((a, b) =>
+      a.run.date_created > b.run.date_created
+        ? -1
+        : a.run.date_created < b.run.date_created
+          ? 1
+          : 0,
+    );
+  }
+
+  const latestRunByServiceKind: Record<string, ServiceRunEntry> = {};
+  const previousRunsByServiceKind: Record<string, ServiceRunEntry[]> = {};
+  for (const [kind, list] of Object.entries(entriesByKind)) {
+    const [head, ...rest] = list;
+    if (head) {
+      latestRunByServiceKind[kind] = head;
+    }
+    previousRunsByServiceKind[kind] = rest;
+  }
+
+  return { latestRunByServiceKind, previousRunsByServiceKind };
+}

--- a/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
@@ -15,6 +15,7 @@ type WorkListSummaryComponentProps = {
 
 export type WorkListCheckService = ClientExtensionCheckService & {
   workListSummaryComponent?: ComponentType<WorkListSummaryComponentProps>;
+  isWorkListSummaryVisible?: (metadata: unknown) => boolean;
 };
 
 type WorkCheckSummariesProps = {
@@ -82,10 +83,20 @@ export function WorkCheckSummaries({
 
   const serviceById = new Map(checkServices.map((service) => [service.id, service]));
   const summaries = Object.values(latestCheckRunsByServiceKind)
-    .map((entry) => ({ entry, service: serviceById.get(entry.run.kind) }))
+    .map((entry) => {
+      const service = serviceById.get(entry.run.kind);
+      return { entry, service, metadata: serviceDataFromRun(entry) };
+    })
     .filter(
-      (summary): summary is { entry: ServiceRunEntry; service: WorkListCheckService } =>
-        summary.service != null,
+      (
+        summary,
+      ): summary is {
+        entry: ServiceRunEntry;
+        service: WorkListCheckService;
+        metadata: unknown;
+      } =>
+        summary.service != null &&
+        (summary.service.isWorkListSummaryVisible?.(summary.metadata) ?? true),
     )
     .sort((a, b) =>
       a.entry.run.date_created > b.entry.run.date_created

--- a/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router';
 import type { ComponentType } from 'react';
 import type { ClientExtensionCheckService } from '@curvenote/scms-core';
-import { ui } from '@curvenote/scms-core';
+import { formatDate } from '@curvenote/scms-core';
 import type { ServiceRunEntry } from '../works.$workId/checkServiceRunSummaries';
 
 type WorkListSummaryComponentProps = {
@@ -19,7 +19,6 @@ export type WorkListCheckService = ClientExtensionCheckService & {
 
 type WorkCheckSummariesProps = {
   workId: string;
-  latestNonDraftWorkVersionId?: string;
   latestCheckRunsByServiceKind?: Record<string, ServiceRunEntry>;
   checkServices: WorkListCheckService[];
 };
@@ -74,7 +73,6 @@ function WorkCheckSummaryContent({
 
 export function WorkCheckSummaries({
   workId,
-  latestNonDraftWorkVersionId,
   latestCheckRunsByServiceKind,
   checkServices,
 }: WorkCheckSummariesProps) {
@@ -105,23 +103,16 @@ export function WorkCheckSummaries({
     <div className="flex justify-end mt-2">
       <div className="flex flex-wrap gap-2 justify-end items-center">
         {summaries.map(({ entry, service }) => {
-          const isLatestRunOnLatestVersion = entry.workVersionId === latestNonDraftWorkVersionId;
           return (
             <Link
               key={entry.run.id}
               to={`${workId}/checks`}
               className="inline-flex gap-2 items-center px-2 py-1 max-w-full text-xs rounded-sm border border-gray-200 bg-white text-gray-700 transition-colors hover:bg-gray-50 hover:text-blue-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-blue-300"
-              title={`${service.name} check run on version v${entry.versionNumber}`}
+              title={`${service.name} check run on work version created ${formatDate(entry.versionDateCreated)}`}
             >
               <span className="inline-flex gap-1.5 items-center min-w-0">
                 <WorkCheckSummaryContent service={service} entry={entry} />
               </span>
-              <ui.VersionTagBadge
-                tag={`v${entry.versionNumber}`}
-                emphasis={isLatestRunOnLatestVersion ? 'latest' : 'previous'}
-                hideIcon
-                className="py-0.5"
-              />
             </Link>
           );
         })}

--- a/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
@@ -1,7 +1,12 @@
 import { Link } from 'react-router';
 import type { ComponentType } from 'react';
 import type { ClientExtensionCheckService } from '@curvenote/scms-core';
-import { formatDate, ui } from '@curvenote/scms-core';
+import {
+  formatDate,
+  getCheckServiceRunServiceData,
+  isCheckWorkListSummaryVisible,
+  ui,
+} from '@curvenote/scms-core';
 import type { ServiceRunEntry } from '../works.$workId/checkServiceRunSummaries';
 
 type WorkListSummaryComponentProps = {
@@ -25,14 +30,6 @@ type WorkCheckSummariesProps = {
   checkServices: WorkListCheckService[];
 };
 
-function serviceDataFromRun(entry: ServiceRunEntry): unknown {
-  return entry.run.data != null &&
-    typeof entry.run.data === 'object' &&
-    'serviceData' in entry.run.data
-    ? (entry.run.data as { serviceData?: unknown }).serviceData
-    : undefined;
-}
-
 function WorkCheckSummaryContent({
   service,
   entry,
@@ -41,7 +38,7 @@ function WorkCheckSummaryContent({
   entry: ServiceRunEntry;
 }) {
   const SummaryComponent = service.workListSummaryComponent;
-  const metadata = serviceDataFromRun(entry);
+  const metadata = getCheckServiceRunServiceData(entry.run);
 
   if (SummaryComponent) {
     return (
@@ -86,7 +83,7 @@ export function WorkCheckSummaries({
   const summaries = Object.values(latestCheckRunsByServiceKind)
     .map((entry) => {
       const service = serviceById.get(entry.run.kind);
-      return { entry, service, metadata: serviceDataFromRun(entry) };
+      return { entry, service, metadata: getCheckServiceRunServiceData(entry.run) };
     })
     .filter(
       (
@@ -96,8 +93,7 @@ export function WorkCheckSummaries({
         service: WorkListCheckService;
         metadata: unknown;
       } =>
-        summary.service != null &&
-        (summary.service.isWorkListSummaryVisible?.(summary.metadata) ?? true),
+        summary.service != null && isCheckWorkListSummaryVisible(summary.service, summary.metadata),
     )
     .sort((a, b) =>
       a.entry.run.date_created > b.entry.run.date_created

--- a/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
@@ -125,9 +125,9 @@ export function WorkCheckSummaries({
             >
               <Link
                 to={`${workId}/checks`}
-                className="inline-flex gap-2 items-center px-2 py-1 max-w-full text-xs rounded-sm border border-gray-200 bg-white text-gray-700 transition-colors hover:bg-gray-50 hover:text-blue-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-blue-300"
+                className="inline-flex gap-2 items-center h-7 px-2 max-w-full text-xs rounded-sm border border-gray-200 bg-white text-gray-700 transition-colors hover:bg-gray-50 hover:text-blue-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-blue-300"
               >
-                <span className="inline-flex gap-1.5 items-center min-w-0">
+                <span className="inline-flex gap-1.5 items-center h-5 min-w-0">
                   <WorkCheckSummaryContent service={service} entry={entry} />
                 </span>
               </Link>

--- a/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
@@ -11,6 +11,7 @@ type WorkListSummaryComponentProps = {
   checkServiceId: string;
   checkServiceName: string;
   checkRunDateModified: string;
+  compact?: boolean;
 };
 
 export type WorkListCheckService = ClientExtensionCheckService & {

--- a/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
@@ -1,0 +1,131 @@
+import { Link } from 'react-router';
+import type { ComponentType } from 'react';
+import type { ClientExtensionCheckService } from '@curvenote/scms-core';
+import { ui } from '@curvenote/scms-core';
+import type { ServiceRunEntry } from '../works.$workId/checkServiceRunSummaries';
+
+type WorkListSummaryComponentProps = {
+  metadata: any;
+  checkRunId: string;
+  workVersionId: string;
+  checkServiceId: string;
+  checkServiceName: string;
+  checkRunDateModified: string;
+};
+
+export type WorkListCheckService = ClientExtensionCheckService & {
+  workListSummaryComponent?: ComponentType<WorkListSummaryComponentProps>;
+};
+
+type WorkCheckSummariesProps = {
+  workId: string;
+  latestNonDraftWorkVersionId?: string;
+  latestCheckRunsByServiceKind?: Record<string, ServiceRunEntry>;
+  checkServices: WorkListCheckService[];
+};
+
+function serviceDataFromRun(entry: ServiceRunEntry): unknown {
+  return entry.run.data != null &&
+    typeof entry.run.data === 'object' &&
+    'serviceData' in entry.run.data
+    ? (entry.run.data as { serviceData?: unknown }).serviceData
+    : undefined;
+}
+
+function WorkCheckSummaryContent({
+  service,
+  entry,
+}: {
+  service: WorkListCheckService;
+  entry: ServiceRunEntry;
+}) {
+  const SummaryComponent = service.workListSummaryComponent;
+  const metadata = serviceDataFromRun(entry);
+
+  if (SummaryComponent) {
+    return (
+      <SummaryComponent
+        metadata={metadata}
+        checkRunId={entry.run.id}
+        workVersionId={entry.workVersionId}
+        checkServiceId={service.id}
+        checkServiceName={service.name}
+        checkRunDateModified={entry.run.date_modified}
+      />
+    );
+  }
+
+  const SummaryTitleComponent = service.sectionSummaryTitleComponent;
+  const SummaryBadgeComponent = service.sectionSummaryBadgeComponent;
+
+  return (
+    <>
+      {SummaryTitleComponent ? (
+        <span className="flex items-center min-w-0 max-w-32 [&_img]:max-h-4 [&_svg]:max-h-4">
+          <SummaryTitleComponent metadata={metadata} />
+        </span>
+      ) : (
+        <span className="truncate">{service.name}</span>
+      )}
+      {SummaryBadgeComponent ? <SummaryBadgeComponent metadata={metadata} /> : null}
+    </>
+  );
+}
+
+export function WorkCheckSummaries({
+  workId,
+  latestNonDraftWorkVersionId,
+  latestCheckRunsByServiceKind,
+  checkServices,
+}: WorkCheckSummariesProps) {
+  if (!latestCheckRunsByServiceKind || Object.keys(latestCheckRunsByServiceKind).length === 0) {
+    return null;
+  }
+
+  const serviceById = new Map(checkServices.map((service) => [service.id, service]));
+  const summaries = Object.values(latestCheckRunsByServiceKind)
+    .map((entry) => ({ entry, service: serviceById.get(entry.run.kind) }))
+    .filter(
+      (summary): summary is { entry: ServiceRunEntry; service: WorkListCheckService } =>
+        summary.service != null,
+    )
+    .sort((a, b) =>
+      a.entry.run.date_created > b.entry.run.date_created
+        ? -1
+        : a.entry.run.date_created < b.entry.run.date_created
+          ? 1
+          : 0,
+    );
+
+  if (summaries.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex justify-end mt-2">
+      <div className="flex flex-wrap gap-2 justify-end items-center">
+        {summaries.map(({ entry, service }) => {
+          const isLatestRunOnLatestVersion = entry.workVersionId === latestNonDraftWorkVersionId;
+          return (
+            <Link
+              key={entry.run.id}
+              to={`${workId}/checks`}
+              className="inline-flex gap-2 items-center px-2 py-1 max-w-full text-xs rounded-sm border border-gray-200 bg-white text-gray-700 transition-colors hover:bg-gray-50 hover:text-blue-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-blue-300"
+              title={`${service.name} check run on version v${entry.versionNumber}`}
+            >
+              <span className="inline-flex gap-1.5 items-center min-w-0">
+                <WorkCheckSummaryContent service={service} entry={entry} />
+              </span>
+              <ui.VersionTagBadge
+                tag={`v${entry.versionNumber}`}
+                emphasis={isLatestRunOnLatestVersion ? 'latest' : 'previous'}
+                hideIcon
+                className="py-0.5"
+              />
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
@@ -117,7 +117,9 @@ export function WorkCheckSummaries({
           return (
             <ui.SimpleTooltip
               key={entry.run.id}
-              title={`${service.name} check was run on ${formatDate(entry.run.date_created)}`}
+              title={`${service.name} check was run on ${formatDate(
+                entry.run.date_created,
+              )} on the work version dated ${formatDate(entry.versionDateCreated)}`}
               side="top"
               sideOffset={6}
             >

--- a/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
@@ -106,9 +106,7 @@ export function WorkCheckSummaries({
           return (
             <ui.SimpleTooltip
               key={entry.run.id}
-              title={`${service.name} check run on work version created ${formatDate(
-                entry.versionDateCreated,
-              )}`}
+              title={`${service.name} check was run on ${formatDate(entry.run.date_created)}`}
               side="top"
               sideOffset={6}
             >

--- a/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router';
 import type { ComponentType } from 'react';
 import type { ClientExtensionCheckService } from '@curvenote/scms-core';
-import { formatDate } from '@curvenote/scms-core';
+import { formatDate, ui } from '@curvenote/scms-core';
 import type { ServiceRunEntry } from '../works.$workId/checkServiceRunSummaries';
 
 type WorkListSummaryComponentProps = {
@@ -104,16 +104,23 @@ export function WorkCheckSummaries({
       <div className="flex flex-wrap gap-2 justify-start items-center">
         {summaries.map(({ entry, service }) => {
           return (
-            <Link
+            <ui.SimpleTooltip
               key={entry.run.id}
-              to={`${workId}/checks`}
-              className="inline-flex gap-2 items-center px-2 py-1 max-w-full text-xs rounded-sm border border-gray-200 bg-white text-gray-700 transition-colors hover:bg-gray-50 hover:text-blue-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-blue-300"
-              title={`${service.name} check run on work version created ${formatDate(entry.versionDateCreated)}`}
+              title={`${service.name} check run on work version created ${formatDate(
+                entry.versionDateCreated,
+              )}`}
+              side="top"
+              sideOffset={6}
             >
-              <span className="inline-flex gap-1.5 items-center min-w-0">
-                <WorkCheckSummaryContent service={service} entry={entry} />
-              </span>
-            </Link>
+              <Link
+                to={`${workId}/checks`}
+                className="inline-flex gap-2 items-center px-2 py-1 max-w-full text-xs rounded-sm border border-gray-200 bg-white text-gray-700 transition-colors hover:bg-gray-50 hover:text-blue-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-blue-300"
+              >
+                <span className="inline-flex gap-1.5 items-center min-w-0">
+                  <WorkCheckSummaryContent service={service} entry={entry} />
+                </span>
+              </Link>
+            </ui.SimpleTooltip>
           );
         })}
       </div>

--- a/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkCheckSummaries.tsx
@@ -100,8 +100,8 @@ export function WorkCheckSummaries({
   }
 
   return (
-    <div className="flex justify-end mt-2">
-      <div className="flex flex-wrap gap-2 justify-end items-center">
+    <div className="flex justify-start mt-2">
+      <div className="flex flex-wrap gap-2 justify-start items-center">
         {summaries.map(({ entry, service }) => {
           return (
             <Link

--- a/platform/scms/app/routes/app/works._index/WorkList.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkList.tsx
@@ -1,5 +1,6 @@
 import { ui } from '@curvenote/scms-core';
 import { WorkListItem } from './WorkListItem';
+import type { WorkListCheckService } from './WorkCheckSummaries';
 import { WorksClientSearch } from './WorksClientSearch';
 import {
   filterWorks,
@@ -15,13 +16,15 @@ import type { WorkWithRole } from './ClientListingHelpers';
 export function WorkList({
   items,
   workflows,
+  checkServices,
 }: {
   items: Promise<WorkWithRole[]>;
   workflows: Record<string, any>;
+  checkServices: WorkListCheckService[];
 }) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const renderItem = (work: WorkWithRole, _globalIndex: number, _localIndex?: number) => (
-    <WorkListItem work={work} workflows={workflows} />
+    <WorkListItem work={work} workflows={workflows} checkServices={checkServices} />
   );
 
   const renderGroup = (

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -195,6 +195,7 @@ export function WorkListItem({
           <WorkVersionTimelineHoverCard
             versionsUrl={workVersionsUrl}
             workId={work.id}
+            checkServices={checkServices}
             align="end"
             side="left"
             title="Work Timeline"

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -44,6 +44,18 @@ export function WorkListItem({
   const publishedDate = latestVersion?.date;
 
   const workVersionsUrl = workVersionsTimelineUrl(work.id);
+  const showWorkDoi = Boolean(work.doi && work.doi !== latestVersion?.doi);
+  const showVersionDoi = Boolean(latestVersion?.doi);
+  const submissionsWithBadges = work.submissions
+    .map((submission) => {
+      const latestNonDraftSubmissionVersion = submission.versions?.[0];
+      const workflowKey = submission.collection?.workflow;
+      const workflow = workflowKey ? workflows[workflowKey] : undefined;
+      if (!latestNonDraftSubmissionVersion || !workflowKey || !workflow) return null;
+      return { submission, latestNonDraftSubmissionVersion, workflowKey, workflow };
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => entry != null);
+  const showBadgeRow = showWorkDoi || showVersionDoi || submissionsWithBadges.length > 0;
 
   return (
     <div className="px-6 py-4">
@@ -72,86 +84,83 @@ export function WorkListItem({
             )}
           </div>
 
-          {/* Show SubmissionVersionBadge for each submission with latest version */}
-          <div className="flex flex-wrap gap-2 items-center mt-2">
-            {work.doi && work.doi !== latestVersion?.doi && (
-              <ui.Badge variant="outline-muted" asChild>
-                <a
-                  href={work.doi.startsWith('http') ? work.doi : `https://doi.org/${work.doi}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex gap-1 items-center text-xs"
-                >
-                  Work DOI: {work.doi.replace('https://doi.org/', '')}
-                  <ExternalLink className="w-2.5 h-2.5" />
-                </a>
-              </ui.Badge>
-            )}
-            {latestVersion?.doi && (
-              <ui.Badge variant="outline-muted" asChild>
-                <a
-                  href={
-                    latestVersion.doi.startsWith('http')
-                      ? latestVersion.doi
-                      : `https://doi.org/${latestVersion.doi}`
-                  }
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex gap-1 items-center text-xs"
-                >
-                  DOI: {latestVersion.doi.replace('https://doi.org/', '')}
-                  <ExternalLink className="w-2.5 h-2.5" />
-                </a>
-              </ui.Badge>
-            )}
-            {work.submissions
-              .filter((submission) => submission.versions && submission.versions.length > 0)
-              .map((submission) => {
-                // `dbGetWorksAndSubmissionVersions` already filters out DRAFT submission versions.
-                const latestNonDraftSubmissionVersion = submission.versions[0];
-
-                // Guard against null/undefined collection
-                if (!submission.collection?.workflow) return null;
-
-                const workflow = workflows[submission.collection.workflow];
-
-                if (!latestNonDraftSubmissionVersion || !workflow) return null;
-
-                return (
-                  <SubmissionVersionTimelineHoverCard
-                    key={`submission-badge-${submission.id}`}
-                    versionsUrl={submissionVersionsTimelineUrl(submission.site.name, submission.id)}
-                    title={`Submissions at ${submission.site.title || submission.site.name}`}
+          {showBadgeRow && (
+            <div className="flex flex-wrap gap-2 items-center mt-2">
+              {work.doi && work.doi !== latestVersion?.doi && (
+                <ui.Badge variant="outline-muted" asChild>
+                  <a
+                    href={work.doi.startsWith('http') ? work.doi : `https://doi.org/${work.doi}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex gap-1 items-center text-xs"
                   >
-                    <ui.SubmissionVersionBadge
-                      submissionVersion={{
-                        id: latestNonDraftSubmissionVersion.id,
-                        status: latestNonDraftSubmissionVersion.status,
-                        submission: {
-                          id: submission.id,
-                          collection: {
-                            workflow: submission.collection.workflow,
+                    Work DOI: {work.doi.replace('https://doi.org/', '')}
+                    <ExternalLink className="w-2.5 h-2.5" />
+                  </a>
+                </ui.Badge>
+              )}
+              {latestVersion?.doi && (
+                <ui.Badge variant="outline-muted" asChild>
+                  <a
+                    href={
+                      latestVersion.doi.startsWith('http')
+                        ? latestVersion.doi
+                        : `https://doi.org/${latestVersion.doi}`
+                    }
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex gap-1 items-center text-xs"
+                  >
+                    DOI: {latestVersion.doi.replace('https://doi.org/', '')}
+                    <ExternalLink className="w-2.5 h-2.5" />
+                  </a>
+                </ui.Badge>
+              )}
+              {submissionsWithBadges.map(
+                ({ submission, latestNonDraftSubmissionVersion, workflowKey, workflow }) => {
+                  // `dbGetWorksAndSubmissionVersions` already filters out DRAFT submission versions.
+                  return (
+                    <SubmissionVersionTimelineHoverCard
+                      key={`submission-badge-${submission.id}`}
+                      versionsUrl={submissionVersionsTimelineUrl(
+                        submission.site.name,
+                        submission.id,
+                      )}
+                      title={`Submissions at ${submission.site.title || submission.site.name}`}
+                    >
+                      <ui.SubmissionVersionBadge
+                        submissionVersion={{
+                          id: latestNonDraftSubmissionVersion.id,
+                          status: latestNonDraftSubmissionVersion.status,
+                          submission: {
+                            id: submission.id,
+                            collection: {
+                              workflow: workflowKey,
+                            },
+                            site: {
+                              name: submission.site.name,
+                              title: submission.site.title,
+                              metadata: submission.site.metadata,
+                            },
                           },
-                          site: {
-                            name: submission.site.name,
-                            title: submission.site.title,
-                            metadata: submission.site.metadata,
-                          },
-                        },
-                      }}
-                      workflows={{ [submission.collection.workflow]: workflow }}
-                      basePath={`/app/works/${work.id}`}
-                      workVersionId={
-                        latestNonDraftSubmissionVersion.work_version?.id || latestVersion?.id || ''
-                      }
-                      showSite
-                      showLink={false}
-                      variant="outline"
-                    />
-                  </SubmissionVersionTimelineHoverCard>
-                );
-              })}
-          </div>
+                        }}
+                        workflows={{ [workflowKey]: workflow }}
+                        basePath={`/app/works/${work.id}`}
+                        workVersionId={
+                          latestNonDraftSubmissionVersion.work_version?.id ||
+                          latestVersion?.id ||
+                          ''
+                        }
+                        showSite
+                        showLink={false}
+                        variant="outline"
+                      />
+                    </SubmissionVersionTimelineHoverCard>
+                  );
+                },
+              )}
+            </div>
+          )}
           <WorkCheckSummaries
             workId={work.id}
             latestCheckRunsByServiceKind={work.latestCheckRunsByServiceKind}

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -154,7 +154,6 @@ export function WorkListItem({
           </div>
           <WorkCheckSummaries
             workId={work.id}
-            latestNonDraftWorkVersionId={latestVersion?.id}
             latestCheckRunsByServiceKind={work.latestCheckRunsByServiceKind}
             checkServices={checkServices}
           />

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -11,15 +11,19 @@ import {
 } from '@curvenote/scms-core';
 import { ExternalLink, Timeline } from 'lucide-react';
 import type { dbGetWorksAndSubmissionVersions } from './db.server';
+import type { WorkListCheckService } from './WorkCheckSummaries';
+import { WorkCheckSummaries } from './WorkCheckSummaries';
 
 export type WorkCardDBO = Awaited<ReturnType<typeof dbGetWorksAndSubmissionVersions>>[0];
 
 export function WorkListItem({
   work,
   workflows,
+  checkServices,
 }: {
   work: WorkCardDBO;
   workflows: Record<string, any>;
+  checkServices: WorkListCheckService[];
 }) {
   const lastActivity = work.submissions
     .map((submission) => submission.activity?.[0])
@@ -38,11 +42,6 @@ export function WorkListItem({
   // Get the latest non-draft version info for title/authors/published
   const latestVersion = work.versions.find((version) => !version.draft);
   const publishedDate = latestVersion?.date;
-
-  // Check if work has submissions with slugs
-  const hasSlug = work.submissions.some(
-    (submission) => submission.slugs && submission.slugs.length > 0,
-  );
 
   const workVersionsUrl = workVersionsTimelineUrl(work.id);
 
@@ -73,8 +72,8 @@ export function WorkListItem({
             )}
           </div>
 
-          {/* DOI Links as Badges */}
-          <div className="flex flex-wrap gap-2 items-center">
+          {/* Show SubmissionVersionBadge for each submission with latest version */}
+          <div className="flex flex-wrap gap-2 items-center mt-2">
             {work.doi && work.doi !== latestVersion?.doi && (
               <ui.Badge variant="outline-muted" asChild>
                 <a
@@ -105,22 +104,6 @@ export function WorkListItem({
                 </a>
               </ui.Badge>
             )}
-            {hasSlug && (
-              <primitives.Chip
-                className="text-sky-700 border-[1px] border-sky-700 dark:border-sky-300 dark:text-sky-300"
-                title="Work has slug"
-              >
-                Slug
-              </primitives.Chip>
-            )}
-            <ui.TagChips
-              tags={[...(latestVersion?.tags ?? latestWorkVersion?.tags ?? [])]}
-              limit={6}
-              titlePrefix="Tag"
-            />
-          </div>
-          {/* Show SubmissionVersionBadge for each submission with latest version */}
-          <div className="flex flex-wrap gap-2 mt-2">
             {work.submissions
               .filter((submission) => submission.versions && submission.versions.length > 0)
               .map((submission) => {
@@ -169,6 +152,12 @@ export function WorkListItem({
                 );
               })}
           </div>
+          <WorkCheckSummaries
+            workId={work.id}
+            latestNonDraftWorkVersionId={latestVersion?.id}
+            latestCheckRunsByServiceKind={work.latestCheckRunsByServiceKind}
+            checkServices={checkServices}
+          />
         </div>
 
         {/* Column 2: Activity and Date */}

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -169,8 +169,8 @@ export function WorkListItem({
         </div>
 
         {/* Column 2: Activity and Date */}
-        <div className="flex flex-col flex-shrink-0 items-center self-stretch w-48 pt-[1px]">
-          <div className="flex flex-wrap gap-2 justify-center mb-2 w-full">
+        <div className="flex flex-col flex-shrink-0 items-start self-stretch w-48 pt-[1px]">
+          <div className="flex flex-wrap gap-2 justify-start mb-2 w-full">
             {activityTime && (
               <primitives.Chip
                 className="text-gray-500 border-[1px] border-gray-200 dark:border-gray-500 dark:text-gray-500"

--- a/platform/scms/app/routes/app/works._index/db.server.ts
+++ b/platform/scms/app/routes/app/works._index/db.server.ts
@@ -8,6 +8,8 @@ import {
 import type { WorkRole, WorkVersion } from '@curvenote/scms-db';
 import type { SecureContext } from '@curvenote/scms-server';
 import { previewCacheObjectIds } from '../works.$workId.upload.$workVersionId/metadata-extract/previewCache';
+import { dbGetCheckServiceRunsByWorkVersionIds } from '../works.$workId/db.server';
+import { getCheckRunSummaryByKind } from '../works.$workId/checkServiceRunSummaries';
 
 export async function dbGetWorksAndSubmissionVersions(userId: string) {
   const prisma = await getPrismaClient();
@@ -118,9 +120,27 @@ export async function dbGetWorksAndSubmissionVersions(userId: string) {
   });
 
   // Drop works that are single-version + single DRAFT-only submission (no visible submissions)
-  return mapped
+  const visibleWorks = mapped
     .filter((w) => !w.excludeAsSingleDraftSubmissionWork)
-    .map(({ excludeAsSingleDraftSubmissionWork: _dropped, ...w }) => w);
+    .map((work) => {
+      const { excludeAsSingleDraftSubmissionWork, ...visibleWork } = work;
+      void excludeAsSingleDraftSubmissionWork;
+      return visibleWork;
+    });
+
+  const nonDraftVersionIds = visibleWorks.flatMap((work) =>
+    work.versions.filter((version) => !version.draft).map((version) => version.id),
+  );
+  const runsByVersionId = await dbGetCheckServiceRunsByWorkVersionIds(nonDraftVersionIds);
+
+  return visibleWorks.map((work) => {
+    const nonDraftVersions = work.versions.filter((version) => !version.draft);
+    const { latestRunByServiceKind } = getCheckRunSummaryByKind(nonDraftVersions, runsByVersionId);
+    return {
+      ...work,
+      latestCheckRunsByServiceKind: latestRunByServiceKind,
+    };
+  });
 }
 
 /**

--- a/platform/scms/app/routes/app/works._index/route.tsx
+++ b/platform/scms/app/routes/app/works._index/route.tsx
@@ -14,6 +14,8 @@ import {
   joinPageTitle,
   getWorkflows,
   registerExtensionWorkflows,
+  getExtensionCheckServicesFromClientConfig,
+  useDeploymentConfig,
   scopes,
   capitalize,
   plural,
@@ -24,10 +26,10 @@ import { PlusCircle } from 'lucide-react';
 import { z } from 'zod';
 import { zfd } from 'zod-form-data';
 import { WorkList } from './WorkList';
+import type { WorkListCheckService } from './WorkCheckSummaries';
 import { dbGetWorksAndSubmissionVersions, dangerouslyDeleteDraftWork } from './db.server';
 import { getValidDraftWorksForUser } from './getDrafts.server';
 import { extensions } from '../../../extensions/client';
-import { extensions as serverExtensions } from '../../../extensions/server';
 
 // Action schema for handling draft work intents
 const WorksActionSchema = zfd.formData({
@@ -213,6 +215,11 @@ export function shouldRevalidate({
 export default function MyWorks({ loaderData }: Route.ComponentProps) {
   const { items, workflows, error, canUpload, stringReplacements } = loaderData;
   const navigate = useNavigate();
+  const deploymentConfig = useDeploymentConfig();
+  const checkServices = getExtensionCheckServicesFromClientConfig(
+    deploymentConfig,
+    extensions,
+  ) as WorkListCheckService[];
   const workLabel = stringReplacements.work;
   const worksLabel = plural(`${workLabel}(s)`, 2);
   const worksTitle = capitalize(worksLabel);
@@ -221,7 +228,7 @@ export default function MyWorks({ loaderData }: Route.ComponentProps) {
     <div className="max-w-[900px]">
       {/* Works List Section without title when no tasks */}
       {error && <div className="p-2 my-2 text-red-600 bg-red-50">{error}</div>}
-      {items && <WorkList items={items} workflows={workflows} />}
+      {items && <WorkList items={items} workflows={workflows} checkServices={checkServices} />}
     </div>
   );
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds extra DB reads on My Works (all non-draft version IDs) and extends the public extension API; behavior is mostly read-only UI with tested summary logic.
> 
> **Overview**
> Surfaces **latest check run summaries** on the **My Works** list and in the **Work Timeline** hover popover, with a new extension hook so each check service can supply compact list content.
> 
> Extensions can register **`workListSummaryComponent`** and optional **`isWorkListSummaryVisible`**; the platform owns chips, links to `/checks`, and tooltips. Shared helpers **`getCheckServiceRunServiceData`** and **`isCheckWorkListSummaryVisible`** drive both surfaces.
> 
> **Data:** My Works loader batches check runs for all non-draft versions and attaches **`latestCheckRunsByServiceKind`** per work. The versions timeline loader adds **`checkRuns`** (latest per kind per version). **`getCheckRunSummaryByKind`** is extracted from the checks page loader and reused there and on the listing.
> 
> **Checks page:** Section headers no longer show version tags; the latest run card shows work version date (branch icon), and history timeline labels use that date plus run timestamps.
> 
> Minor My Works row tweaks: DOI/submission badges only when needed; check summaries sit below that row; timeline popover is wider on small viewports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e82d34f5ddde496de9821ebefd70101c7d4ef0ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->