### PR TITLE
📋 enable data driven forms for work creation

### DIFF
--- a/.changeset/bright-works-gather.md
+++ b/.changeset/bright-works-gather.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-core': minor
+'@curvenote/scms': minor
+---
+
+Add a create-work flow registry with `WorkCreateOption`, metadata resolution, and a `CreateWorkDropdown` on My Works. Route create-new-version via extension handlers based on work metadata, and skip the upload redirect for draft PMC deposit routes in the works layout.

--- a/packages/scms-core/src/components/CreateWorkDropdown.tsx
+++ b/packages/scms-core/src/components/CreateWorkDropdown.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronUp, PlusCircle } from 'lucide-react';
+import { useNavigate } from 'react-router';
+import type { WorkCreateOption } from '../modules/extensions/types.js';
+import { Button } from './ui/button.js';
+import { Menu, MenuContent, MenuItem, MenuTrigger } from './ui/menu.js';
+import { cn } from '../utils/cn.js';
+
+export interface CreateWorkDropdownProps {
+  options: WorkCreateOption[];
+  /** Primary button label when multiple options exist (e.g. "Create new work"). */
+  triggerLabel: string;
+  disabled?: boolean;
+  className?: string;
+  onDisabledClick?: () => void;
+}
+
+export function CreateWorkDropdown({
+  options,
+  triggerLabel,
+  disabled = false,
+  className,
+  onDisabledClick,
+}: CreateWorkDropdownProps) {
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+
+  const handleSelect = (option: WorkCreateOption) => {
+    setOpen(false);
+    navigate(option.startPath);
+  };
+
+  if (disabled) {
+    return (
+      <Button
+        type="button"
+        size="lg"
+        variant="default"
+        className={cn('inline-flex gap-2 items-center', className)}
+        onClick={onDisabledClick}
+      >
+        <PlusCircle className="w-4 h-4" />
+        {triggerLabel}
+      </Button>
+    );
+  }
+
+  if (options.length <= 1) {
+    const only = options[0];
+    return (
+      <Button
+        type="button"
+        size="lg"
+        variant="default"
+        className={cn('inline-flex gap-2 items-center', className)}
+        onClick={() => (only ? navigate(only.startPath) : undefined)}
+      >
+        <PlusCircle className="w-4 h-4" />
+        {triggerLabel}
+      </Button>
+    );
+  }
+
+  const primary = options[0];
+
+  return (
+    <div className={cn('flex rounded-md shadow-sm', className)} role="group">
+      <Button
+        type="button"
+        size="lg"
+        variant="default"
+        className="inline-flex flex-1 gap-2 items-center min-w-0 rounded-r-none border-r border-white/30"
+        onClick={() => navigate(primary.startPath)}
+      >
+        <PlusCircle className="w-4 h-4 shrink-0" />
+        {triggerLabel}
+      </Button>
+      <Menu open={open} onOpenChange={setOpen}>
+        <MenuTrigger asChild>
+          <Button
+            type="button"
+            size="lg"
+            variant="default"
+            className={cn(
+              'px-2 rounded-l-none border-l-0 border-white/30 transition-colors',
+              open && 'bg-primary/60',
+            )}
+            aria-label="Choose work type to create"
+          >
+            {open ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
+          </Button>
+        </MenuTrigger>
+        <MenuContent className="min-w-[14rem] p-1" align="end" sideOffset={4}>
+          {options.map((option) => (
+            <MenuItem
+              key={option.id}
+              className="flex flex-col gap-0.5 items-start px-3 py-2 text-sm"
+              onSelect={(e) => {
+                e.preventDefault();
+                handleSelect(option);
+              }}
+            >
+              <span className="font-medium">{option.label}</span>
+              {option.description ? (
+                <span className="text-xs text-muted-foreground">{option.description}</span>
+              ) : null}
+            </MenuItem>
+          ))}
+        </MenuContent>
+      </Menu>
+    </div>
+  );
+}

--- a/packages/scms-core/src/components/CreateWorkDropdown.tsx
+++ b/packages/scms-core/src/components/CreateWorkDropdown.tsx
@@ -91,21 +91,27 @@ export function CreateWorkDropdown({
           </Button>
         </MenuTrigger>
         <MenuContent className="min-w-[14rem] p-1" align="end" sideOffset={4}>
-          {options.map((option) => (
-            <MenuItem
-              key={option.id}
-              className="flex flex-col gap-0.5 items-start px-3 py-2 text-sm"
-              onSelect={(e) => {
-                e.preventDefault();
-                handleSelect(option);
-              }}
-            >
-              <span className="font-medium">{option.label}</span>
-              {option.description ? (
-                <span className="text-xs text-muted-foreground">{option.description}</span>
-              ) : null}
-            </MenuItem>
-          ))}
+          {options.map((option) => {
+            const Icon = option.icon;
+            return (
+              <MenuItem
+                key={option.id}
+                className="flex gap-3 items-start px-3 py-2 text-sm"
+                onSelect={(e) => {
+                  e.preventDefault();
+                  handleSelect(option);
+                }}
+              >
+                {Icon ? <Icon className="mt-0.5 w-5 h-5 shrink-0 text-muted-foreground" /> : null}
+                <div className="flex flex-col gap-0.5 items-start min-w-0">
+                  <span className="font-medium">{option.label}</span>
+                  {option.description ? (
+                    <span className="text-xs text-muted-foreground">{option.description}</span>
+                  ) : null}
+                </div>
+              </MenuItem>
+            );
+          })}
         </MenuContent>
       </Menu>
     </div>

--- a/packages/scms-core/src/components/CreateWorkDropdown.tsx
+++ b/packages/scms-core/src/components/CreateWorkDropdown.tsx
@@ -36,7 +36,7 @@ export function CreateWorkDropdown({
         type="button"
         size="lg"
         variant="default"
-        className={cn('inline-flex gap-2 items-center', className)}
+        className={cn('inline-flex gap-1.5 items-center w-fit shrink-0 px-4', className)}
         onClick={onDisabledClick}
       >
         <PlusCircle className="w-4 h-4" />
@@ -52,7 +52,7 @@ export function CreateWorkDropdown({
         type="button"
         size="lg"
         variant="default"
-        className={cn('inline-flex gap-2 items-center', className)}
+        className={cn('inline-flex gap-1.5 items-center w-fit shrink-0 px-4', className)}
         onClick={() => (only ? navigate(only.startPath) : undefined)}
       >
         <PlusCircle className="w-4 h-4" />
@@ -68,7 +68,7 @@ export function CreateWorkDropdown({
           type="button"
           size="lg"
           variant="default"
-          className={cn('inline-flex gap-2 items-center', className)}
+          className={cn('inline-flex gap-1.5 items-center w-fit shrink-0 px-4', className)}
           aria-label="Choose work type to create"
         >
           <PlusCircle className="w-4 h-4 shrink-0" />
@@ -76,7 +76,7 @@ export function CreateWorkDropdown({
           {open ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
         </Button>
       </MenuTrigger>
-      <MenuContent className="min-w-[14rem] p-1" align="end" sideOffset={4}>
+      <MenuContent className="min-w-[20rem] max-w-[24rem] p-1" align="end" sideOffset={4}>
         {options.map((option) => {
           const Icon = option.icon;
           return (

--- a/packages/scms-core/src/components/CreateWorkDropdown.tsx
+++ b/packages/scms-core/src/components/CreateWorkDropdown.tsx
@@ -61,59 +61,44 @@ export function CreateWorkDropdown({
     );
   }
 
-  const primary = options[0];
-
   return (
-    <div className={cn('flex rounded-md shadow-sm', className)} role="group">
-      <Button
-        type="button"
-        size="lg"
-        variant="default"
-        className="inline-flex flex-1 gap-2 items-center min-w-0 rounded-r-none border-r border-white/30"
-        onClick={() => navigate(primary.startPath)}
-      >
-        <PlusCircle className="w-4 h-4 shrink-0" />
-        {triggerLabel}
-      </Button>
-      <Menu open={open} onOpenChange={setOpen}>
-        <MenuTrigger asChild>
-          <Button
-            type="button"
-            size="lg"
-            variant="default"
-            className={cn(
-              'px-2 rounded-l-none border-l-0 border-white/30 transition-colors',
-              open && 'bg-primary/60',
-            )}
-            aria-label="Choose work type to create"
-          >
-            {open ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
-          </Button>
-        </MenuTrigger>
-        <MenuContent className="min-w-[14rem] p-1" align="end" sideOffset={4}>
-          {options.map((option) => {
-            const Icon = option.icon;
-            return (
-              <MenuItem
-                key={option.id}
-                className="flex gap-3 items-start px-3 py-2 text-sm"
-                onSelect={(e) => {
-                  e.preventDefault();
-                  handleSelect(option);
-                }}
-              >
-                {Icon ? <Icon className="mt-0.5 w-5 h-5 shrink-0 text-muted-foreground" /> : null}
-                <div className="flex flex-col gap-0.5 items-start min-w-0">
-                  <span className="font-medium">{option.label}</span>
-                  {option.description ? (
-                    <span className="text-xs text-muted-foreground">{option.description}</span>
-                  ) : null}
-                </div>
-              </MenuItem>
-            );
-          })}
-        </MenuContent>
-      </Menu>
-    </div>
+    <Menu open={open} onOpenChange={setOpen}>
+      <MenuTrigger asChild>
+        <Button
+          type="button"
+          size="lg"
+          variant="default"
+          className={cn('inline-flex gap-2 items-center', className)}
+          aria-label="Choose work type to create"
+        >
+          <PlusCircle className="w-4 h-4 shrink-0" />
+          {triggerLabel}
+          {open ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
+        </Button>
+      </MenuTrigger>
+      <MenuContent className="min-w-[14rem] p-1" align="end" sideOffset={4}>
+        {options.map((option) => {
+          const Icon = option.icon;
+          return (
+            <MenuItem
+              key={option.id}
+              className="flex gap-3 items-start px-3 py-2 text-sm"
+              onSelect={(e) => {
+                e.preventDefault();
+                handleSelect(option);
+              }}
+            >
+              {Icon ? <Icon className="mt-0.5 w-5 h-5 shrink-0 text-muted-foreground" /> : null}
+              <div className="flex flex-col gap-0.5 items-start min-w-0">
+                <span className="font-medium">{option.label}</span>
+                {option.description ? (
+                  <span className="text-xs text-muted-foreground">{option.description}</span>
+                ) : null}
+              </div>
+            </MenuItem>
+          );
+        })}
+      </MenuContent>
+    </Menu>
   );
 }

--- a/packages/scms-core/src/components/FrameHeader.tsx
+++ b/packages/scms-core/src/components/FrameHeader.tsx
@@ -8,6 +8,8 @@ interface FrameHeaderProps {
   title?: React.ReactNode;
   subtitle?: React.ReactNode;
   description?: React.ReactNode;
+  /** Custom action node (e.g. create-work dropdown). Takes precedence over actionLabel/onAction. */
+  action?: React.ReactNode;
   actionLabel?: string;
   actionIcon?: React.ReactNode;
   onAction?: () => void;
@@ -21,6 +23,7 @@ export function FrameHeader({
   title: propTitle,
   subtitle: propSubtitle,
   description: propDescription,
+  action,
   actionLabel,
   actionDisabled,
   actionIcon,
@@ -48,7 +51,9 @@ export function FrameHeader({
           <h1 className="text-2xl font-normal tracking-tight">{title}</h1>
           {subtitle && <div className="py-1 text-base">{subtitle}</div>}
         </div>
-        {actionLabel && (
+        {action ? (
+          <div className={cn(actionAlign === 'right' && 'ml-auto')}>{action}</div>
+        ) : actionLabel ? (
           <div className={cn(actionAlign === 'right' && 'ml-auto')}>
             <StatefulButton onClick={onAction} disabled={actionDisabled}>
               <div className="flex flex-row gap-2 items-center">
@@ -57,7 +62,7 @@ export function FrameHeader({
               </div>
             </StatefulButton>
           </div>
-        )}
+        ) : null}
       </div>
       {description && (
         <div className="text-base leading-relaxed text-muted-foreground">{description}</div>

--- a/packages/scms-core/src/components/index.ts
+++ b/packages/scms-core/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './ClientOnly.js';
+export * from './CreateWorkDropdown.js';
 export * from './EmptyMessage.js';
 export * from './FrameHeader.js';
 export * from './GlobalErrorBoundary.js';

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -31,6 +31,8 @@ export interface WorkCreateOption {
   id: string;
   label: string;
   description?: string;
+  /** Optional icon shown in create-work dropdown menu items. */
+  icon?: IconComponent;
   /** Top-level workVersion.metadata key that identifies this flow on existing works. */
   metadataKey: string;
   /** App-absolute path that starts the create flow (e.g. `/app/works/new`). */

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -24,6 +24,41 @@ export interface ExtensionTask {
   scopes?: string[]; // Optional list of scopes that the task is allowed to be accessed under
 }
 
+export type WorkCreateFormMode = 'standalone' | 'composite';
+
+/** Declarative create-work entry registered by the platform or an extension. */
+export interface WorkCreateOption {
+  id: string;
+  label: string;
+  description?: string;
+  /** Top-level workVersion.metadata key that identifies this flow on existing works. */
+  metadataKey: string;
+  /** App-absolute path that starts the create flow (e.g. `/app/works/new`). */
+  startPath: string;
+  mode?: WorkCreateFormMode;
+  scopes?: string[];
+  /** Present when the option is supplied by an extension. */
+  extensionId?: string;
+  order?: number;
+}
+
+/** @deprecated Use WorkCreateOption */
+export type ExtensionWorkCreateOption = WorkCreateOption;
+
+export interface ExtensionCreateWorkVersionArgs {
+  ctx: Context;
+  workId: string;
+  sourceVersionMetadata: Record<string, unknown>;
+  defaultTitle: string;
+}
+
+export interface ExtensionCreateWorkVersionResult {
+  success: boolean;
+  redirectPath?: string;
+  workVersionId?: string;
+  error?: string;
+}
+
 export interface ExtensionIcon {
   id: string;
   component: IconComponent;
@@ -282,6 +317,8 @@ export interface ClientExtension {
   name: string;
   description: string;
   getTasks?: () => ExtensionTask[];
+  /** Optional create-work menu entries keyed by work-version metadata. */
+  getWorkCreateOptions?: () => WorkCreateOption[];
   getIcons?: () => ExtensionIcon[];
   getAnalyticsEvents?: () => ExtensionAnalyticsEvents;
   getEmailTemplates?: () => ExtensionEmailTemplate[];
@@ -306,6 +343,13 @@ export interface ExtensionAdminActionHandler {
 
 export interface ServerExtension extends ClientExtension {
   registerRoutes?: (appConfig: AppConfig) => Promise<RouteRegistration[]>;
+  /**
+   * Create a new draft work version for an existing work when the resolved create option
+   * belongs to this extension. Return null when this extension does not handle the request.
+   */
+  createWorkVersion?: (
+    args: ExtensionCreateWorkVersionArgs,
+  ) => Promise<ExtensionCreateWorkVersionResult | null>;
   getJobs?: () => JobRegistration[];
   /**
    * Returns the effective configuration for this extension.

--- a/packages/scms-core/src/modules/index.ts
+++ b/packages/scms-core/src/modules/index.ts
@@ -2,3 +2,4 @@ export * from './auth/index.js';
 export * from './builtinTasks/index.js';
 export * from './database/index.js';
 export * from './extensions/index.js';
+export * from './workCreate/index.js';

--- a/packages/scms-core/src/modules/workCreate/builtinArticleOption.ts
+++ b/packages/scms-core/src/modules/workCreate/builtinArticleOption.ts
@@ -1,0 +1,14 @@
+import type { WorkCreateOption } from '../extensions/types.js';
+
+export const BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID = 'article';
+
+/** Built-in Article upload flow (current `/app/works/new` behaviour). */
+export const BUILTIN_ARTICLE_WORK_CREATE_OPTION: WorkCreateOption = {
+  id: BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID,
+  label: 'Article',
+  description: 'Upload a manuscript for checks and publishing',
+  metadataKey: 'frontmatter.myst',
+  startPath: '/app/works/new',
+  mode: 'composite',
+  order: 0,
+};

--- a/packages/scms-core/src/modules/workCreate/builtinArticleOption.ts
+++ b/packages/scms-core/src/modules/workCreate/builtinArticleOption.ts
@@ -1,3 +1,4 @@
+import { FileText } from 'lucide-react';
 import type { WorkCreateOption } from '../extensions/types.js';
 
 export const BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID = 'article';
@@ -6,7 +7,8 @@ export const BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID = 'article';
 export const BUILTIN_ARTICLE_WORK_CREATE_OPTION: WorkCreateOption = {
   id: BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID,
   label: 'Article',
-  description: 'Upload a manuscript for checks and publishing',
+  description: 'upload files for a long form article',
+  icon: FileText,
   metadataKey: 'frontmatter.myst',
   startPath: '/app/works/new',
   mode: 'composite',

--- a/packages/scms-core/src/modules/workCreate/builtinCheckWorkOption.ts
+++ b/packages/scms-core/src/modules/workCreate/builtinCheckWorkOption.ts
@@ -7,7 +7,7 @@ export const BUILTIN_CHECK_WORK_CREATE_OPTION_ID = 'check';
 /** Built-in checks upload flow (same launcher as legacy Check My Work task). */
 export const BUILTIN_CHECK_WORK_CREATE_OPTION: WorkCreateOption = {
   id: BUILTIN_CHECK_WORK_CREATE_OPTION_ID,
-  label: 'Check a Work',
+  label: 'Check My Work',
   description: 'Upload files and run integrity checks',
   icon: ShieldCheck,
   /** Entry-point label for the checks upload launcher; not used for create-new-version resolution. */

--- a/packages/scms-core/src/modules/workCreate/builtinCheckWorkOption.ts
+++ b/packages/scms-core/src/modules/workCreate/builtinCheckWorkOption.ts
@@ -1,0 +1,19 @@
+import { ShieldCheck } from 'lucide-react';
+import type { WorkCreateOption } from '../extensions/types.js';
+import { scopes } from '../../scopes.js';
+
+export const BUILTIN_CHECK_WORK_CREATE_OPTION_ID = 'check';
+
+/** Built-in checks upload flow (same launcher as legacy Check My Work task). */
+export const BUILTIN_CHECK_WORK_CREATE_OPTION: WorkCreateOption = {
+  id: BUILTIN_CHECK_WORK_CREATE_OPTION_ID,
+  label: 'Check a Work',
+  description: 'Upload files and run integrity checks',
+  icon: ShieldCheck,
+  /** Entry-point label for the checks upload launcher; not used for create-new-version resolution. */
+  metadataKey: 'checks',
+  startPath: '/app/works/new',
+  mode: 'composite',
+  scopes: [scopes.app.works.checks.feature],
+  order: 5,
+};

--- a/packages/scms-core/src/modules/workCreate/index.ts
+++ b/packages/scms-core/src/modules/workCreate/index.ts
@@ -1,3 +1,4 @@
 export * from './builtinArticleOption.js';
+export * from './builtinCheckWorkOption.js';
 export * from './workCreateOptions.js';
 export * from './resolveWorkCreateOption.js';

--- a/packages/scms-core/src/modules/workCreate/index.ts
+++ b/packages/scms-core/src/modules/workCreate/index.ts
@@ -1,0 +1,3 @@
+export * from './builtinArticleOption.js';
+export * from './workCreateOptions.js';
+export * from './resolveWorkCreateOption.js';

--- a/packages/scms-core/src/modules/workCreate/resolveWorkCreateOption.ts
+++ b/packages/scms-core/src/modules/workCreate/resolveWorkCreateOption.ts
@@ -11,15 +11,14 @@ function metadataHasKey(metadata: Record<string, unknown>, key: string): boolean
 /**
  * Pick the create-work option that best matches an existing work version's metadata.
  * Extension options win when their metadata key is present; otherwise Article is the fallback.
+ * Built-in Check is an entry-point only (same launcher as Article) and is excluded here.
  */
 export function resolveWorkCreateOptionFromMetadata(
   metadata: Record<string, unknown> | null | undefined,
   availableOptions: WorkCreateOption[],
 ): WorkCreateOption {
   const meta = metadata ?? {};
-  const extensionOptions = availableOptions.filter(
-    (option) => option.id !== BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID,
-  );
+  const extensionOptions = availableOptions.filter((option) => option.extensionId);
 
   for (const option of extensionOptions) {
     if (metadataHasKey(meta, option.metadataKey)) {

--- a/packages/scms-core/src/modules/workCreate/resolveWorkCreateOption.ts
+++ b/packages/scms-core/src/modules/workCreate/resolveWorkCreateOption.ts
@@ -1,0 +1,34 @@
+import type { WorkCreateOption } from '../extensions/types.js';
+import {
+  BUILTIN_ARTICLE_WORK_CREATE_OPTION,
+  BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID,
+} from './builtinArticleOption.js';
+
+function metadataHasKey(metadata: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(metadata, key) && metadata[key] != null;
+}
+
+/**
+ * Pick the create-work option that best matches an existing work version's metadata.
+ * Extension options win when their metadata key is present; otherwise Article is the fallback.
+ */
+export function resolveWorkCreateOptionFromMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+  availableOptions: WorkCreateOption[],
+): WorkCreateOption {
+  const meta = metadata ?? {};
+  const extensionOptions = availableOptions.filter(
+    (option) => option.id !== BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID,
+  );
+
+  for (const option of extensionOptions) {
+    if (metadataHasKey(meta, option.metadataKey)) {
+      return option;
+    }
+  }
+
+  return (
+    availableOptions.find((option) => option.id === BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID) ??
+    BUILTIN_ARTICLE_WORK_CREATE_OPTION
+  );
+}

--- a/packages/scms-core/src/modules/workCreate/workCreateOptions.test.ts
+++ b/packages/scms-core/src/modules/workCreate/workCreateOptions.test.ts
@@ -1,0 +1,94 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import type { ClientExtension, WorkCreateOption } from '../extensions/types.js';
+import {
+  BUILTIN_ARTICLE_WORK_CREATE_OPTION,
+  BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID,
+} from './builtinArticleOption.js';
+import {
+  getAvailableWorkCreateOptions,
+  getExtensionWorkCreateOptions,
+} from './workCreateOptions.js';
+import { resolveWorkCreateOptionFromMetadata } from './resolveWorkCreateOption.js';
+
+const pmcOption: WorkCreateOption = {
+  id: 'pmc-deposit',
+  label: 'PMC Deposit',
+  metadataKey: 'pmc',
+  startPath: '/app/works/pmc',
+  mode: 'standalone',
+  extensionId: 'pmc',
+};
+
+const mockExtensions: ClientExtension[] = [
+  {
+    id: 'pmc',
+    name: 'PMC',
+    description: 'PMC',
+    registerNavigation: () => [],
+    getWorkCreateOptions: () => [
+      {
+        id: 'pmc-deposit',
+        label: 'PMC Deposit',
+        metadataKey: 'pmc',
+        startPath: '/app/works/pmc',
+      },
+    ],
+  },
+];
+
+describe('getExtensionWorkCreateOptions', () => {
+  it('includes extension options when routes are enabled', () => {
+    const options = getExtensionWorkCreateOptions({ pmc: { routes: true } }, mockExtensions, [
+      'app:works:upload',
+    ]);
+    expect(options).toHaveLength(1);
+    expect(options[0]?.id).toBe('pmc-deposit');
+    expect(options[0]?.extensionId).toBe('pmc');
+  });
+
+  it('excludes extension options when routes are disabled', () => {
+    const options = getExtensionWorkCreateOptions({ pmc: { routes: false } }, mockExtensions, [
+      'app:works:upload',
+    ]);
+    expect(options).toHaveLength(0);
+  });
+});
+
+describe('getAvailableWorkCreateOptions', () => {
+  it('always includes the built-in Article option by default', () => {
+    const options = getAvailableWorkCreateOptions({}, [], []);
+    expect(options[0]?.id).toBe(BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID);
+  });
+
+  it('merges Article with enabled extension options', () => {
+    const options = getAvailableWorkCreateOptions({ pmc: { routes: true } }, mockExtensions, []);
+    expect(options.map((o) => o.id)).toEqual(['article', 'pmc-deposit']);
+  });
+});
+
+describe('resolveWorkCreateOptionFromMetadata', () => {
+  it('falls back to Article when no extension metadata key is present', () => {
+    const resolved = resolveWorkCreateOptionFromMetadata({ checks: { enabled: [] } }, [
+      BUILTIN_ARTICLE_WORK_CREATE_OPTION,
+      pmcOption,
+    ]);
+    expect(resolved.id).toBe(BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID);
+  });
+
+  it('selects PMC when metadata.pmc is present', () => {
+    const resolved = resolveWorkCreateOptionFromMetadata({ pmc: { title: 'Example' } }, [
+      BUILTIN_ARTICLE_WORK_CREATE_OPTION,
+      pmcOption,
+    ]);
+    expect(resolved.id).toBe('pmc-deposit');
+  });
+
+  it('prefers extension metadata over Article frontmatter key', () => {
+    const resolved = resolveWorkCreateOptionFromMetadata(
+      { pmc: {}, 'frontmatter.myst': { title: 'Article' } },
+      [BUILTIN_ARTICLE_WORK_CREATE_OPTION, pmcOption],
+    );
+    expect(resolved.id).toBe('pmc-deposit');
+  });
+});

--- a/packages/scms-core/src/modules/workCreate/workCreateOptions.test.ts
+++ b/packages/scms-core/src/modules/workCreate/workCreateOptions.test.ts
@@ -9,8 +9,10 @@ import {
   getAllRegisteredWorkCreateOptions,
   getAvailableWorkCreateOptions,
   getExtensionWorkCreateOptions,
+  hydrateWorkCreateOptions,
   invokeExtensionCreateWorkVersion,
   resolveCreateNewVersionOption,
+  toSerializableWorkCreateOptions,
 } from './workCreateOptions.js';
 import { resolveWorkCreateOptionFromMetadata } from './resolveWorkCreateOption.js';
 
@@ -22,6 +24,8 @@ const pmcOption: WorkCreateOption = {
   mode: 'standalone',
   extensionId: 'pmc',
 };
+
+const MockPmcIcon = () => null;
 
 const mockExtensions: ClientExtension[] = [
   {
@@ -35,8 +39,10 @@ const mockExtensions: ClientExtension[] = [
         label: 'PMC Deposit',
         metadataKey: 'pmc',
         startPath: '/app/works/pmc',
+        icon: MockPmcIcon,
       },
     ],
+    getIcons: () => [{ id: 'pmc', component: MockPmcIcon, tags: ['default'] }],
   },
 ];
 
@@ -190,5 +196,47 @@ describe('invokeExtensionCreateWorkVersion', () => {
       redirectPath: '/deposit',
     });
     expect(createWorkVersion).toHaveBeenCalledWith(args);
+  });
+});
+
+describe('toSerializableWorkCreateOptions / hydrateWorkCreateOptions', () => {
+  it('strips icon from loader payload and re-attaches from client extension registry', () => {
+    const full = getAvailableWorkCreateOptions({ pmc: { routes: true } }, mockExtensions, []);
+    const serialized = toSerializableWorkCreateOptions(full);
+
+    expect(serialized.every((option) => !('icon' in option))).toBe(true);
+
+    const hydrated = hydrateWorkCreateOptions(serialized, mockExtensions);
+    expect(hydrated.find((o) => o.id === 'article')?.icon).toBe(
+      BUILTIN_ARTICLE_WORK_CREATE_OPTION.icon,
+    );
+    expect(hydrated.find((o) => o.id === 'pmc-deposit')?.icon).toBe(MockPmcIcon);
+  });
+
+  it('falls back to extension default icon when option omits icon in getWorkCreateOptions', () => {
+    const extensionsWithoutOptionIcon: ClientExtension[] = [
+      {
+        ...mockExtensions[0]!,
+        getWorkCreateOptions: () => [
+          {
+            id: 'pmc-deposit',
+            label: 'PMC Deposit',
+            metadataKey: 'pmc',
+            startPath: '/app/works/pmc',
+          },
+        ],
+      },
+    ];
+    const serialized = toSerializableWorkCreateOptions([
+      {
+        id: 'pmc-deposit',
+        label: 'PMC Deposit',
+        metadataKey: 'pmc',
+        startPath: '/app/works/pmc',
+        extensionId: 'pmc',
+      },
+    ]);
+    const hydrated = hydrateWorkCreateOptions(serialized, extensionsWithoutOptionIcon);
+    expect(hydrated[0]?.icon).toBe(MockPmcIcon);
   });
 });

--- a/packages/scms-core/src/modules/workCreate/workCreateOptions.test.ts
+++ b/packages/scms-core/src/modules/workCreate/workCreateOptions.test.ts
@@ -1,13 +1,16 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { describe, expect, it } from 'vitest';
-import type { ClientExtension, WorkCreateOption } from '../extensions/types.js';
+import { describe, expect, it, vi } from 'vitest';
+import type { ClientExtension, ServerExtension, WorkCreateOption } from '../extensions/types.js';
 import {
   BUILTIN_ARTICLE_WORK_CREATE_OPTION,
   BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID,
 } from './builtinArticleOption.js';
 import {
+  getAllRegisteredWorkCreateOptions,
   getAvailableWorkCreateOptions,
   getExtensionWorkCreateOptions,
+  invokeExtensionCreateWorkVersion,
+  resolveCreateNewVersionOption,
 } from './workCreateOptions.js';
 import { resolveWorkCreateOptionFromMetadata } from './resolveWorkCreateOption.js';
 
@@ -90,5 +93,102 @@ describe('resolveWorkCreateOptionFromMetadata', () => {
       [BUILTIN_ARTICLE_WORK_CREATE_OPTION, pmcOption],
     );
     expect(resolved.id).toBe('pmc-deposit');
+  });
+});
+
+describe('getAllRegisteredWorkCreateOptions', () => {
+  it('returns extension options regardless of routes config', () => {
+    const options = getAllRegisteredWorkCreateOptions(mockExtensions);
+    expect(options.map((o) => o.id)).toEqual(['pmc-deposit']);
+    expect(options[0]?.extensionId).toBe('pmc');
+  });
+});
+
+describe('resolveCreateNewVersionOption', () => {
+  it('returns the available extension option for PMC metadata', () => {
+    const result = resolveCreateNewVersionOption(
+      { pmc: { title: 'Example' } },
+      { pmc: { routes: true } },
+      mockExtensions,
+      ['app:works:upload'],
+    );
+    expect(result).toEqual({ ok: true, option: expect.objectContaining({ id: 'pmc-deposit' }) });
+  });
+
+  it('returns 403 when PMC metadata implies PMC but routes are disabled', () => {
+    const result = resolveCreateNewVersionOption(
+      { pmc: { title: 'Example' } },
+      { pmc: { routes: false } },
+      mockExtensions,
+      ['app:works:upload'],
+    );
+    expect(result).toEqual({
+      ok: false,
+      error: 'The "PMC Deposit" create flow is not available.',
+      status: 403,
+    });
+  });
+
+  it('falls back to Article for non-extension metadata', () => {
+    const result = resolveCreateNewVersionOption(
+      { checks: { enabled: [] } },
+      { pmc: { routes: true } },
+      mockExtensions,
+      [],
+    );
+    expect(result).toEqual({ ok: true, option: BUILTIN_ARTICLE_WORK_CREATE_OPTION });
+  });
+});
+
+describe('invokeExtensionCreateWorkVersion', () => {
+  const args = {
+    ctx: {} as never,
+    workId: 'work-1',
+    sourceVersionMetadata: {},
+    defaultTitle: 'Title',
+  };
+
+  it('returns null when extensionId is missing', async () => {
+    await expect(invokeExtensionCreateWorkVersion([], undefined, args)).resolves.toBeNull();
+  });
+
+  it('returns null when no matching extension is registered', async () => {
+    await expect(invokeExtensionCreateWorkVersion([], 'pmc', args)).resolves.toBeNull();
+  });
+
+  it('returns null when the extension has no createWorkVersion handler', async () => {
+    const extensions: ServerExtension[] = [
+      {
+        id: 'pmc',
+        name: 'PMC',
+        description: 'PMC',
+        registerNavigation: () => [],
+      },
+    ];
+    await expect(invokeExtensionCreateWorkVersion(extensions, 'pmc', args)).resolves.toBeNull();
+  });
+
+  it('dispatches to the matching extension handler', async () => {
+    const createWorkVersion = vi.fn(async () => ({
+      success: true,
+      workVersionId: 'work-version-1',
+      redirectPath: '/deposit',
+    }));
+    const extensions: ServerExtension[] = [
+      {
+        id: 'pmc',
+        name: 'PMC',
+        description: 'PMC',
+        registerNavigation: () => [],
+        createWorkVersion,
+      },
+    ];
+
+    await expect(invokeExtensionCreateWorkVersion(extensions, 'pmc', args)).resolves.toEqual({
+      success: true,
+      workVersionId: 'work-version-1',
+      redirectPath: '/deposit',
+    });
+    expect(createWorkVersion).toHaveBeenCalledWith(args);
   });
 });

--- a/packages/scms-core/src/modules/workCreate/workCreateOptions.test.ts
+++ b/packages/scms-core/src/modules/workCreate/workCreateOptions.test.ts
@@ -79,12 +79,12 @@ describe('getAvailableWorkCreateOptions', () => {
     expect(options.map((o) => o.id)).toEqual(['article', 'pmc-deposit']);
   });
 
-  it('includes Check a Work when checks feature scope is present', () => {
+  it('includes Check My Work when checks feature scope is present', () => {
     const options = getAvailableWorkCreateOptions({}, [], ['app:works:checks:feature']);
     expect(options.map((o) => o.id)).toEqual(['article', 'check']);
   });
 
-  it('omits Check a Work without checks feature scope', () => {
+  it('omits Check My Work without checks feature scope', () => {
     const options = getAvailableWorkCreateOptions({}, [], ['app:works:upload']);
     expect(options.map((o) => o.id)).toEqual(['article']);
   });

--- a/packages/scms-core/src/modules/workCreate/workCreateOptions.test.ts
+++ b/packages/scms-core/src/modules/workCreate/workCreateOptions.test.ts
@@ -6,6 +6,10 @@ import {
   BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID,
 } from './builtinArticleOption.js';
 import {
+  BUILTIN_CHECK_WORK_CREATE_OPTION,
+  BUILTIN_CHECK_WORK_CREATE_OPTION_ID,
+} from './builtinCheckWorkOption.js';
+import {
   getAllRegisteredWorkCreateOptions,
   getAvailableWorkCreateOptions,
   getExtensionWorkCreateOptions,
@@ -74,12 +78,23 @@ describe('getAvailableWorkCreateOptions', () => {
     const options = getAvailableWorkCreateOptions({ pmc: { routes: true } }, mockExtensions, []);
     expect(options.map((o) => o.id)).toEqual(['article', 'pmc-deposit']);
   });
+
+  it('includes Check a Work when checks feature scope is present', () => {
+    const options = getAvailableWorkCreateOptions({}, [], ['app:works:checks:feature']);
+    expect(options.map((o) => o.id)).toEqual(['article', 'check']);
+  });
+
+  it('omits Check a Work without checks feature scope', () => {
+    const options = getAvailableWorkCreateOptions({}, [], ['app:works:upload']);
+    expect(options.map((o) => o.id)).toEqual(['article']);
+  });
 });
 
 describe('resolveWorkCreateOptionFromMetadata', () => {
   it('falls back to Article when no extension metadata key is present', () => {
     const resolved = resolveWorkCreateOptionFromMetadata({ checks: { enabled: [] } }, [
       BUILTIN_ARTICLE_WORK_CREATE_OPTION,
+      BUILTIN_CHECK_WORK_CREATE_OPTION,
       pmcOption,
     ]);
     expect(resolved.id).toBe(BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID);

--- a/packages/scms-core/src/modules/workCreate/workCreateOptions.ts
+++ b/packages/scms-core/src/modules/workCreate/workCreateOptions.ts
@@ -12,6 +12,10 @@ import {
   BUILTIN_ARTICLE_WORK_CREATE_OPTION,
   BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID,
 } from './builtinArticleOption.js';
+import {
+  BUILTIN_CHECK_WORK_CREATE_OPTION,
+  BUILTIN_CHECK_WORK_CREATE_OPTION_ID,
+} from './builtinCheckWorkOption.js';
 import { resolveWorkCreateOptionFromMetadata } from './resolveWorkCreateOption.js';
 
 /** Loader-safe create-work option (no React component references). */
@@ -33,6 +37,9 @@ function iconForSerializableOption(
 ): IconComponent | undefined {
   if (option.id === BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID) {
     return BUILTIN_ARTICLE_WORK_CREATE_OPTION.icon;
+  }
+  if (option.id === BUILTIN_CHECK_WORK_CREATE_OPTION_ID) {
+    return BUILTIN_CHECK_WORK_CREATE_OPTION.icon;
   }
   if (!option.extensionId) return undefined;
 
@@ -105,8 +112,12 @@ export function getAvailableWorkCreateOptions(
   { includeArticle = true }: { includeArticle?: boolean } = {},
 ): WorkCreateOption[] {
   const extensionOptions = getExtensionWorkCreateOptions(config, clientExtensions, userScopes);
-  const articleOption = includeArticle ? [BUILTIN_ARTICLE_WORK_CREATE_OPTION] : [];
-  return [...articleOption, ...extensionOptions];
+  const builtinOptions: WorkCreateOption[] = [];
+  if (includeArticle) builtinOptions.push(BUILTIN_ARTICLE_WORK_CREATE_OPTION);
+  if (filterOptionByScopes(BUILTIN_CHECK_WORK_CREATE_OPTION, userScopes)) {
+    builtinOptions.push(BUILTIN_CHECK_WORK_CREATE_OPTION);
+  }
+  return sortWorkCreateOptions([...builtinOptions, ...extensionOptions]);
 }
 
 /**

--- a/packages/scms-core/src/modules/workCreate/workCreateOptions.ts
+++ b/packages/scms-core/src/modules/workCreate/workCreateOptions.ts
@@ -1,0 +1,71 @@
+import type {
+  ClientExtension,
+  ExtensionCreateWorkVersionArgs,
+  ExtensionCreateWorkVersionResult,
+  ServerExtension,
+  WorkCreateOption,
+} from '../extensions/types.js';
+import { scopes } from '../../scopes.js';
+import { BUILTIN_ARTICLE_WORK_CREATE_OPTION } from './builtinArticleOption.js';
+
+function userHasAllScopes(userScopes: string[], requiredScopes: string[]): boolean {
+  if (userScopes.includes(scopes.system.admin)) return true;
+  if (requiredScopes.length === 0) return true;
+  if (userScopes.length === 0) return false;
+  return requiredScopes.every((scope) => userScopes.includes(scope));
+}
+
+function filterOptionByScopes(option: WorkCreateOption, userScopes: string[]): boolean {
+  const required = option.scopes ?? [];
+  return userHasAllScopes(userScopes, required);
+}
+
+/**
+ * Returns extension create-work options filtered by extension config (`routes: true`) and scopes.
+ */
+export function getExtensionWorkCreateOptions(
+  config: Record<string, { routes?: boolean }>,
+  clientExtensions: ClientExtension[],
+  userScopes: string[],
+): WorkCreateOption[] {
+  const options: WorkCreateOption[] = [];
+
+  for (const ext of clientExtensions) {
+    const extConfig = config[ext.id];
+    if (extConfig?.routes !== true || !ext.getWorkCreateOptions) continue;
+
+    for (const option of ext.getWorkCreateOptions()) {
+      if (!filterOptionByScopes(option, userScopes)) continue;
+      options.push({ ...option, extensionId: ext.id });
+    }
+  }
+
+  return options.sort(
+    (a, b) => (a.order ?? 100) - (b.order ?? 100) || a.label.localeCompare(b.label),
+  );
+}
+
+/**
+ * Built-in Article option plus extension options available to the current user.
+ */
+export function getAvailableWorkCreateOptions(
+  config: Record<string, { routes?: boolean }>,
+  clientExtensions: ClientExtension[],
+  userScopes: string[],
+  { includeArticle = true }: { includeArticle?: boolean } = {},
+): WorkCreateOption[] {
+  const extensionOptions = getExtensionWorkCreateOptions(config, clientExtensions, userScopes);
+  const articleOption = includeArticle ? [BUILTIN_ARTICLE_WORK_CREATE_OPTION] : [];
+  return [...articleOption, ...extensionOptions];
+}
+
+export async function invokeExtensionCreateWorkVersion(
+  serverExtensions: ServerExtension[],
+  extensionId: string | undefined,
+  args: ExtensionCreateWorkVersionArgs,
+): Promise<ExtensionCreateWorkVersionResult | null> {
+  if (!extensionId) return null;
+  const ext = serverExtensions.find((e) => e.id === extensionId);
+  if (!ext?.createWorkVersion) return null;
+  return ext.createWorkVersion(args);
+}

--- a/packages/scms-core/src/modules/workCreate/workCreateOptions.ts
+++ b/packages/scms-core/src/modules/workCreate/workCreateOptions.ts
@@ -2,12 +2,57 @@ import type {
   ClientExtension,
   ExtensionCreateWorkVersionArgs,
   ExtensionCreateWorkVersionResult,
+  IconComponent,
   ServerExtension,
   WorkCreateOption,
 } from '../extensions/types.js';
+import { getExtensionIcon } from '../extensions/icons.js';
 import { scopes } from '../../scopes.js';
-import { BUILTIN_ARTICLE_WORK_CREATE_OPTION } from './builtinArticleOption.js';
+import {
+  BUILTIN_ARTICLE_WORK_CREATE_OPTION,
+  BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID,
+} from './builtinArticleOption.js';
 import { resolveWorkCreateOptionFromMetadata } from './resolveWorkCreateOption.js';
+
+/** Loader-safe create-work option (no React component references). */
+export type SerializableWorkCreateOption = Omit<WorkCreateOption, 'icon'>;
+
+export function toSerializableWorkCreateOptions(
+  options: WorkCreateOption[],
+): SerializableWorkCreateOption[] {
+  return options.map((option) => {
+    const { icon, ...rest } = option;
+    void icon;
+    return rest;
+  });
+}
+
+function iconForSerializableOption(
+  option: SerializableWorkCreateOption,
+  clientExtensions: ClientExtension[],
+): IconComponent | undefined {
+  if (option.id === BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID) {
+    return BUILTIN_ARTICLE_WORK_CREATE_OPTION.icon;
+  }
+  if (!option.extensionId) return undefined;
+
+  const ext = clientExtensions.find((e) => e.id === option.extensionId);
+  const registered = ext?.getWorkCreateOptions?.().find((o) => o.id === option.id);
+  if (registered?.icon) return registered.icon;
+
+  return getExtensionIcon(clientExtensions, option.extensionId);
+}
+
+/** Re-attach icons from the client extension registry after loader deserialization. */
+export function hydrateWorkCreateOptions(
+  options: SerializableWorkCreateOption[],
+  clientExtensions: ClientExtension[],
+): WorkCreateOption[] {
+  return options.map((option) => {
+    const icon = iconForSerializableOption(option, clientExtensions);
+    return icon ? { ...option, icon } : option;
+  });
+}
 
 function sortWorkCreateOptions(options: WorkCreateOption[]): WorkCreateOption[] {
   return options.sort(

--- a/packages/scms-core/src/modules/workCreate/workCreateOptions.ts
+++ b/packages/scms-core/src/modules/workCreate/workCreateOptions.ts
@@ -7,6 +7,13 @@ import type {
 } from '../extensions/types.js';
 import { scopes } from '../../scopes.js';
 import { BUILTIN_ARTICLE_WORK_CREATE_OPTION } from './builtinArticleOption.js';
+import { resolveWorkCreateOptionFromMetadata } from './resolveWorkCreateOption.js';
+
+function sortWorkCreateOptions(options: WorkCreateOption[]): WorkCreateOption[] {
+  return options.sort(
+    (a, b) => (a.order ?? 100) - (b.order ?? 100) || a.label.localeCompare(b.label),
+  );
+}
 
 function userHasAllScopes(userScopes: string[], requiredScopes: string[]): boolean {
   if (userScopes.includes(scopes.system.admin)) return true;
@@ -40,9 +47,7 @@ export function getExtensionWorkCreateOptions(
     }
   }
 
-  return options.sort(
-    (a, b) => (a.order ?? 100) - (b.order ?? 100) || a.label.localeCompare(b.label),
-  );
+  return sortWorkCreateOptions(options);
 }
 
 /**
@@ -57,6 +62,69 @@ export function getAvailableWorkCreateOptions(
   const extensionOptions = getExtensionWorkCreateOptions(config, clientExtensions, userScopes);
   const articleOption = includeArticle ? [BUILTIN_ARTICLE_WORK_CREATE_OPTION] : [];
   return [...articleOption, ...extensionOptions];
+}
+
+/**
+ * All extension create-work options from registered extensions, without config or scope filtering.
+ * Used to detect a work's intended flow when create-new-version may not expose that flow to the user.
+ */
+export function getAllRegisteredWorkCreateOptions(
+  clientExtensions: ClientExtension[],
+): WorkCreateOption[] {
+  const options: WorkCreateOption[] = [];
+
+  for (const ext of clientExtensions) {
+    if (!ext.getWorkCreateOptions) continue;
+
+    for (const option of ext.getWorkCreateOptions()) {
+      options.push({ ...option, extensionId: ext.id });
+    }
+  }
+
+  return sortWorkCreateOptions(options);
+}
+
+export type ResolveCreateNewVersionOptionResult =
+  | { ok: true; option: WorkCreateOption }
+  | { ok: false; error: string; status: 403 };
+
+/**
+ * Resolve which create flow to use for an existing work, failing clearly when metadata implies
+ * an extension flow that is disabled or unavailable to the current user.
+ */
+export function resolveCreateNewVersionOption(
+  sourceMetadata: Record<string, unknown>,
+  config: Record<string, { routes?: boolean }>,
+  extensions: ClientExtension[],
+  userScopes: string[],
+): ResolveCreateNewVersionOptionResult {
+  const allRegisteredOptions = getAllRegisteredWorkCreateOptions(extensions);
+  const intendedOption = resolveWorkCreateOptionFromMetadata(sourceMetadata, [
+    BUILTIN_ARTICLE_WORK_CREATE_OPTION,
+    ...allRegisteredOptions,
+  ]);
+
+  const availableOptions = getAvailableWorkCreateOptions(config, extensions, userScopes);
+
+  if (intendedOption.extensionId) {
+    const availableOption = availableOptions.find(
+      (option) =>
+        option.id === intendedOption.id && option.extensionId === intendedOption.extensionId,
+    );
+    if (!availableOption) {
+      return {
+        ok: false,
+        error: `The "${intendedOption.label}" create flow is not available.`,
+        status: 403,
+      };
+    }
+    return { ok: true, option: availableOption };
+  }
+
+  return {
+    ok: true,
+    option: resolveWorkCreateOptionFromMetadata(sourceMetadata, availableOptions),
+  };
 }
 
 export async function invokeExtensionCreateWorkVersion(

--- a/platform/scms/app/routes/app/works.$workId.details/WorkDetailsTopBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkDetailsTopBar.tsx
@@ -46,6 +46,7 @@ export function WorkDetailsTopBar({
     success?: boolean;
     workId?: string;
     workVersionId?: string;
+    redirectPath?: string;
   }>();
 
   const uploadButtonLabel = canResumeDraft ? 'Resume Draft Version' : 'Create new version';
@@ -68,13 +69,14 @@ export function WorkDetailsTopBar({
       fetcher.data.intent === 'create-new-version' &&
       fetcher.state === 'idle'
     ) {
-      if (
-        'success' in fetcher.data &&
-        fetcher.data.success &&
-        fetcher.data.workId &&
-        fetcher.data.workVersionId
-      ) {
-        navigate(`${workBasePath}/upload/${fetcher.data.workVersionId}?from=details`);
+      if ('success' in fetcher.data && fetcher.data.success && fetcher.data.workId) {
+        if (fetcher.data.redirectPath) {
+          navigate(fetcher.data.redirectPath);
+          return;
+        }
+        if (fetcher.data.workVersionId) {
+          navigate(`${workBasePath}/upload/${fetcher.data.workVersionId}?from=details`);
+        }
       }
     }
   }, [fetcher.state, fetcher.data, navigate, workBasePath]);

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -13,6 +13,7 @@ import {
   metadataForNewDraftFileWorkVersion,
   userHasScope,
   works as worksLoaders,
+  getUserScopesSet,
 } from '@curvenote/scms-server';
 import {
   MainWrapper,
@@ -26,6 +27,10 @@ import {
   loadCheckMaintenanceByServiceIds,
   CheckMaintenanceProvider,
   scopes,
+  getAvailableWorkCreateOptions,
+  resolveWorkCreateOptionFromMetadata,
+  invokeExtensionCreateWorkVersion,
+  BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID,
 } from '@curvenote/scms-core';
 import { buildMenu } from './menu';
 import {
@@ -98,6 +103,72 @@ export async function action(args: ActionFunctionArgs) {
     try {
       const latestNonDraft = ctx.work.versions?.find((v) => !v.draft);
       const workTitle = latestNonDraft?.title ?? ctx.workDTO?.title ?? '';
+      const sourceMetadata = (latestNonDraft?.metadata ?? {}) as Record<string, unknown>;
+      const userScopes = Array.from(getUserScopesSet(ctx.user));
+      const extensionConfigs = Object.fromEntries(
+        Object.entries(ctx.$config?.app?.extensions ?? {}).map(([key, value]) => [
+          key,
+          { routes: value?.routes ?? false },
+        ]),
+      );
+      const availableOptions = getAvailableWorkCreateOptions(
+        extensionConfigs,
+        serverExtensions,
+        userScopes,
+      );
+      const resolvedOption = resolveWorkCreateOptionFromMetadata(sourceMetadata, availableOptions);
+
+      if (resolvedOption.extensionId) {
+        const extResult = await invokeExtensionCreateWorkVersion(
+          serverExtensions,
+          resolvedOption.extensionId,
+          {
+            ctx,
+            workId: ctx.work.id,
+            sourceVersionMetadata: sourceMetadata,
+            defaultTitle: workTitle,
+          },
+        );
+        if (!extResult) {
+          return data(
+            {
+              success: false,
+              intent,
+              error: `No handler registered for create option "${resolvedOption.id}"`,
+            },
+            { status: 500 },
+          );
+        }
+        if (!extResult.success) {
+          return data(
+            {
+              success: false,
+              intent,
+              error: extResult.error ?? 'Failed to create new version',
+            },
+            { status: 500 },
+          );
+        }
+        return {
+          success: true,
+          intent: 'create-new-version',
+          workId: ctx.work.id,
+          workVersionId: extResult.workVersionId,
+          redirectPath: extResult.redirectPath,
+        };
+      }
+
+      if (resolvedOption.id !== BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID) {
+        return data(
+          {
+            success: false,
+            intent,
+            error: `Unsupported create option "${resolvedOption.id}"`,
+          },
+          { status: 500 },
+        );
+      }
+
       const result = await dbCreateDraftWorkVersion(
         ctx,
         ctx.work.id,

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -101,8 +101,14 @@ export async function action(args: ActionFunctionArgs) {
     }
     try {
       const latestNonDraft = ctx.work.versions?.find((v) => !v.draft);
+      const [latestNonDraftWithMetadata] = latestNonDraft
+        ? await dbAttachMetadataToWorkVersions([latestNonDraft])
+        : [];
       const workTitle = latestNonDraft?.title ?? ctx.workDTO?.title ?? '';
-      const sourceMetadata = (latestNonDraft?.metadata ?? {}) as Record<string, unknown>;
+      const sourceMetadata = (latestNonDraftWithMetadata?.metadata ?? {}) as Record<
+        string,
+        unknown
+      >;
       const userScopes = Array.from(getUserScopesSet(ctx.user));
       const extensionConfigs = Object.fromEntries(
         Object.entries(ctx.$config?.app?.extensions ?? {}).map(([key, value]) => [

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -249,6 +249,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
 
   // Draft-only works should route users into the upload flow, not the details pages.
   if (isDraftOnlyWork) {
+    const isPmcDepositPath = pathname.startsWith(`/app/works/${workId}/site/pmc/`);
     const isDetailsLikePath =
       pathname === `/app/works/${workId}` ||
       pathname === `/app/works/${workId}/` ||
@@ -257,7 +258,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
       pathname.startsWith(`/app/works/${workId}/work-integrity`) ||
       pathname.startsWith(`/app/works/${workId}/site/`);
 
-    if (!isOnUploadRoute && isDetailsLikePath) {
+    if (!isOnUploadRoute && isDetailsLikePath && !isPmcDepositPath) {
       throw redirect(`/app/works/${workId}/upload/${workVersionsWithMetadata[0].id}`);
     }
   }

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -27,8 +27,7 @@ import {
   loadCheckMaintenanceByServiceIds,
   CheckMaintenanceProvider,
   scopes,
-  getAvailableWorkCreateOptions,
-  resolveWorkCreateOptionFromMetadata,
+  resolveCreateNewVersionOption,
   invokeExtensionCreateWorkVersion,
   BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID,
 } from '@curvenote/scms-core';
@@ -111,12 +110,16 @@ export async function action(args: ActionFunctionArgs) {
           { routes: value?.routes ?? false },
         ]),
       );
-      const availableOptions = getAvailableWorkCreateOptions(
+      const resolved = resolveCreateNewVersionOption(
+        sourceMetadata,
         extensionConfigs,
         serverExtensions,
         userScopes,
       );
-      const resolvedOption = resolveWorkCreateOptionFromMetadata(sourceMetadata, availableOptions);
+      if (!resolved.ok) {
+        return data({ success: false, intent, error: resolved.error }, { status: resolved.status });
+      }
+      const resolvedOption = resolved.option;
 
       if (resolvedOption.extensionId) {
         const extResult = await invokeExtensionCreateWorkVersion(

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -37,7 +37,6 @@ export function WorkListItem({
 
   // Get the latest work version (versions are ordered date_created desc)
   const latestWorkVersion = work.versions[0];
-  const isDraft = latestWorkVersion?.draft === true;
 
   // Get the latest non-draft version info for title/authors/published
   const latestVersion = work.versions.find((version) => !version.draft);
@@ -71,11 +70,6 @@ export function WorkListItem({
                 {latestVersion?.title || latestWorkVersion?.title || 'Untitled Work'}
               </Link>
             </h3>
-            {isDraft && (
-              <ui.Badge variant="secondary" className="font-normal shrink-0">
-                Draft
-              </ui.Badge>
-            )}
           </div>
 
           <div className="flex flex-wrap gap-1 text-sm text-gray-600 dark:text-gray-400">

--- a/platform/scms/app/routes/app/works._index/route.tsx
+++ b/platform/scms/app/routes/app/works._index/route.tsx
@@ -19,6 +19,8 @@ import {
   getExtensionCheckServicesFromClientConfig,
   useDeploymentConfig,
   getAvailableWorkCreateOptions,
+  hydrateWorkCreateOptions,
+  toSerializableWorkCreateOptions,
   scopes,
   capitalize,
   plural,
@@ -64,10 +66,8 @@ export const loader = async (args: LoaderFunctionArgs) => {
         { routes: value?.routes ?? false },
       ]),
     );
-    const createWorkOptions = getAvailableWorkCreateOptions(
-      extensionConfigs,
-      extensions,
-      userScopes,
+    const createWorkOptions = toSerializableWorkCreateOptions(
+      getAvailableWorkCreateOptions(extensionConfigs, extensions, userScopes),
     );
 
     return {
@@ -229,6 +229,7 @@ export function shouldRevalidate({
 
 export default function MyWorks({ loaderData }: Route.ComponentProps) {
   const { items, workflows, error, canUpload, createWorkOptions, stringReplacements } = loaderData;
+  const hydratedCreateWorkOptions = hydrateWorkCreateOptions(createWorkOptions ?? [], extensions);
   const deploymentConfig = useDeploymentConfig();
   const checkServices = getExtensionCheckServicesFromClientConfig(
     deploymentConfig,
@@ -258,7 +259,7 @@ export default function MyWorks({ loaderData }: Route.ComponentProps) {
               subtitle={`Manage your ${worksLabel}`}
               action={
                 <CreateWorkDropdown
-                  options={createWorkOptions ?? []}
+                  options={hydratedCreateWorkOptions}
                   triggerLabel={`Create new ${workLabel}`}
                   disabled={!canUpload}
                   onDisabledClick={() =>

--- a/platform/scms/app/routes/app/works._index/route.tsx
+++ b/platform/scms/app/routes/app/works._index/route.tsx
@@ -64,13 +64,17 @@ export const loader = async (args: LoaderFunctionArgs) => {
         { routes: value?.routes ?? false },
       ]),
     );
+    const createWorkOptions = getAvailableWorkCreateOptions(
+      extensionConfigs,
+      extensions,
+      userScopes,
+    );
 
     return {
       items: worksPromise,
       workflows,
       canUpload,
-      userScopes,
-      extensionConfigs,
+      createWorkOptions,
       stringReplacements,
     };
   } catch {
@@ -224,8 +228,7 @@ export function shouldRevalidate({
 }
 
 export default function MyWorks({ loaderData }: Route.ComponentProps) {
-  const { items, workflows, error, canUpload, userScopes, extensionConfigs, stringReplacements } =
-    loaderData;
+  const { items, workflows, error, canUpload, createWorkOptions, stringReplacements } = loaderData;
   const deploymentConfig = useDeploymentConfig();
   const checkServices = getExtensionCheckServicesFromClientConfig(
     deploymentConfig,
@@ -234,11 +237,6 @@ export default function MyWorks({ loaderData }: Route.ComponentProps) {
   const workLabel = stringReplacements.work;
   const worksLabel = plural(`${workLabel}(s)`, 2);
   const worksTitle = capitalize(worksLabel);
-  const createWorkOptions = getAvailableWorkCreateOptions(
-    extensionConfigs ?? {},
-    extensions,
-    userScopes ?? [],
-  );
 
   const worksList = (
     <div className="max-w-[900px]">
@@ -260,7 +258,7 @@ export default function MyWorks({ loaderData }: Route.ComponentProps) {
               subtitle={`Manage your ${worksLabel}`}
               action={
                 <CreateWorkDropdown
-                  options={createWorkOptions}
+                  options={createWorkOptions ?? []}
                   triggerLabel={`Create new ${workLabel}`}
                   disabled={!canUpload}
                   onDisabledClick={() =>

--- a/platform/scms/app/routes/app/works._index/route.tsx
+++ b/platform/scms/app/routes/app/works._index/route.tsx
@@ -5,24 +5,26 @@ import {
   withAppScopedContext,
   userHasScope,
   withValidFormData,
+  getUserScopesSet,
 } from '@curvenote/scms-server';
 import {
   MainWrapper,
   PageFrame,
   FrameHeader,
+  CreateWorkDropdown,
   getBrandingFromMetaMatches,
   joinPageTitle,
   getWorkflows,
   registerExtensionWorkflows,
   getExtensionCheckServicesFromClientConfig,
   useDeploymentConfig,
+  getAvailableWorkCreateOptions,
   scopes,
   capitalize,
   plural,
 } from '@curvenote/scms-core';
 import type { LoaderFunctionArgs, ShouldRevalidateFunctionArgs } from 'react-router';
-import { useNavigate, data } from 'react-router';
-import { PlusCircle } from 'lucide-react';
+import { data } from 'react-router';
 import { z } from 'zod';
 import { zfd } from 'zod-form-data';
 import { WorkList } from './WorkList';
@@ -55,11 +57,20 @@ export const loader = async (args: LoaderFunctionArgs) => {
     const workflows = getWorkflows(ctx.$config, registerExtensionWorkflows(extensions));
 
     const canUpload = userHasScope(ctx.user, scopes.app.works.upload);
+    const userScopes = Array.from(getUserScopesSet(ctx.user));
+    const extensionConfigs = Object.fromEntries(
+      Object.entries(ctx.$config?.app?.extensions ?? {}).map(([key, value]) => [
+        key,
+        { routes: value?.routes ?? false },
+      ]),
+    );
 
     return {
       items: worksPromise,
       workflows,
       canUpload,
+      userScopes,
+      extensionConfigs,
       stringReplacements,
     };
   } catch {
@@ -213,8 +224,8 @@ export function shouldRevalidate({
 }
 
 export default function MyWorks({ loaderData }: Route.ComponentProps) {
-  const { items, workflows, error, canUpload, stringReplacements } = loaderData;
-  const navigate = useNavigate();
+  const { items, workflows, error, canUpload, userScopes, extensionConfigs, stringReplacements } =
+    loaderData;
   const deploymentConfig = useDeploymentConfig();
   const checkServices = getExtensionCheckServicesFromClientConfig(
     deploymentConfig,
@@ -223,6 +234,11 @@ export default function MyWorks({ loaderData }: Route.ComponentProps) {
   const workLabel = stringReplacements.work;
   const worksLabel = plural(`${workLabel}(s)`, 2);
   const worksTitle = capitalize(worksLabel);
+  const createWorkOptions = getAvailableWorkCreateOptions(
+    extensionConfigs ?? {},
+    extensions,
+    userScopes ?? [],
+  );
 
   const worksList = (
     <div className="max-w-[900px]">
@@ -242,12 +258,15 @@ export default function MyWorks({ loaderData }: Route.ComponentProps) {
               actionAlign="right"
               title={`My ${worksTitle}`}
               subtitle={`Manage your ${worksLabel}`}
-              actionLabel={`Create new ${workLabel}`}
-              actionIcon={<PlusCircle className="w-4 h-4" />}
-              onAction={
-                canUpload
-                  ? () => navigate('/app/works/new')
-                  : () => alert('For early access to upload features, please contact support')
+              action={
+                <CreateWorkDropdown
+                  options={createWorkOptions}
+                  triggerLabel={`Create new ${workLabel}`}
+                  disabled={!canUpload}
+                  onDisabledClick={() =>
+                    alert('For early access to upload features, please contact support')
+                  }
+                />
               }
             />
           }

--- a/platform/scms/docs/create-work-flows.md
+++ b/platform/scms/docs/create-work-flows.md
@@ -1,0 +1,362 @@
+# Create-work flows — architecture and routing
+
+This document describes how users start new works and new versions in SCMS when multiple **create flows** exist (Article upload, PMC Deposit, and future extension flows). It complements [upload-work-and-new-version-flows.md](./upload-work-and-new-version-flows.md), which focuses on the original Article-only paths.
+
+**Contents**
+
+- [Mental model](#mental-model)
+- [Create-work registry](#create-work-registry)
+- [Extension config flags](#extension-config-flags)
+- [Entry points](#entry-points)
+- [Launcher routes](#launcher-routes)
+- [Create new version (work details)](#create-new-version-work-details)
+- [Metadata resolution](#metadata-resolution)
+- [Work layout guards](#work-layout-guards)
+- [Fetcher vs redirect](#fetcher-vs-redirect)
+- [Code reference](#code-reference)
+- [Known gaps](#known-gaps)
+
+---
+
+## Mental model
+
+There is **no central router** that maps every button to a form. Instead:
+
+1. **Entry UI** (dashboard task card, My Works dropdown, work details button) sends the user to a **launcher route** or POSTs an action.
+2. **Launchers** check for existing drafts, optionally show a resume dialog, create a draft work/version, then **navigate client-side** to the correct form.
+3. **Create-new-version** on work details **infers** the flow from the latest **non-draft** version metadata (extensions win; Article is the fallback).
+
+```mermaid
+flowchart TD
+  subgraph Entry["Entry points"]
+    Dash["Dashboard task cards"]
+    MyWorks["My Works Create dropdown"]
+    Details["Work details Create new version"]
+  end
+
+  subgraph Registry["Create-work registry (scms-core)"]
+    Options["WorkCreateOption list"]
+    Resolve["resolveWorkCreateOptionFromMetadata"]
+  end
+
+  subgraph Launchers["Launcher routes"]
+    ArticleNew["/app/works/new"]
+    PmcNew["/app/works/pmc"]
+  end
+
+  subgraph Forms["Final forms"]
+    Upload["/upload/:workVersionId\n(Article)"]
+    PmcDeposit["/site/pmc/deposit/:submissionVersionId\n(PMC)"]
+  end
+
+  Dash -->|"hardcoded navigate()"| Launchers
+  MyWorks -->|"option.startPath"| Launchers
+  Details --> Resolve
+  Resolve -->|"Article"| Upload
+  Resolve -->|"PMC extension"| PmcDeposit
+
+  ArticleNew --> Upload
+  PmcNew --> PmcDeposit
+```
+
+| Layer | Responsibility |
+|-------|----------------|
+| **Dashboard** | Which task **cards** to show (`task: true` + scopes) |
+| **Task card component** | Where to **start** (hardcoded launcher URL in the component) |
+| **My Works dropdown** | Which **create options** to offer (`routes: true` + registry) |
+| **Launcher** | Draft check → create → navigate to form |
+| **Work details action** | Metadata-based flow for **new version** on an existing work |
+
+---
+
+## Create-work registry
+
+Registered in `@curvenote/scms-core` alongside other extension registries (tasks, checks, routes, workflows).
+
+### `WorkCreateOption`
+
+Declarative description of a create flow — **not** a work “type” enum:
+
+| Field | Purpose |
+|-------|---------|
+| `id` | Stable option id (e.g. `article`, `pmc-deposit`) |
+| `label` / `description` / `icon` | My Works dropdown presentation |
+| `metadataKey` | Top-level `workVersion.metadata` key that identifies this flow on **existing** works |
+| `startPath` | App-absolute path that starts creation (e.g. `/app/works/new`) |
+| `mode` | `standalone` \| `composite` (reserved for future composite forms) |
+| `extensionId` | Set when filtered from an extension |
+
+### Built-in Article option
+
+Always available when upload scope is present:
+
+- `id`: `article`
+- `metadataKey`: `frontmatter.myst` (descriptive; **not used for resolution** — see [Metadata resolution](#metadata-resolution))
+- `startPath`: `/app/works/new`
+
+### Extension options
+
+Extensions implement `getWorkCreateOptions()` on `ClientExtension`. Example: PMC registers `pmc-deposit` with `metadataKey: pmc`, `startPath: /app/works/pmc`.
+
+### Helpers
+
+| Function | Purpose |
+|----------|---------|
+| `getAvailableWorkCreateOptions()` | Built-in Article + extension options filtered by config and scopes |
+| `getExtensionWorkCreateOptions()` | Extension options only |
+| `resolveWorkCreateOptionFromMetadata()` | Pick flow for create-new-version from prior version metadata |
+| `invokeExtensionCreateWorkVersion()` | Call extension `createWorkVersion` handler |
+
+**Source:** `packages/scms-core/src/modules/workCreate/`
+
+---
+
+## Extension config flags
+
+Extension blocks in app-config include capability booleans (`routes`, `task`, `checks`, `workflows`, `navigation`, …).
+
+| Flag | Gates |
+|------|--------|
+| **`routes`** | Server route registration; My Works create options; PMC launcher loader/action |
+| **`task`** | Dashboard task cards only |
+| **`checks`** | Check services (orthogonal to create flow) |
+
+Dashboard tasks and My Works dropdown use **different** flags today. PMC task card navigates to `/app/works/pmc`, which requires **`routes: true`** for the launcher to work. In practice, enable both for PMC user-facing flows.
+
+---
+
+## Entry points
+
+### Dashboard task cards
+
+The dashboard loader builds a map of allowed task ids per extension (`task: true` + scopes) and allowed built-in task ids from `dashboard.tasks.builtins`.
+
+Each task renders `task.component` — the component **owns its own click handler**:
+
+| Task | Component | Navigates to |
+|------|-----------|--------------|
+| Check My Work | `AutomatedChecksTaskCard` | `/app/works/new` |
+| PMC Deposit | `PMCDepositTaskCard` | `/app/works/pmc` |
+
+The dashboard does **not** read `WorkCreateOption` or `startPath`.
+
+```mermaid
+flowchart LR
+  Config["extension.task + scopes"]
+  Dash["Dashboard loader"]
+  Card["Task card onClick"]
+  Launcher["Launcher route"]
+
+  Config --> Dash --> Card --> Launcher
+```
+
+### My Works — Create dropdown
+
+`works._index` loader passes `extensionConfigs` (routes flags) and `userScopes` into `getAvailableWorkCreateOptions()`. `CreateWorkDropdown` lists options; choosing one navigates to `option.startPath`.
+
+When only one option exists, the UI may collapse to a single button (no menu).
+
+### Work details — Create new version
+
+See [Create new version (work details)](#create-new-version-work-details).
+
+---
+
+## Launcher routes
+
+Launchers share a pattern: brief loading state → POST `get-drafts` → resume dialog or auto-create → client `navigate()` to the form.
+
+### Article — `/app/works/new`
+
+| Step | Behaviour |
+|------|-----------|
+| Draft query | User’s article draft **works** (`getValidDraftWorksForUser`; requires `checks` in metadata) |
+| Create | POST `/app/works` with `intent=create-new-draft` |
+| Response | JSON `{ workId, workVersionId }` |
+| Navigate | `/app/works/:workId/upload/:workVersionId?from=new` |
+
+**Route:** `platform/scms/app/routes/app/works.new/route.tsx`
+
+### PMC — `/app/works/pmc`
+
+| Step | Behaviour |
+|------|-----------|
+| Draft query | POST `/app/works/pmc` with `intent=get-drafts` → PMC drafts only |
+| Create | POST `/app/works/pmc` (default action) |
+| Response | JSON `{ intent: 'create-deposit', workId, submissionVersionId }` |
+| Navigate | `/app/works/:workId/site/pmc/deposit/:submissionVersionId` |
+
+**Route:** `extensions/hhmi-os-ext/packages/pmc/src/routes/pmc.tsx`  
+**UI:** `PMCDepositLauncher.tsx`
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Launcher as PMCDepositLauncher
+  participant Action as POST /app/works/pmc
+  participant Form as PMC deposit route
+
+  User->>Launcher: Task card or dropdown
+  Launcher->>Action: intent=get-drafts
+  Action-->>Launcher: { drafts }
+
+  alt drafts present
+    Launcher->>User: Resume dialog
+    User->>Form: navigate deposit URL
+  else no drafts
+    Launcher->>Action: create (default)
+    Action-->>Launcher: { intent, workId, submissionVersionId }
+    Launcher->>Form: navigate(deposit URL)
+  end
+```
+
+---
+
+## Create new version (work details)
+
+**Button:** `WorkDetailsTopBar` on `/app/works/:workId/details`.
+
+| Button label | When | Destination |
+|--------------|------|-------------|
+| **Resume Draft Version** | Latest version is draft with `metadata.checks` | Article upload URL |
+| **Create new version** | Otherwise | POST `create-new-version` → metadata-based routing |
+
+```mermaid
+flowchart TD
+  Click["Create new version"]
+  POST["POST /app/works/:workId\nintent=create-new-version"]
+  Meta["Latest non-draft version metadata"]
+  Resolve["resolveWorkCreateOptionFromMetadata"]
+  Ext["Extension createWorkVersion"]
+  Art["dbCreateDraftWorkVersion\n(fresh checks metadata)"]
+  Nav["Client navigate"]
+
+  Click --> POST --> Meta --> Resolve
+  Resolve -->|metadata.pmc| Ext
+  Resolve -->|fallback| Art
+  Ext -->|"redirectPath"| Nav
+  Art -->|"workVersionId"| Nav
+  Nav --> PmcForm["PMC deposit"]
+  Nav --> UploadForm["Article upload"]
+```
+
+**Article path:** Creates draft version with `metadataForNewDraftFileWorkVersion()` — does **not** clone prior article metadata.
+
+**PMC path:** Extension `createPMCWorkVersion` seeds `metadata.pmc` from the previous version (clears `previewed` / `confirmed`), creates draft submission version, returns `redirectPath`.
+
+**Action:** `platform/scms/app/routes/app/works.$workId/route.tsx`  
+**Client navigation:** `WorkDetailsTopBar.tsx` uses `redirectPath` when present, else upload URL.
+
+---
+
+## Metadata resolution
+
+`resolveWorkCreateOptionFromMetadata()` logic:
+
+1. Consider **extension** options only (match `metadataKey` on metadata).
+2. If no extension key matches → **Article fallback**.
+
+Article is **not** selected because `frontmatter.myst` is present. That key is evidence that upload/extraction has run, but it is often missing on early drafts. Extension keys (e.g. `pmc`) are strong flow identifiers.
+
+| Latest non-draft metadata | Resolved flow |
+|---------------------------|---------------|
+| `{ checks: { enabled: [] } }` only | Article |
+| `{ frontmatter.myst: ... }` only | Article (fallback) |
+| `{ pmc: ... }` | PMC |
+| `{ pmc: ..., frontmatter.myst: ... }` | PMC (extension wins) |
+
+`metadata.checks` is **orthogonal** — it does not identify the create flow.
+
+---
+
+## Work layout guards
+
+Draft-only works are redirected into an upload/deposit flow instead of details pages.
+
+The work layout loader (`works.$workId/route.tsx`) redirects draft-only works away from “details-like” paths. **PMC deposit paths are excluded** so navigation to `/site/pmc/deposit/...` is not bounced to article upload:
+
+```typescript
+const isPmcDepositPath = pathname.startsWith(`/app/works/${workId}/site/pmc/`);
+// ...
+if (!isOnUploadRoute && isDetailsLikePath && !isPmcDepositPath) {
+  throw redirect(`/app/works/${workId}/upload/...`);
+}
+```
+
+---
+
+## Fetcher vs redirect
+
+React Router **`useFetcher().submit()` does not perform browser navigation on server `redirect()` responses**. Launchers and work-details create flows must return **JSON** and call **`navigate()`** on the client (same pattern as `works.new` for Article).
+
+| Pattern | Used by |
+|---------|---------|
+| Action returns JSON; client `navigate()` | Article create, PMC create, create-new-version |
+| Server `redirect()` in action | Full document POST / resume-draft redirect (non-fetcher) |
+
+---
+
+## Code reference
+
+Paths relative to repository root.
+
+### scms-core — registry and UI
+
+| Purpose | Location |
+|---------|----------|
+| `WorkCreateOption` type | `packages/scms-core/src/modules/extensions/types.ts` |
+| Registry helpers | `packages/scms-core/src/modules/workCreate/workCreateOptions.ts` |
+| Metadata resolver | `packages/scms-core/src/modules/workCreate/resolveWorkCreateOption.ts` |
+| Built-in Article option | `packages/scms-core/src/modules/workCreate/builtinArticleOption.ts` |
+| Create dropdown UI | `packages/scms-core/src/components/CreateWorkDropdown.tsx` |
+| Dashboard task filtering | `packages/scms-core/src/modules/extensions/tasks.ts` |
+| Extension route registration | `packages/scms-server/src/modules/extensions/routes.ts` |
+
+### Platform — entry and actions
+
+| Purpose | Location |
+|---------|----------|
+| My Works + dropdown | `platform/scms/app/routes/app/works._index/route.tsx` |
+| Article launcher | `platform/scms/app/routes/app/works.new/route.tsx` |
+| Work layout + create-new-version action | `platform/scms/app/routes/app/works.$workId/route.tsx` |
+| Work details top bar | `platform/scms/app/routes/app/works.$workId.details/WorkDetailsTopBar.tsx` |
+| Resume-draft heuristic (`checks`) | `platform/scms/app/routes/app/works.$workId/metadata.server.ts` |
+| Dashboard tasks | `platform/scms/app/routes/app/dashboard/route.tsx` |
+| Built-in Check My Work card | `packages/scms-core/src/modules/builtinTasks/AutomatedChecksTaskCard.tsx` |
+
+### PMC extension (hhmi-os-ext)
+
+| Purpose | Location |
+|---------|----------|
+| PMC task card | `extensions/hhmi-os-ext/packages/pmc/src/DepositTaskCard.tsx` |
+| PMC launcher UI | `extensions/hhmi-os-ext/packages/pmc/src/PMCDepositLauncher.tsx` |
+| PMC launcher action | `extensions/hhmi-os-ext/packages/pmc/src/routes/pmc.tsx` |
+| Create option registration | `extensions/hhmi-os-ext/packages/pmc/src/client.ts` |
+| Create-new-version handler | `extensions/hhmi-os-ext/packages/pmc/src/createWorkVersion.server.ts` |
+
+### Action intents (create flows)
+
+| Intent | Route | Purpose |
+|--------|-------|---------|
+| `create-new-draft` | `POST /app/works` | New article work + first version |
+| `get-drafts` | `POST /app/works` or `/app/works/pmc` | List drafts (scope differs by route) |
+| `create-deposit` | Response from `POST /app/works/pmc` | PMC create success payload |
+| `create-new-version` | `POST /app/works/:workId` | New version; metadata-routed |
+
+---
+
+## Known gaps
+
+1. **Resume draft on work details** still uses the article heuristic (`checks` in metadata) and always navigates to the upload route — not PMC deposit resume.
+2. **Article create-new-version** does not clone prior `frontmatter.myst` / files metadata (conservative by design).
+3. **Dashboard `task` vs launcher `routes`** can diverge if config enables task without routes; PMC task would redirect away from a disabled launcher.
+
+---
+
+## Adding a new create flow
+
+1. Register `getWorkCreateOptions()` on the extension (and `createWorkVersion` on the server extension for new-version support).
+2. Add a launcher route (draft check, create action, client navigation to your form).
+3. Optionally add a dashboard task card that navigates to the same launcher `startPath`.
+4. Choose a top-level `metadataKey` for resolution on existing works.
+5. Ensure work layout guards do not redirect your form URL to article upload.

--- a/platform/scms/docs/index.md
+++ b/platform/scms/docs/index.md
@@ -4,4 +4,5 @@ title: Curvenote Platform Documentation
 
 Welcome to the Curvenote Platform.
 
-- [Upload Work and Upload New Version flows](upload-work-and-new-version-flows.md) – From button click through draft checks, work/version creation, and redirect to the upload form.
+- [Create-work flows (architecture)](create-work-flows.md) – Multi-flow create registry, dashboard tasks, My Works dropdown, launchers, metadata-based new-version routing, and PMC vs Article paths.
+- [Upload Work and Upload New Version flows](upload-work-and-new-version-flows.md) – Article-focused reference for `/app/works/new` and work-details upload (see create-work-flows for PMC and extension flows).

--- a/platform/scms/docs/upload-work-and-new-version-flows.md
+++ b/platform/scms/docs/upload-work-and-new-version-flows.md
@@ -1,6 +1,8 @@
 # New Work and Create new version – Flows and code reference
 
-This document describes the two entry flows for starting or resuming file uploads: **Upload Work** (from the My Works listing) and **Upload New Version** (from a work’s details page). Both flows share the same resume-draft UX (check for existing drafts, show dialog or create new, then redirect to the upload form).
+> **See also:** [create-work-flows.md](./create-work-flows.md) for the full multi-flow architecture (Article + PMC + extension registry, My Works dropdown, metadata-based create-new-version routing, and diagrams). This document remains an Article/upload-focused code reference.
+
+This document describes the two entry flows for starting or resuming **Article** file uploads: **Upload Work** (from the My Works listing) and **Upload New Version** (from a work’s details page). Both flows share the same resume-draft UX (check for existing drafts, show dialog or create new, then redirect to the upload form).
 
 **Contents**
 


### PR DESCRIPTION
A first step at driving the upload/creation process for specific flavours of a work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes work creation and new-version routing across loaders, actions, and extension hooks; mis-resolution or missing handlers could send users to the wrong flow or 403/500, though behavior is covered by new unit tests.
> 
> **Overview**
> Introduces a **create-work flow registry** in `scms-core` so Article, Check My Work, and extension flows (e.g. PMC) are declared via `WorkCreateOption` and filtered by extension `routes` config and user scopes.
> 
> **My Works** replaces the single “create” button with **`CreateWorkDropdown`** (loader-serialized options, client icon hydration). **`FrameHeader`** accepts a custom `action` slot for that UI.
> 
> **Create new version** on work details now loads the latest non-draft version metadata, resolves the flow with **`resolveCreateNewVersionOption`**, and either calls **`ServerExtension.createWorkVersion`** (client follows optional **`redirectPath`**) or keeps the built-in Article **`dbCreateDraftWorkVersion`** path. Returns **403** when metadata implies a disabled extension flow.
> 
> The work layout **no longer auto-redirects** draft-only works away from **PMC deposit** URLs under `/site/pmc/`. The works list **drops the Draft badge** on titles.
> 
> Adds **`workCreate` unit tests** and **`create-work-flows.md`** architecture docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7866b33ba31f61abeca3e8359510b67194551085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->