### PR TITLE
📨 add submit to site UI

### DIFF
--- a/.changeset/submission-work-site-unique.md
+++ b/.changeset/submission-work-site-unique.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-db': patch
+---
+
+Enforce one submission per work on a site via a unique `(work_id, site_id)` constraint.

--- a/.changeset/submit-work-to-site.md
+++ b/.changeset/submit-work-to-site.md
@@ -1,5 +1,6 @@
 ---
 '@curvenote/scms-core': minor
+'@curvenote/scms-server': minor
 '@curvenote/scms': minor
 ---
 

--- a/.changeset/submit-work-to-site.md
+++ b/.changeset/submit-work-to-site.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-core': minor
+'@curvenote/scms': minor
+---
+
+Add scope-gated submit-to-site from the work details page. Users with `app:works:submit-to-site` can pick a work version and submit to an available SCMS site from the Submitted to bar; others see guidance with a link to contact support for early access.

--- a/.changeset/work-version-contains-api.md
+++ b/.changeset/work-version-contains-api.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-core': minor
+'@curvenote/scms': minor
+---
+
+Document extension `createWorkVersion` contains contract. Manual POST `/v1/works` defaults omitted `contains` to `["myst"]` on work and first version; site form versions store explicit `[]`.

--- a/.changeset/work-version-contains-schema.md
+++ b/.changeset/work-version-contains-schema.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-db': minor
+---
+
+Add `WorkVersion.contains` (`String[]`, default `[]`) and backfill existing rows from parent `Work.contains`.

--- a/.changeset/work-version-contains-server.md
+++ b/.changeset/work-version-contains-server.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-server': minor
+---
+
+Set `WorkVersion.contains` on every version create path and merge labels into `Work.contains` via shared `resolveVersionContains` / `mergeWorkContains` helpers.

--- a/ee/sites/docs/submitting-works-to-sites.md
+++ b/ee/sites/docs/submitting-works-to-sites.md
@@ -1,0 +1,107 @@
+# Submitting Works to Sites
+
+You can submit a completed work version directly from the work details page. The
+submission flow lets you choose which version of the work to send, review the
+files and checks for that version, and then choose the site that should receive
+it.
+
+## Submit a Work Version
+
+1. Open the work details page.
+2. Find the **Submitted to** bar near the top of the page.
+3. Select the **+** button.
+4. Choose the completed work version you want to submit.
+5. Review the checks and files shown for that version.
+6. Choose the destination site.
+
+After the submission is created, you are taken to the submission version page for
+the site. From there you can continue with the site's review, publishing, or
+workflow steps.
+
+Draft work versions cannot be submitted. If no completed version is available,
+finish creating a work version before submitting to a site.
+
+## First Submission for a Work
+
+When a work is submitted to a site for the first time, Curvenote creates a new
+site submission and attaches the selected work version as its first submission
+version.
+
+For example, if a work has one completed version, `v1`, and you submit it to a
+site:
+
+- A new submission is created on that site.
+- The selected work version becomes the first submission version.
+- The **Submitted to** bar shows the site, its current workflow status, and a
+  link to the submission.
+
+This links the work and the site together. Future submissions of newer work
+versions to the same site are added to the same site submission.
+
+## Submitting Newer Work Versions
+
+A work can have multiple completed versions. When you create a newer version, you
+can submit that version to any available site from the same **Submitted to**
+menu.
+
+If the work has already been submitted to the selected site, Curvenote does not
+create a separate site submission. Instead, it adds the selected work version as
+a new submission version under the existing site submission.
+
+For example:
+
+1. Submit work version `v1` to Site A.
+2. Create work version `v2`.
+3. Open the **Submitted to** menu and choose `v2`.
+4. Submit `v2` to Site A.
+
+Curvenote keeps one submission on Site A, now with multiple submission versions.
+The site workflow can then track the newer version without losing the history of
+the earlier one.
+
+## Submitting to Multiple Sites
+
+The same work version can be submitted to more than one site. Each site receives
+its own site submission.
+
+For example:
+
+- Submit `v1` to Site A.
+- Submit `v1` to Site B.
+- Later, submit `v2` to Site A.
+- Later, submit `v2` to Site B.
+
+In this case, Site A and Site B each keep their own submission history. Each
+site can have its own workflow status and review outcome for each submitted
+version.
+
+## Already Submitted Versions
+
+When the selected work version has already been submitted to a site, that site is
+marked as **Submitted** in the menu and cannot be selected again for the same
+version. This prevents duplicate submission versions.
+
+To submit again to that site, choose a different completed work version.
+
+## Choosing a Destination Site
+
+The menu lists sites that are available to receive the selected work. External
+sites are shown first. If a site has already received this work before, it may
+remain available for newer work versions even when it is no longer accepting
+brand-new submissions.
+
+If no sites are available, the menu shows that there are no SCMS sites available
+for submission.
+
+## What Happens After Submission
+
+After a successful submission, Curvenote opens the submission version page for
+the destination site. The submission appears in the **Submitted to** bar with the
+site name, current workflow status, and a status indicator.
+
+You can return to the work details page later to:
+
+- See where the work has been submitted.
+- Open each site submission.
+- Submit newer completed work versions.
+- Submit the work to additional sites.

--- a/ee/sites/src/routes/forms.$siteName.$formName.$pageName/db.server.ts
+++ b/ee/sites/src/routes/forms.$siteName.$formName.$pageName/db.server.ts
@@ -141,6 +141,7 @@ export async function dbCreateWorkAndSubmission(
               description: data.workDescription || null,
               draft: false,
               authors: data.authors,
+              contains: [],
               metadata: {
                 fields: {
                   ...(data.formMetadata ?? {}),

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -54,6 +54,13 @@ export interface ExtensionCreateWorkVersionArgs {
   defaultTitle: string;
 }
 
+/**
+ * Result of an extension-owned "create new work version" flow.
+ *
+ * When `createWorkVersion` creates a `WorkVersion` directly (via Prisma or a server helper),
+ * it must set `WorkVersion.contains` for that version and merge those labels into `Work.contains`.
+ * Use `resolveVersionContains` and `mergeWorkContains` from `@curvenote/scms-server`.
+ */
 export interface ExtensionCreateWorkVersionResult {
   success: boolean;
   redirectPath?: string;
@@ -348,6 +355,8 @@ export interface ServerExtension extends ClientExtension {
   /**
    * Create a new draft work version for an existing work when the resolved create option
    * belongs to this extension. Return null when this extension does not handle the request.
+   * Implementations must set `WorkVersion.contains` and merge into `Work.contains` (see
+   * `ExtensionCreateWorkVersionResult`).
    */
   createWorkVersion?: (
     args: ExtensionCreateWorkVersionArgs,

--- a/packages/scms-core/src/scopes.ts
+++ b/packages/scms-core/src/scopes.ts
@@ -128,6 +128,7 @@ export const app = {
   works: {
     feature: 'app:works:feature', // UI level feature flag
     upload: 'app:works:upload',
+    submitToSite: 'app:works:submit-to-site',
     checks: {
       feature: 'app:works:checks:feature',
       dispatch: 'app:works:checks:dispatch',

--- a/packages/scms-server/src/backend/db.server.ts
+++ b/packages/scms-server/src/backend/db.server.ts
@@ -10,8 +10,16 @@ import type {
 } from './db.types.js';
 import type { SubmissionVersion, WorkVersion } from '@curvenote/scms-db';
 import { Prisma, ActivityType, WorkRole } from '@curvenote/scms-db';
-import { error401, httpError, WorkContents, TrackEvent, scopes } from '@curvenote/scms-core';
+import {
+  error401,
+  error404,
+  httpError,
+  WorkContents,
+  TrackEvent,
+  scopes,
+} from '@curvenote/scms-core';
 import { userHasScope } from './scopes.helpers.server.js';
+import { mergeWorkContains, resolveVersionContains } from './loaders/works/contains.server.js';
 import { uuidv7 } from 'uuidv7';
 import { KnownBuckets } from './storage/constants.server.js';
 import { Folder, StorageBackend } from './storage/index.js';
@@ -432,6 +440,7 @@ export async function dbCreateDraftWork(
               description,
               draft: true,
               authors,
+              contains,
               metadata: metadata ?? {},
             },
           ],
@@ -533,10 +542,22 @@ export async function dbCreateDraftWorkVersion(
   const cdnKey = uuidv7();
 
   return prisma.$transaction(async (tx) => {
+    const existing = await tx.work.findUnique({
+      where: { id: workId },
+      select: { contains: true },
+    });
+    if (!existing) throw error404();
+    const versionContains = resolveVersionContains(
+      undefined,
+      existing.contains.length > 0 ? existing.contains : [WorkContents.FILES],
+    );
+    const workContains = mergeWorkContains(existing.contains, versionContains);
+
     const work = await tx.work.update({
       where: { id: workId },
       data: {
         date_modified: date_created,
+        contains: { set: workContains },
         versions: {
           create: [
             {
@@ -549,6 +570,7 @@ export async function dbCreateDraftWorkVersion(
               description: '',
               draft: true,
               authors: [],
+              contains: versionContains,
               metadata: versionMetadata,
             },
           ],

--- a/packages/scms-server/src/backend/db.server.ts
+++ b/packages/scms-server/src/backend/db.server.ts
@@ -19,7 +19,7 @@ import {
   scopes,
 } from '@curvenote/scms-core';
 import { userHasScope } from './scopes.helpers.server.js';
-import { mergeWorkContains, resolveVersionContains } from './loaders/works/contains.server.js';
+import { draftUploadVersionContains, mergeWorkContains } from './loaders/works/contains.server.js';
 import { uuidv7 } from 'uuidv7';
 import { KnownBuckets } from './storage/constants.server.js';
 import { Folder, StorageBackend } from './storage/index.js';
@@ -544,13 +544,18 @@ export async function dbCreateDraftWorkVersion(
   return prisma.$transaction(async (tx) => {
     const existing = await tx.work.findUnique({
       where: { id: workId },
-      select: { contains: true },
+      select: {
+        contains: true,
+        versions: {
+          orderBy: { date_created: 'desc' },
+          take: 1,
+          select: { contains: true },
+        },
+      },
     });
     if (!existing) throw error404();
-    const versionContains = resolveVersionContains(
-      undefined,
-      existing.contains.length > 0 ? existing.contains : [WorkContents.FILES],
-    );
+    const previousVersionContains = existing.versions[0]?.contains ?? [];
+    const versionContains = draftUploadVersionContains(previousVersionContains);
     const workContains = mergeWorkContains(existing.contains, versionContains);
 
     const work = await tx.work.update({

--- a/packages/scms-server/src/backend/etl/register-work.server.ts
+++ b/packages/scms-server/src/backend/etl/register-work.server.ts
@@ -8,6 +8,7 @@ import { authorizeEtlSite, verifyEtlBearerUserId, type EtlAuth } from './auth.se
 import { cdnKeyUnderArticle } from './register-work-cdn-key.js';
 import { deriveEtlThumbnailStorageKey } from './register-work-thumbnail.js';
 import { buildSubmissionMetadataWithSupersedes } from './register-work-lineage.js';
+import { mergeWorkContains } from '../loaders/works/contains.server.js';
 
 export type EtlRegisterWorkInput = {
   site: string;
@@ -282,18 +283,23 @@ async function registerWorkInDb(
       cdn,
       cdn_key: input.cdn_key,
       thumbnail,
+      contains,
       metadata: workVersionMetadata as Prisma.InputJsonValue | undefined,
     };
 
     if (existingWorkId) {
       workId = existingWorkId;
       workVersionId = uuid();
+      const existingWork = await tx.work.findUniqueOrThrow({
+        where: { id: workId },
+        select: { contains: true },
+      });
       await tx.work.update({
         where: { id: workId },
         data: {
           date_modified: date_created,
           doi: input.doi,
-          contains: { set: contains },
+          contains: { set: mergeWorkContains(existingWork.contains, contains) },
           versions: {
             create: [
               {

--- a/packages/scms-server/src/backend/index.ts
+++ b/packages/scms-server/src/backend/index.ts
@@ -34,6 +34,7 @@ export * from './domains.server.js';
 export * from './workDraftChecksMetadata.server.js';
 export * from './work-version-subject.server.js';
 export * from './work-version-affiliations.server.js';
+export * from './loaders/works/contains.server.js';
 
 export * from './etl/index.js';
 export * from './loaders/index.js';

--- a/packages/scms-server/src/backend/loaders/sites/submissions/create.server.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/create.server.ts
@@ -7,6 +7,7 @@ import {
   siteWorkWorkVersionWithWorkSelect,
 } from '../../../prisma.selects.server.js';
 import { formatSubmissionDTO } from './get.server.js';
+import getSubmissionVersion from './versions/get.server.js';
 import { formatDate, normalizeExplicitTags } from '@curvenote/common';
 import type { UserDBO } from '../../../db.types.js';
 import { ActivityType } from '@curvenote/scms-db';
@@ -180,6 +181,79 @@ export async function dbCreateNewSubmission(
   });
 }
 
+type CreateSubmissionArgs = {
+  ctx: SiteContext;
+  workVersionId: string;
+  kindId: string;
+  draft: boolean;
+  jobId?: string;
+  collectionId?: string;
+  metadata?: Record<string, any>;
+  tags?: string[];
+};
+
+async function createSubmissionRecord({
+  ctx,
+  workVersionId,
+  kindId,
+  draft,
+  jobId,
+  collectionId,
+  metadata,
+  tags,
+}: CreateSubmissionArgs) {
+  if (!ctx.user) throw error401();
+  return dbCreateNewSubmission(
+    ctx.user,
+    ctx.site.name,
+    workVersionId,
+    kindId,
+    draft,
+    jobId,
+    collectionId,
+    metadata,
+    tags,
+  );
+}
+
+async function notifyNewSubmissionCreated(
+  ctx: SiteContext,
+  submission: Awaited<ReturnType<typeof dbCreateNewSubmission>>,
+  draft: boolean,
+) {
+  const createdVersion = submission.versions[0];
+  await ctx.trackEvent(TrackEvent.SUBMISSION_CREATED, {
+    submissionId: submission.id,
+    submissionVersionId: createdVersion.id,
+    workId: createdVersion.work_version.work_id,
+    workTitle: createdVersion.work_version.title,
+    kindId: submission.kind.id,
+    kindName: submission.kind.name,
+    collectionId: submission.collection.id,
+    collectionName: submission.collection.name,
+    isDraft: draft,
+    status: createdVersion.status,
+  });
+
+  const submissionUrl = asSiteSubmissionUrl(ctx.asBaseUrl, ctx.site.name, submission.id);
+  await ctx.sendSlackNotification({
+    eventType: SlackEventType.SUBMISSION_VERSION_CREATED,
+    message: `New submission: ${createdVersion.work_version.title ?? 'Untitled'}`,
+    user: ctx.user,
+    metadata: {
+      title: createdVersion.work_version.title,
+      status: createdVersion.status,
+      site: ctx.site.name,
+      collection: submission.collection.name,
+      kind: submission.kind.name,
+      submissionId: submission.id,
+      submissionVersionId: createdVersion.id,
+      submissionUrl,
+      workId: createdVersion.work_version.work_id,
+    },
+  });
+}
+
 export default async function create(
   ctx: SiteContext,
   extensions: ClientExtension[],
@@ -191,51 +265,47 @@ export default async function create(
   metadata?: Record<string, any>,
   tags?: string[],
 ) {
-  if (!ctx.user) throw error401(); // ctx.secure()
   // TODO - check does site allow anonymous submissions?
   // TODO - check does site allow submissions from this user?
   // TODO - rate limit the user?
-  const submission = await dbCreateNewSubmission(
-    ctx.user,
-    ctx.site.name,
-    workId,
+  const submission = await createSubmissionRecord({
+    ctx,
+    workVersionId: workId,
     kindId,
     draft,
     jobId,
     collectionId,
     metadata,
     tags,
-  );
-
-  await ctx.trackEvent(TrackEvent.SUBMISSION_CREATED, {
-    submissionId: submission.id,
-    submissionVersionId: submission.versions[0].id,
-    workId: submission.versions[0].work_version.work_id,
-    workTitle: submission.versions[0].work_version.title,
-    kindId: submission.kind.id,
-    kindName: submission.kind.name,
-    collectionId: submission.collection.id,
-    collectionName: submission.collection.name,
-    isDraft: draft,
-    status: submission.versions[0].status,
   });
 
-  const submissionUrl = asSiteSubmissionUrl(ctx.asBaseUrl, ctx.site.name, submission.id);
-  await ctx.sendSlackNotification({
-    eventType: SlackEventType.SUBMISSION_VERSION_CREATED,
-    message: `New submission: ${submission.versions[0].work_version.title ?? 'Untitled'}`,
-    user: ctx.user,
-    metadata: {
-      title: submission.versions[0].work_version.title,
-      status: submission.versions[0].status,
-      site: ctx.site.name,
-      collection: submission.collection.name,
-      kind: submission.kind.name,
-      submissionId: submission.id,
-      submissionVersionId: submission.versions[0].id,
-      submissionUrl,
-      workId: submission.versions[0].work_version.work_id,
-    },
-  });
+  await notifyNewSubmissionCreated(ctx, submission, draft);
   return formatSubmissionDTO(ctx, submission, extensions);
+}
+
+/** Like `create`, but returns the created submission version DTO (same shape as `versions.create`). */
+export async function createReturningVersion(
+  ctx: SiteContext,
+  extensions: ClientExtension[],
+  workVersionId: string,
+  kindId: string,
+  draft: boolean,
+  jobId?: string,
+  collectionId?: string,
+  metadata?: Record<string, any>,
+  tags?: string[],
+) {
+  const submission = await createSubmissionRecord({
+    ctx,
+    workVersionId,
+    kindId,
+    draft,
+    jobId,
+    collectionId,
+    metadata,
+    tags,
+  });
+
+  await notifyNewSubmissionCreated(ctx, submission, draft);
+  return getSubmissionVersion(ctx, submission.versions[0].id);
 }

--- a/packages/scms-server/src/backend/loaders/sites/submissions/index.ts
+++ b/packages/scms-server/src/backend/loaders/sites/submissions/index.ts
@@ -7,5 +7,5 @@ export { default as get } from './get.server.js';
 export * from './get.server.js';
 export { default as list } from './list.server.js';
 export * from './list.server.js';
-export { default as create } from './create.server.js';
+export { default as create, createReturningVersion } from './create.server.js';
 export * from './slugs.server.js';

--- a/packages/scms-server/src/backend/loaders/works/contains.server.test.ts
+++ b/packages/scms-server/src/backend/loaders/works/contains.server.test.ts
@@ -1,0 +1,41 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import { WorkContents } from '@curvenote/scms-core';
+import { mergeWorkContains, resolveVersionContains } from './contains.server.js';
+
+describe('resolveVersionContains', () => {
+  it('defaults undefined to myst', () => {
+    expect(resolveVersionContains(undefined)).toEqual(['myst']);
+  });
+
+  it('uses a custom fallback when undefined', () => {
+    expect(resolveVersionContains(undefined, [WorkContents.FILES])).toEqual(['files']);
+  });
+
+  it('preserves explicit empty array', () => {
+    expect(resolveVersionContains([])).toEqual([]);
+  });
+
+  it('dedupes requested values', () => {
+    expect(resolveVersionContains(['myst', 'myst', 'files'])).toEqual(['myst', 'files']);
+  });
+});
+
+describe('mergeWorkContains', () => {
+  it('merges existing and incoming labels', () => {
+    expect(mergeWorkContains(['myst'], ['files'])).toEqual(['myst', 'files']);
+  });
+
+  it('dedupes overlapping labels', () => {
+    expect(mergeWorkContains(['myst', 'files'], ['files', 'meca'])).toEqual([
+      'myst',
+      'files',
+      'meca',
+    ]);
+  });
+
+  it('treats nullish existing as empty', () => {
+    expect(mergeWorkContains(null, ['myst'])).toEqual(['myst']);
+    expect(mergeWorkContains(undefined, ['files'])).toEqual(['files']);
+  });
+});

--- a/packages/scms-server/src/backend/loaders/works/contains.server.test.ts
+++ b/packages/scms-server/src/backend/loaders/works/contains.server.test.ts
@@ -1,7 +1,11 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, expect, it } from 'vitest';
 import { WorkContents } from '@curvenote/scms-core';
-import { mergeWorkContains, resolveVersionContains } from './contains.server.js';
+import {
+  draftUploadVersionContains,
+  mergeWorkContains,
+  resolveVersionContains,
+} from './contains.server.js';
 
 describe('resolveVersionContains', () => {
   it('defaults undefined to myst', () => {
@@ -18,6 +22,20 @@ describe('resolveVersionContains', () => {
 
   it('dedupes requested values', () => {
     expect(resolveVersionContains(['myst', 'myst', 'files'])).toEqual(['myst', 'files']);
+  });
+});
+
+describe('draftUploadVersionContains', () => {
+  it('inherits prior version labels and adds files when missing', () => {
+    expect(draftUploadVersionContains(['myst'])).toEqual(['myst', 'files']);
+  });
+
+  it('does not duplicate files when already present', () => {
+    expect(draftUploadVersionContains(['myst', 'files'])).toEqual(['myst', 'files']);
+  });
+
+  it('adds files to an empty prior version', () => {
+    expect(draftUploadVersionContains([])).toEqual(['files']);
   });
 });
 

--- a/packages/scms-server/src/backend/loaders/works/contains.server.ts
+++ b/packages/scms-server/src/backend/loaders/works/contains.server.ts
@@ -1,0 +1,17 @@
+import { DEFAULT_WORK_CONTENTS } from '@curvenote/scms-core';
+
+/** Undefined → fallback; explicit [] stays []. */
+export function resolveVersionContains(
+  requested: string[] | undefined,
+  fallback: string[] = DEFAULT_WORK_CONTENTS,
+): string[] {
+  if (requested === undefined) return [...fallback];
+  return Array.from(new Set(requested));
+}
+
+export function mergeWorkContains(
+  existing: string[] | undefined | null,
+  incoming: string[],
+): string[] {
+  return Array.from(new Set([...(existing ?? []), ...incoming]));
+}

--- a/packages/scms-server/src/backend/loaders/works/contains.server.ts
+++ b/packages/scms-server/src/backend/loaders/works/contains.server.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_WORK_CONTENTS } from '@curvenote/scms-core';
+import { DEFAULT_WORK_CONTENTS, WorkContents } from '@curvenote/scms-core';
 
 /** Undefined → fallback; explicit [] stays []. */
 export function resolveVersionContains(
@@ -7,6 +7,15 @@ export function resolveVersionContains(
 ): string[] {
   if (requested === undefined) return [...fallback];
   return Array.from(new Set(requested));
+}
+
+/** Upload-new-version draft: carry forward the prior version labels and mark FILES. */
+export function draftUploadVersionContains(previousVersionContains: string[]): string[] {
+  const labels = [...previousVersionContains];
+  if (!labels.includes(WorkContents.FILES)) {
+    labels.push(WorkContents.FILES);
+  }
+  return Array.from(new Set(labels));
 }
 
 export function mergeWorkContains(

--- a/packages/scms-server/src/backend/loaders/works/create.server.ts
+++ b/packages/scms-server/src/backend/loaders/works/create.server.ts
@@ -122,6 +122,7 @@ export async function dbCreateWorkAndVersion(
               doi: data.doi ?? null,
               canonical: data.canonical ?? null,
               tags: versionTags,
+              contains,
               metadata: data.metadata ?? undefined,
             } as Prisma.WorkVersionCreateInput,
           ],

--- a/packages/scms-server/src/backend/loaders/works/index.ts
+++ b/packages/scms-server/src/backend/loaders/works/index.ts
@@ -1,5 +1,6 @@
 export { default as create } from './create.server.js';
 export * from './create.server.js';
+export * from './contains.server.js';
 export { default as get } from './get.server.js';
 export * from './get.server.js';
 export { default as update } from './update.server.js';

--- a/packages/scms-server/src/backend/loaders/works/versions/create.server.ts
+++ b/packages/scms-server/src/backend/loaders/works/versions/create.server.ts
@@ -6,6 +6,7 @@ import { getPrismaClient } from '../../../prisma.server.js';
 import { error401, error404, isMystCdnContentSource, site } from '@curvenote/scms-core';
 import { dbGetWorkForUser, formatWorkDTO, getWorkFromSubmission } from '../get.server.js';
 import { getCreateWorkVersionDataFromMyst } from '../create.server.js';
+import { mergeWorkContains, resolveVersionContains } from '../contains.server.js';
 import { ActivityType } from '@curvenote/scms-db';
 
 export async function dbCreateWorkVersionAndUpdateWork(
@@ -23,16 +24,14 @@ export async function dbCreateWorkVersionAndUpdateWork(
       select: { doi: true, contains: true },
     });
     if (!existing) throw error404();
-    const contains =
-      data.contains && data.contains.length
-        ? Array.from(new Set([...(existing.contains ?? []), ...data.contains]))
-        : undefined;
+    const versionContains = resolveVersionContains(data.contains);
+    const workContains = mergeWorkContains(existing.contains, versionContains);
     const work = await tx.work.update({
       where: { id: workId },
       data: {
         date_modified: date_created,
         doi: existing.doi ?? data.doi ?? undefined,
-        contains: contains ? { set: contains } : undefined,
+        contains: { set: workContains },
         versions: {
           create: [
             {
@@ -49,6 +48,7 @@ export async function dbCreateWorkVersionAndUpdateWork(
               doi: data.doi,
               canonical: data.canonical,
               tags: versionTags,
+              contains: versionContains,
               metadata: data.metadata ?? undefined,
             },
           ],

--- a/platform/scms/app/routes/api/v1.works.tsx
+++ b/platform/scms/app/routes/api/v1.works.tsx
@@ -7,6 +7,7 @@ import {
   withAPISecureContext,
   works,
   getPrismaClient,
+  resolveVersionContains,
 } from '@curvenote/scms-server';
 import { formatDate, normalizeExplicitTags } from '@curvenote/common';
 import { ActivityType, WorkRole } from '@curvenote/scms-db';
@@ -90,8 +91,9 @@ async function dbCreateManualWorkAndVersion(
     tags?: string[];
   },
   key?: string,
-  contains: string[] = [],
+  contains?: string[],
 ) {
+  const resolvedContains = resolveVersionContains(contains);
   const date_created = formatDate();
   const workId = uuid();
   const workVersionId = uuid();
@@ -104,7 +106,7 @@ async function dbCreateManualWorkAndVersion(
         key,
         date_created,
         date_modified: date_created,
-        contains,
+        contains: resolvedContains,
         doi: data.doi ?? null,
         created_by: { connect: { id: userId } },
         versions: {
@@ -123,6 +125,7 @@ async function dbCreateManualWorkAndVersion(
               cdn: data.cdn ?? null,
               cdn_key: data.cdn_key ?? null,
               tags: versionTags,
+              contains: resolvedContains,
               metadata: data.metadata ?? undefined,
             },
           ],

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -342,235 +342,248 @@ export function SubmittedToBar({
         <ui.PopoverContent
           className={cn(
             'text-sm border shadow-lg bg-background text-foreground border-border',
-            canSubmitToSite ? 'p-0 w-[760px]' : 'p-4 w-80',
+            canSubmitToSite
+              ? 'p-0 w-[min(760px,calc(100vw-2rem))] max-w-[calc(100vw-2rem)]'
+              : 'p-4 w-80 max-w-[calc(100vw-2rem)]',
           )}
-          align={canSubmitToSite ? 'start' : 'end'}
-          side={canSubmitToSite ? 'right' : 'bottom'}
-          sideOffset={canSubmitToSite ? 8 : undefined}
+          side="bottom"
+          align="center"
+          sideOffset={8}
+          collisionPadding={16}
         >
           {canSubmitToSite ? (
-            <fetcher.Form method="post" action={basePath} className="grid grid-cols-[300px_1fr]">
-              <input type="hidden" name="workVersionId" value={selectedVersion?.id ?? ''} />
-              <div className="p-4 space-y-4 border-r border-border bg-muted/20">
-                <div>
-                  <p className="text-sm font-medium">Choose the version to submit</p>
-                  <p className="text-xs text-muted-foreground">
-                    Review available files, metadata, and checks before choosing a venue.
-                  </p>
+            <>
+              <ui.PopoverArrow className="fill-background stroke-border stroke-[1px]" />
+              <fetcher.Form method="post" action={basePath} className="grid grid-cols-[300px_1fr]">
+                <input type="hidden" name="workVersionId" value={selectedVersion?.id ?? ''} />
+                <div className="p-4 space-y-4 border-r border-border bg-muted/20">
+                  <div>
+                    <p className="text-sm font-medium">Choose the version to submit</p>
+                    <p className="text-xs text-muted-foreground">
+                      Review available files, metadata, and checks before choosing a venue.
+                    </p>
+                  </div>
+
+                  <ui.Popover open={versionDropdownOpen} onOpenChange={setVersionDropdownOpen}>
+                    <ui.PopoverTrigger asChild>
+                      <button
+                        id="submit-version-select"
+                        type="button"
+                        className={cn(
+                          'flex h-16 w-full items-center justify-between gap-3 rounded-md border border-input bg-white px-3 py-2 text-left shadow-xs transition-colors',
+                          'hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+                        )}
+                      >
+                        {selectedVersion ? (
+                          <span className="flex min-w-0 flex-col items-start">
+                            <span className="truncate font-medium">
+                              Version {selectedVersionLabel}
+                            </span>
+                            <span className="text-xs text-muted-foreground">
+                              {new Date(
+                                selectedVersion.date_modified ?? selectedVersion.date_created,
+                              ).toLocaleDateString()}
+                            </span>
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">Select a version</span>
+                        )}
+                        <ChevronDown className="w-4 h-4 text-muted-foreground shrink-0" />
+                      </button>
+                    </ui.PopoverTrigger>
+                    <ui.PopoverContent
+                      align="start"
+                      side="bottom"
+                      sideOffset={6}
+                      className="p-1 w-[268px]"
+                    >
+                      <div className="space-y-1">
+                        {versionOptions.map(({ version, label }) => {
+                          const selected = version.id === selectedVersionId;
+                          return (
+                            <button
+                              key={version.id}
+                              type="button"
+                              className={cn(
+                                'flex w-full items-center justify-between gap-3 rounded-sm px-3 py-2 text-left transition-colors',
+                                'hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                                selected && 'bg-accent',
+                              )}
+                              onClick={() => {
+                                setSelectedVersionId(version.id);
+                                setVersionDropdownOpen(false);
+                              }}
+                            >
+                              <span className="flex min-w-0 flex-col items-start">
+                                <span className="truncate font-medium">Version {label}</span>
+                                <span className="text-xs text-muted-foreground">
+                                  {new Date(
+                                    version.date_modified ?? version.date_created,
+                                  ).toLocaleDateString()}
+                                </span>
+                              </span>
+                              {selected ? (
+                                <Check className="w-4 h-4 text-primary shrink-0" />
+                              ) : null}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </ui.PopoverContent>
+                  </ui.Popover>
+
+                  {selectedVersion ? (
+                    <>
+                      <div className="space-y-2">
+                        <p className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
+                          Checks
+                        </p>
+                        <div className="space-y-1.5">
+                          {checkRows.length > 0 ? (
+                            checkRows.map((row) => {
+                              const SummaryTitleComponent =
+                                row.service?.sectionSummaryTitleComponent;
+                              const SummaryBadgeComponent =
+                                row.service?.sectionSummaryBadgeComponent;
+                              const metadata = serviceDataFromRun(row.run);
+                              const fallbackScore = row.run ? getCheckScore(row.run) : null;
+                              return (
+                                <div
+                                  key={row.id}
+                                  className="flex gap-2 justify-between items-center p-2 rounded-md border bg-background border-border"
+                                >
+                                  <span className="flex min-w-0 flex-1 items-center overflow-hidden [&_img]:max-h-5 [&_img]:w-auto [&_img]:object-contain [&_svg]:max-h-5 [&_svg]:w-auto">
+                                    {SummaryTitleComponent && row.run ? (
+                                      <SummaryTitleComponent metadata={metadata} />
+                                    ) : (
+                                      <span className="text-xs font-medium truncate">
+                                        {row.name}
+                                      </span>
+                                    )}
+                                  </span>
+                                  {row.run ? (
+                                    SummaryBadgeComponent ? (
+                                      <SummaryBadgeComponent metadata={metadata} />
+                                    ) : (
+                                      <ui.Badge variant="success">
+                                        {fallbackScore ? `Score ${fallbackScore}` : 'Run'}
+                                      </ui.Badge>
+                                    )
+                                  ) : (
+                                    <ui.Badge variant="outline-muted">Not run</ui.Badge>
+                                  )}
+                                </div>
+                              );
+                            })
+                          ) : (
+                            <p className="text-xs text-muted-foreground">
+                              No check services available.
+                            </p>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="space-y-2">
+                        <p className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
+                          Files
+                        </p>
+                        {fileLabels.length > 0 ? (
+                          <ul className="space-y-1 text-[11px] leading-4 text-muted-foreground">
+                            {Object.entries(selectedFiles).map(([key, value]) => (
+                              <li key={key} className="truncate">
+                                {getFileLabel(key, value)}
+                              </li>
+                            ))}
+                          </ul>
+                        ) : (
+                          <p className="text-[11px] leading-4 text-muted-foreground">
+                            No files are available for this version.
+                          </p>
+                        )}
+                      </div>
+                    </>
+                  ) : null}
                 </div>
 
-                <ui.Popover open={versionDropdownOpen} onOpenChange={setVersionDropdownOpen}>
-                  <ui.PopoverTrigger asChild>
-                    <button
-                      id="submit-version-select"
-                      type="button"
-                      className={cn(
-                        'flex h-16 w-full items-center justify-between gap-3 rounded-md border border-input bg-white px-3 py-2 text-left shadow-xs transition-colors',
-                        'hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
-                      )}
-                    >
-                      {selectedVersion ? (
-                        <span className="flex min-w-0 flex-col items-start">
-                          <span className="truncate font-medium">
-                            Version {selectedVersionLabel}
-                          </span>
-                          <span className="text-xs text-muted-foreground">
-                            {new Date(
-                              selectedVersion.date_modified ?? selectedVersion.date_created,
-                            ).toLocaleDateString()}
-                          </span>
-                        </span>
-                      ) : (
-                        <span className="text-muted-foreground">Select a version</span>
-                      )}
-                      <ChevronDown className="w-4 h-4 text-muted-foreground shrink-0" />
-                    </button>
-                  </ui.PopoverTrigger>
-                  <ui.PopoverContent
-                    align="start"
-                    side="bottom"
-                    sideOffset={6}
-                    className="p-1 w-[268px]"
-                  >
+                <div className="p-2 space-y-2">
+                  <div className="px-2 py-1">
+                    <p className="text-sm font-medium">Submit to site</p>
+                    <p className="text-xs text-muted-foreground">
+                      Choose an SCMS site to receive this work. External sites are listed first.
+                    </p>
+                  </div>
+                  {availableSites.length > 0 ? (
                     <div className="space-y-1">
-                      {versionOptions.map(({ version, label }) => {
-                        const selected = version.id === selectedVersionId;
+                      <input type="hidden" name="intent" value="submit-to-site" />
+                      {availableSites.map((site) => {
+                        const siteTitle = site.title ?? site.name;
+                        const abbr =
+                          abbreviateTitle(siteTitle) || siteTitle.charAt(0).toUpperCase();
+                        const metadata = site.metadata as SiteVisualMetadata | undefined;
+                        const isCurrentSiteSubmitting = submittingSiteName === site.name;
+                        const alreadySubmitted = submittedSiteNames.has(site.name);
                         return (
                           <button
-                            key={version.id}
-                            type="button"
+                            key={site.id}
+                            type="submit"
+                            name="siteName"
+                            value={site.name}
+                            disabled={isSubmitting}
                             className={cn(
-                              'flex w-full items-center justify-between gap-3 rounded-sm px-3 py-2 text-left transition-colors',
+                              'flex gap-3 items-start p-2 w-full text-left rounded-md transition-colors',
                               'hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-                              selected && 'bg-accent',
+                              isSubmitting && 'opacity-70',
                             )}
-                            onClick={() => {
-                              setSelectedVersionId(version.id);
-                              setVersionDropdownOpen(false);
-                            }}
                           >
-                            <span className="flex min-w-0 flex-col items-start">
-                              <span className="truncate font-medium">Version {label}</span>
-                              <span className="text-xs text-muted-foreground">
-                                {new Date(
-                                  version.date_modified ?? version.date_created,
-                                ).toLocaleDateString()}
+                            <span className="flex overflow-hidden justify-center items-center w-9 h-9 rounded border bg-muted shrink-0 border-border">
+                              {metadata?.logo != null || metadata?.logo_dark != null ? (
+                                <SiteLogo
+                                  className="object-contain w-8 h-8"
+                                  alt={siteTitle}
+                                  logo={metadata?.logo}
+                                  logo_dark={metadata?.logo_dark}
+                                />
+                              ) : (
+                                <span className="text-xs font-medium text-muted-foreground">
+                                  {abbr}
+                                </span>
+                              )}
+                            </span>
+                            <span className="min-w-0 flex-1">
+                              <span className="flex gap-2 items-center">
+                                {metadata?.favicon ? (
+                                  <img
+                                    src={metadata.favicon}
+                                    alt=""
+                                    className="object-contain w-4 h-4 shrink-0"
+                                  />
+                                ) : null}
+                                <span className="font-medium truncate">{siteTitle}</span>
+                              </span>
+                              <span className="block text-xs leading-snug whitespace-normal text-muted-foreground">
+                                {site.description ?? site.name}
                               </span>
                             </span>
-                            {selected ? <Check className="w-4 h-4 text-primary shrink-0" /> : null}
+                            <span className="flex gap-2 items-center shrink-0">
+                              {alreadySubmitted ? (
+                                <ui.Badge variant="secondary">Submitted</ui.Badge>
+                              ) : null}
+                              {isCurrentSiteSubmitting ? (
+                                <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
+                              ) : null}
+                            </span>
                           </button>
                         );
                       })}
                     </div>
-                  </ui.PopoverContent>
-                </ui.Popover>
-
-                {selectedVersion ? (
-                  <>
-                    <div className="space-y-2">
-                      <p className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
-                        Checks
-                      </p>
-                      <div className="space-y-1.5">
-                        {checkRows.length > 0 ? (
-                          checkRows.map((row) => {
-                            const SummaryTitleComponent = row.service?.sectionSummaryTitleComponent;
-                            const SummaryBadgeComponent = row.service?.sectionSummaryBadgeComponent;
-                            const metadata = serviceDataFromRun(row.run);
-                            const fallbackScore = row.run ? getCheckScore(row.run) : null;
-                            return (
-                              <div
-                                key={row.id}
-                                className="flex gap-2 justify-between items-center p-2 rounded-md border bg-background border-border"
-                              >
-                                <span className="flex min-w-0 flex-1 items-center overflow-hidden [&_img]:max-h-5 [&_img]:w-auto [&_img]:object-contain [&_svg]:max-h-5 [&_svg]:w-auto">
-                                  {SummaryTitleComponent && row.run ? (
-                                    <SummaryTitleComponent metadata={metadata} />
-                                  ) : (
-                                    <span className="text-xs font-medium truncate">{row.name}</span>
-                                  )}
-                                </span>
-                                {row.run ? (
-                                  SummaryBadgeComponent ? (
-                                    <SummaryBadgeComponent metadata={metadata} />
-                                  ) : (
-                                    <ui.Badge variant="success">
-                                      {fallbackScore ? `Score ${fallbackScore}` : 'Run'}
-                                    </ui.Badge>
-                                  )
-                                ) : (
-                                  <ui.Badge variant="outline-muted">Not run</ui.Badge>
-                                )}
-                              </div>
-                            );
-                          })
-                        ) : (
-                          <p className="text-xs text-muted-foreground">
-                            No check services available.
-                          </p>
-                        )}
-                      </div>
-                    </div>
-
-                    <div className="space-y-2">
-                      <p className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
-                        Files
-                      </p>
-                      {fileLabels.length > 0 ? (
-                        <ul className="space-y-1 text-[11px] leading-4 text-muted-foreground">
-                          {Object.entries(selectedFiles).map(([key, value]) => (
-                            <li key={key} className="truncate">
-                              {getFileLabel(key, value)}
-                            </li>
-                          ))}
-                        </ul>
-                      ) : (
-                        <p className="text-[11px] leading-4 text-muted-foreground">
-                          No files are available for this version.
-                        </p>
-                      )}
-                    </div>
-                  </>
-                ) : null}
-              </div>
-
-              <div className="p-2 space-y-2">
-                <div className="px-2 py-1">
-                  <p className="text-sm font-medium">Submit to site</p>
-                  <p className="text-xs text-muted-foreground">
-                    Choose an SCMS site to receive this work. External sites are listed first.
-                  </p>
+                  ) : (
+                    <p className="px-2 py-3 text-sm text-muted-foreground">
+                      No SCMS sites are available for submission.
+                    </p>
+                  )}
                 </div>
-                {availableSites.length > 0 ? (
-                  <div className="space-y-1">
-                    <input type="hidden" name="intent" value="submit-to-site" />
-                    {availableSites.map((site) => {
-                      const siteTitle = site.title ?? site.name;
-                      const abbr = abbreviateTitle(siteTitle) || siteTitle.charAt(0).toUpperCase();
-                      const metadata = site.metadata as SiteVisualMetadata | undefined;
-                      const isCurrentSiteSubmitting = submittingSiteName === site.name;
-                      const alreadySubmitted = submittedSiteNames.has(site.name);
-                      return (
-                        <button
-                          key={site.id}
-                          type="submit"
-                          name="siteName"
-                          value={site.name}
-                          disabled={isSubmitting}
-                          className={cn(
-                            'flex gap-3 items-start p-2 w-full text-left rounded-md transition-colors',
-                            'hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-                            isSubmitting && 'opacity-70',
-                          )}
-                        >
-                          <span className="flex overflow-hidden justify-center items-center w-9 h-9 rounded border bg-muted shrink-0 border-border">
-                            {metadata?.logo != null || metadata?.logo_dark != null ? (
-                              <SiteLogo
-                                className="object-contain w-8 h-8"
-                                alt={siteTitle}
-                                logo={metadata?.logo}
-                                logo_dark={metadata?.logo_dark}
-                              />
-                            ) : (
-                              <span className="text-xs font-medium text-muted-foreground">
-                                {abbr}
-                              </span>
-                            )}
-                          </span>
-                          <span className="min-w-0 flex-1">
-                            <span className="flex gap-2 items-center">
-                              {metadata?.favicon ? (
-                                <img
-                                  src={metadata.favicon}
-                                  alt=""
-                                  className="object-contain w-4 h-4 shrink-0"
-                                />
-                              ) : null}
-                              <span className="font-medium truncate">{siteTitle}</span>
-                            </span>
-                            <span className="block text-xs leading-snug whitespace-normal text-muted-foreground">
-                              {site.description ?? site.name}
-                            </span>
-                          </span>
-                          <span className="flex gap-2 items-center shrink-0">
-                            {alreadySubmitted ? (
-                              <ui.Badge variant="secondary">Submitted</ui.Badge>
-                            ) : null}
-                            {isCurrentSiteSubmitting ? (
-                              <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
-                            ) : null}
-                          </span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                ) : (
-                  <p className="px-2 py-3 text-sm text-muted-foreground">
-                    No SCMS sites are available for submission.
-                  </p>
-                )}
-              </div>
-            </fetcher.Form>
+              </fetcher.Form>
+            </>
           ) : (
             <SubmitToSiteEarlyAccessMessage />
           )}

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -205,8 +205,7 @@ export function SubmittedToBar({
   const [versionDropdownOpen, setVersionDropdownOpen] = useState(false);
   const versionOptions = useMemo(() => {
     const completedVersions = versions.filter((version) => !version.draft);
-    const selectableVersions = completedVersions.length > 0 ? completedVersions : versions;
-    const sorted = [...selectableVersions].sort((a, b) =>
+    const sorted = [...completedVersions].sort((a, b) =>
       a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
     );
     const versionNumberByVersionId: Record<string, number> = {};
@@ -253,6 +252,7 @@ export function SubmittedToBar({
     })),
     ...fallbackCheckRows,
   ];
+  const hasCompletedVersions = versionOptions.length > 0;
   const submittingSiteName = fetcher.formData?.get('siteName');
   const isSubmitting = fetcher.state !== 'idle';
   const submittedSiteNames = new Set(submissions.map((sub) => sub.site.name));
@@ -364,73 +364,80 @@ export function SubmittedToBar({
                     </p>
                   </div>
 
-                  <ui.Popover open={versionDropdownOpen} onOpenChange={setVersionDropdownOpen}>
-                    <ui.PopoverTrigger asChild>
-                      <button
-                        id="submit-version-select"
-                        type="button"
-                        className={cn(
-                          'flex h-16 w-full items-center justify-between gap-3 rounded-md border border-input bg-white px-3 py-2 text-left shadow-xs transition-colors',
-                          'hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
-                        )}
-                      >
-                        {selectedVersion ? (
-                          <span className="flex min-w-0 flex-col items-start">
-                            <span className="truncate font-medium">
-                              Version {selectedVersionLabel}
-                            </span>
-                            <span className="text-xs text-muted-foreground">
-                              {new Date(
-                                selectedVersion.date_modified ?? selectedVersion.date_created,
-                              ).toLocaleDateString()}
-                            </span>
-                          </span>
-                        ) : (
-                          <span className="text-muted-foreground">Select a version</span>
-                        )}
-                        <ChevronDown className="w-4 h-4 text-muted-foreground shrink-0" />
-                      </button>
-                    </ui.PopoverTrigger>
-                    <ui.PopoverContent
-                      align="start"
-                      side="bottom"
-                      sideOffset={6}
-                      className="p-1 w-[268px]"
-                    >
-                      <div className="space-y-1">
-                        {versionOptions.map(({ version, label }) => {
-                          const selected = version.id === selectedVersionId;
-                          return (
-                            <button
-                              key={version.id}
-                              type="button"
-                              className={cn(
-                                'flex w-full items-center justify-between gap-3 rounded-sm px-3 py-2 text-left transition-colors',
-                                'hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-                                selected && 'bg-accent',
-                              )}
-                              onClick={() => {
-                                setSelectedVersionId(version.id);
-                                setVersionDropdownOpen(false);
-                              }}
-                            >
-                              <span className="flex min-w-0 flex-col items-start">
-                                <span className="truncate font-medium">Version {label}</span>
-                                <span className="text-xs text-muted-foreground">
-                                  {new Date(
-                                    version.date_modified ?? version.date_created,
-                                  ).toLocaleDateString()}
-                                </span>
+                  {hasCompletedVersions ? (
+                    <ui.Popover open={versionDropdownOpen} onOpenChange={setVersionDropdownOpen}>
+                      <ui.PopoverTrigger asChild>
+                        <button
+                          id="submit-version-select"
+                          type="button"
+                          className={cn(
+                            'flex h-16 w-full items-center justify-between gap-3 rounded-md border border-input bg-white px-3 py-2 text-left shadow-xs transition-colors',
+                            'hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+                          )}
+                        >
+                          {selectedVersion ? (
+                            <span className="flex min-w-0 flex-col items-start">
+                              <span className="truncate font-medium">
+                                Version {selectedVersionLabel}
                               </span>
-                              {selected ? (
-                                <Check className="w-4 h-4 text-primary shrink-0" />
-                              ) : null}
-                            </button>
-                          );
-                        })}
-                      </div>
-                    </ui.PopoverContent>
-                  </ui.Popover>
+                              <span className="text-xs text-muted-foreground">
+                                {new Date(
+                                  selectedVersion.date_modified ?? selectedVersion.date_created,
+                                ).toLocaleDateString()}
+                              </span>
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground">Select a version</span>
+                          )}
+                          <ChevronDown className="w-4 h-4 text-muted-foreground shrink-0" />
+                        </button>
+                      </ui.PopoverTrigger>
+                      <ui.PopoverContent
+                        align="start"
+                        side="bottom"
+                        sideOffset={6}
+                        className="p-1 w-[268px]"
+                      >
+                        <div className="space-y-1">
+                          {versionOptions.map(({ version, label }) => {
+                            const selected = version.id === selectedVersionId;
+                            return (
+                              <button
+                                key={version.id}
+                                type="button"
+                                className={cn(
+                                  'flex w-full items-center justify-between gap-3 rounded-sm px-3 py-2 text-left transition-colors',
+                                  'hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                                  selected && 'bg-accent',
+                                )}
+                                onClick={() => {
+                                  setSelectedVersionId(version.id);
+                                  setVersionDropdownOpen(false);
+                                }}
+                              >
+                                <span className="flex min-w-0 flex-col items-start">
+                                  <span className="truncate font-medium">Version {label}</span>
+                                  <span className="text-xs text-muted-foreground">
+                                    {new Date(
+                                      version.date_modified ?? version.date_created,
+                                    ).toLocaleDateString()}
+                                  </span>
+                                </span>
+                                {selected ? (
+                                  <Check className="w-4 h-4 text-primary shrink-0" />
+                                ) : null}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </ui.PopoverContent>
+                    </ui.Popover>
+                  ) : (
+                    <p className="rounded-md border border-dashed border-muted-foreground/40 bg-background px-3 py-4 text-xs leading-relaxed text-muted-foreground">
+                      No completed version is available to submit. Finish creating a version before
+                      submitting to a site.
+                    </p>
+                  )}
 
                   {selectedVersion ? (
                     <>
@@ -528,7 +535,7 @@ export function SubmittedToBar({
                             type="submit"
                             name="siteName"
                             value={site.name}
-                            disabled={isSubmitting}
+                            disabled={!hasCompletedVersions || isSubmitting}
                             className={cn(
                               'flex gap-3 items-start p-2 w-full text-left rounded-md transition-colors',
                               'hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -1,8 +1,45 @@
-import { Link } from 'react-router';
-import { primitives, SiteLogo, cn, ui } from '@curvenote/scms-core';
-import type { Workflow } from '@curvenote/scms-core';
-import type { SubmissionWithVersionsAndSite } from '../works.$workId/types';
-import { Plus } from 'lucide-react';
+import { Link, useFetcher, useLocation, useNavigate } from 'react-router';
+import {
+  primitives,
+  SiteLogo,
+  cn,
+  ui,
+  RequestHelpDialog,
+  useDeploymentConfig,
+  useMyUser,
+} from '@curvenote/scms-core';
+import type { ClientExtensionCheckService, Workflow } from '@curvenote/scms-core';
+import type {
+  SubmissionWithVersionsAndSite,
+  WorkVersionForDetailsClient,
+} from '../works.$workId/types';
+import type { CheckServiceRunRow } from '../works.$workId/db.server';
+import { Check, ChevronDown, Loader2, Plus } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+type SubmissionTargetSite = {
+  id: string;
+  name: string;
+  title: string;
+  description: string | null;
+  metadata: unknown;
+  external: boolean;
+};
+
+type SiteVisualMetadata = {
+  favicon?: string;
+  logo?: string;
+  logo_dark?: string;
+};
+
+type SubmitToSiteFetcherData = {
+  success?: boolean;
+  intent?: string;
+  siteName?: string;
+  submissionVersionId?: string;
+  alreadySubmitted?: boolean;
+  error?: string | { message?: string };
+};
 
 function getStatusLabelAndDot(
   workflows: Record<string, Workflow>,
@@ -34,15 +71,211 @@ function abbreviateTitle(title: string): string {
     .toUpperCase();
 }
 
+function getErrorMessage(data: SubmitToSiteFetcherData | undefined): string | null {
+  if (!data?.error) return null;
+  if (typeof data.error === 'string') return data.error;
+  return data.error.message ?? 'Could not submit to site';
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function getNestedRecord(
+  record: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | null {
+  return asRecord(record[key]);
+}
+
+function formatScore(value: unknown): string | null {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return null;
+    return value > 0 && value <= 1 ? `${Math.round(value * 100)}%` : String(Math.round(value));
+  }
+  if (typeof value === 'string' && value.trim() !== '') return value;
+  return null;
+}
+
+function getCheckScore(run: CheckServiceRunRow): string | null {
+  const data = asRecord(run.data);
+  if (!data) return null;
+  const serviceData = getNestedRecord(data, 'serviceData') ?? data;
+  const summary = getNestedRecord(serviceData, 'summary');
+  const result = getNestedRecord(serviceData, 'result');
+  const checks = getNestedRecord(serviceData, 'checks');
+  const checksSummary = checks ? getNestedRecord(checks, 'summary') : null;
+  return (
+    formatScore(serviceData.score) ??
+    formatScore(summary?.score) ??
+    formatScore(result?.score) ??
+    formatScore(checksSummary?.score)
+  );
+}
+
+function serviceDataFromRun(run: CheckServiceRunRow | undefined): unknown {
+  if (!run) return undefined;
+  const data = asRecord(run.data);
+  return data?.serviceData ?? undefined;
+}
+
+function getVersionFiles(version: WorkVersionForDetailsClient): Record<string, unknown> {
+  return asRecord(version.metadata?.files) ?? {};
+}
+
+function getFileLabel(key: string, value: unknown): string {
+  const file = asRecord(value);
+  return (
+    (typeof file?.filename === 'string' && file.filename) ||
+    (typeof file?.name === 'string' && file.name) ||
+    key
+  );
+}
+
+function SubmitToSiteEarlyAccessMessage() {
+  const [supportOpen, setSupportOpen] = useState(false);
+  const location = useLocation();
+  const user = useMyUser();
+  const config = useDeploymentConfig();
+  const helpConfig = config.statusBar?.items?.find((item) => item.type === 'request-help');
+  const helpProps = helpConfig?.type === 'request-help' ? helpConfig.properties : undefined;
+
+  const orcidAccount = user?.linkedAccounts?.find(
+    (account) => account.provider === 'orcid' && !account.pending,
+  );
+  const orcid = orcidAccount?.idAtProvider || 'unknown';
+  const currentPage = `${location.pathname}${location.search}${location.hash}`;
+
+  return (
+    <>
+      <p className="leading-relaxed">
+        To submit new works at the moment, use the Curvenote CLI or GitHub integrations. If you are
+        interested in early access to the direct submission feature, please{' '}
+        <ui.Button
+          type="button"
+          variant="link"
+          className="inline h-auto p-0 align-baseline"
+          onClick={() => setSupportOpen(true)}
+        >
+          contact support
+        </ui.Button>
+        .
+      </p>
+      <RequestHelpDialog
+        orcid={orcid}
+        open={supportOpen}
+        onOpenChange={setSupportOpen}
+        prompt={
+          helpProps?.prompt ??
+          'I am interested in early access to the direct submission feature from the work details page.'
+        }
+        title={helpProps?.title ?? helpProps?.label ?? 'Request help from the support team'}
+        description={helpProps?.description}
+        actionUrl="/app/request-help"
+        successMessage={helpProps?.successMessage}
+        currentPage={currentPage}
+      />
+    </>
+  );
+}
+
 export function SubmittedToBar({
   submissions,
   workflows,
   basePath,
+  canSubmitToSite,
+  availableSites,
+  versions,
+  checkServiceRunsByWorkVersionId,
+  checkServices,
 }: {
   submissions: SubmissionWithVersionsAndSite[];
   workflows: Record<string, Workflow>;
   basePath: string;
+  canSubmitToSite: boolean;
+  availableSites: SubmissionTargetSite[];
+  versions: WorkVersionForDetailsClient[];
+  checkServiceRunsByWorkVersionId: Record<string, CheckServiceRunRow[]>;
+  checkServices: ClientExtensionCheckService[];
 }) {
+  const navigate = useNavigate();
+  const fetcher = useFetcher<SubmitToSiteFetcherData>();
+  const [versionDropdownOpen, setVersionDropdownOpen] = useState(false);
+  const versionOptions = useMemo(() => {
+    const completedVersions = versions.filter((version) => !version.draft);
+    const selectableVersions = completedVersions.length > 0 ? completedVersions : versions;
+    const sorted = [...selectableVersions].sort((a, b) =>
+      a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
+    );
+    const versionNumberByVersionId: Record<string, number> = {};
+    [...versions]
+      .sort((a, b) =>
+        a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
+      )
+      .forEach((version, index) => {
+        versionNumberByVersionId[version.id] = versions.length - index;
+      });
+    return sorted.map((version) => ({
+      version,
+      label: `v${versionNumberByVersionId[version.id] ?? 0}`,
+    }));
+  }, [versions]);
+  const [selectedVersionId, setSelectedVersionId] = useState(versionOptions[0]?.version.id ?? '');
+  const selectedVersion =
+    versionOptions.find((option) => option.version.id === selectedVersionId)?.version ??
+    versionOptions[0]?.version;
+  const selectedVersionLabel =
+    versionOptions.find((option) => option.version.id === selectedVersion?.id)?.label ?? 'version';
+  const selectedCheckRuns = selectedVersion
+    ? (checkServiceRunsByWorkVersionId[selectedVersion.id] ?? [])
+    : [];
+  const selectedFiles = selectedVersion ? getVersionFiles(selectedVersion) : {};
+  const fileLabels = Object.entries(selectedFiles).map(([key, value]) => getFileLabel(key, value));
+  const selectedCheckRunByKind = new Map<string, CheckServiceRunRow>();
+  [...selectedCheckRuns]
+    .sort((a, b) =>
+      a.date_modified > b.date_modified ? -1 : a.date_modified < b.date_modified ? 1 : 0,
+    )
+    .forEach((run) => {
+      if (!selectedCheckRunByKind.has(run.kind)) selectedCheckRunByKind.set(run.kind, run);
+    });
+  const fallbackCheckRows = selectedCheckRuns
+    .filter((run) => !checkServices.some((service) => service.id === run.kind))
+    .map((run) => ({ id: run.kind, name: run.kind, run }));
+  const checkRows = [
+    ...checkServices.map((service) => ({
+      id: service.id,
+      name: service.name,
+      run: selectedCheckRunByKind.get(service.id),
+      service,
+    })),
+    ...fallbackCheckRows,
+  ];
+  const submittingSiteName = fetcher.formData?.get('siteName');
+  const isSubmitting = fetcher.state !== 'idle';
+  const submittedSiteNames = new Set(submissions.map((sub) => sub.site.name));
+
+  useEffect(() => {
+    if (fetcher.state !== 'idle' || fetcher.data?.intent !== 'submit-to-site') return;
+    const errorMessage = getErrorMessage(fetcher.data);
+    if (errorMessage) {
+      ui.toastError(errorMessage);
+      return;
+    }
+    if (fetcher.data.success && fetcher.data.siteName && fetcher.data.submissionVersionId) {
+      navigate(
+        `${basePath}/site/${fetcher.data.siteName}/submission/${fetcher.data.submissionVersionId}`,
+      );
+    }
+  }, [basePath, fetcher.data, fetcher.state, navigate]);
+
+  useEffect(() => {
+    if (selectedVersionId || !versionOptions[0]) return;
+    setSelectedVersionId(versionOptions[0].version.id);
+  }, [selectedVersionId, versionOptions]);
+
   return (
     <primitives.Card
       lift
@@ -107,14 +340,240 @@ export function SubmittedToBar({
           <Plus className="w-4 h-4" />
         </ui.PopoverTrigger>
         <ui.PopoverContent
-          className="p-4 w-80 text-sm border shadow-lg bg-background text-foreground border-border"
-          align="end"
-          side="bottom"
+          className={cn(
+            'text-sm border shadow-lg bg-background text-foreground border-border',
+            canSubmitToSite ? 'p-0 w-[760px]' : 'p-4 w-80',
+          )}
+          align={canSubmitToSite ? 'start' : 'end'}
+          side={canSubmitToSite ? 'right' : 'bottom'}
+          sideOffset={canSubmitToSite ? 8 : undefined}
         >
-          <p className="leading-relaxed">
-            Coming soon. To submit new works at the moment, use the Curvenote CLI or GitHub
-            integrations.
-          </p>
+          {canSubmitToSite ? (
+            <fetcher.Form method="post" action={basePath} className="grid grid-cols-[300px_1fr]">
+              <input type="hidden" name="workVersionId" value={selectedVersion?.id ?? ''} />
+              <div className="p-4 space-y-4 border-r border-border bg-muted/20">
+                <div>
+                  <p className="text-sm font-medium">Choose the version to submit</p>
+                  <p className="text-xs text-muted-foreground">
+                    Review available files, metadata, and checks before choosing a venue.
+                  </p>
+                </div>
+
+                <ui.Popover open={versionDropdownOpen} onOpenChange={setVersionDropdownOpen}>
+                  <ui.PopoverTrigger asChild>
+                    <button
+                      id="submit-version-select"
+                      type="button"
+                      className={cn(
+                        'flex h-16 w-full items-center justify-between gap-3 rounded-md border border-input bg-white px-3 py-2 text-left shadow-xs transition-colors',
+                        'hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+                      )}
+                    >
+                      {selectedVersion ? (
+                        <span className="flex min-w-0 flex-col items-start">
+                          <span className="truncate font-medium">
+                            Version {selectedVersionLabel}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {new Date(
+                              selectedVersion.date_modified ?? selectedVersion.date_created,
+                            ).toLocaleDateString()}
+                          </span>
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">Select a version</span>
+                      )}
+                      <ChevronDown className="w-4 h-4 text-muted-foreground shrink-0" />
+                    </button>
+                  </ui.PopoverTrigger>
+                  <ui.PopoverContent
+                    align="start"
+                    side="bottom"
+                    sideOffset={6}
+                    className="p-1 w-[268px]"
+                  >
+                    <div className="space-y-1">
+                      {versionOptions.map(({ version, label }) => {
+                        const selected = version.id === selectedVersionId;
+                        return (
+                          <button
+                            key={version.id}
+                            type="button"
+                            className={cn(
+                              'flex w-full items-center justify-between gap-3 rounded-sm px-3 py-2 text-left transition-colors',
+                              'hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                              selected && 'bg-accent',
+                            )}
+                            onClick={() => {
+                              setSelectedVersionId(version.id);
+                              setVersionDropdownOpen(false);
+                            }}
+                          >
+                            <span className="flex min-w-0 flex-col items-start">
+                              <span className="truncate font-medium">Version {label}</span>
+                              <span className="text-xs text-muted-foreground">
+                                {new Date(
+                                  version.date_modified ?? version.date_created,
+                                ).toLocaleDateString()}
+                              </span>
+                            </span>
+                            {selected ? <Check className="w-4 h-4 text-primary shrink-0" /> : null}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </ui.PopoverContent>
+                </ui.Popover>
+
+                {selectedVersion ? (
+                  <>
+                    <div className="space-y-2">
+                      <p className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
+                        Checks
+                      </p>
+                      <div className="space-y-1.5">
+                        {checkRows.length > 0 ? (
+                          checkRows.map((row) => {
+                            const SummaryTitleComponent = row.service?.sectionSummaryTitleComponent;
+                            const SummaryBadgeComponent = row.service?.sectionSummaryBadgeComponent;
+                            const metadata = serviceDataFromRun(row.run);
+                            const fallbackScore = row.run ? getCheckScore(row.run) : null;
+                            return (
+                              <div
+                                key={row.id}
+                                className="flex gap-2 justify-between items-center p-2 rounded-md border bg-background border-border"
+                              >
+                                <span className="flex min-w-0 flex-1 items-center overflow-hidden [&_img]:max-h-5 [&_img]:w-auto [&_img]:object-contain [&_svg]:max-h-5 [&_svg]:w-auto">
+                                  {SummaryTitleComponent && row.run ? (
+                                    <SummaryTitleComponent metadata={metadata} />
+                                  ) : (
+                                    <span className="text-xs font-medium truncate">{row.name}</span>
+                                  )}
+                                </span>
+                                {row.run ? (
+                                  SummaryBadgeComponent ? (
+                                    <SummaryBadgeComponent metadata={metadata} />
+                                  ) : (
+                                    <ui.Badge variant="success">
+                                      {fallbackScore ? `Score ${fallbackScore}` : 'Run'}
+                                    </ui.Badge>
+                                  )
+                                ) : (
+                                  <ui.Badge variant="outline-muted">Not run</ui.Badge>
+                                )}
+                              </div>
+                            );
+                          })
+                        ) : (
+                          <p className="text-xs text-muted-foreground">
+                            No check services available.
+                          </p>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="space-y-2">
+                      <p className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
+                        Files
+                      </p>
+                      {fileLabels.length > 0 ? (
+                        <ul className="space-y-1 text-[11px] leading-4 text-muted-foreground">
+                          {Object.entries(selectedFiles).map(([key, value]) => (
+                            <li key={key} className="truncate">
+                              {getFileLabel(key, value)}
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="text-[11px] leading-4 text-muted-foreground">
+                          No files are available for this version.
+                        </p>
+                      )}
+                    </div>
+                  </>
+                ) : null}
+              </div>
+
+              <div className="p-2 space-y-2">
+                <div className="px-2 py-1">
+                  <p className="text-sm font-medium">Submit to site</p>
+                  <p className="text-xs text-muted-foreground">
+                    Choose an SCMS site to receive this work. External sites are listed first.
+                  </p>
+                </div>
+                {availableSites.length > 0 ? (
+                  <div className="space-y-1">
+                    <input type="hidden" name="intent" value="submit-to-site" />
+                    {availableSites.map((site) => {
+                      const siteTitle = site.title ?? site.name;
+                      const abbr = abbreviateTitle(siteTitle) || siteTitle.charAt(0).toUpperCase();
+                      const metadata = site.metadata as SiteVisualMetadata | undefined;
+                      const isCurrentSiteSubmitting = submittingSiteName === site.name;
+                      const alreadySubmitted = submittedSiteNames.has(site.name);
+                      return (
+                        <button
+                          key={site.id}
+                          type="submit"
+                          name="siteName"
+                          value={site.name}
+                          disabled={isSubmitting}
+                          className={cn(
+                            'flex gap-3 items-start p-2 w-full text-left rounded-md transition-colors',
+                            'hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                            isSubmitting && 'opacity-70',
+                          )}
+                        >
+                          <span className="flex overflow-hidden justify-center items-center w-9 h-9 rounded border bg-muted shrink-0 border-border">
+                            {metadata?.logo != null || metadata?.logo_dark != null ? (
+                              <SiteLogo
+                                className="object-contain w-8 h-8"
+                                alt={siteTitle}
+                                logo={metadata?.logo}
+                                logo_dark={metadata?.logo_dark}
+                              />
+                            ) : (
+                              <span className="text-xs font-medium text-muted-foreground">
+                                {abbr}
+                              </span>
+                            )}
+                          </span>
+                          <span className="min-w-0 flex-1">
+                            <span className="flex gap-2 items-center">
+                              {metadata?.favicon ? (
+                                <img
+                                  src={metadata.favicon}
+                                  alt=""
+                                  className="object-contain w-4 h-4 shrink-0"
+                                />
+                              ) : null}
+                              <span className="font-medium truncate">{siteTitle}</span>
+                            </span>
+                            <span className="block text-xs leading-snug whitespace-normal text-muted-foreground">
+                              {site.description ?? site.name}
+                            </span>
+                          </span>
+                          <span className="flex gap-2 items-center shrink-0">
+                            {alreadySubmitted ? (
+                              <ui.Badge variant="secondary">Submitted</ui.Badge>
+                            ) : null}
+                            {isCurrentSiteSubmitting ? (
+                              <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
+                            ) : null}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="px-2 py-3 text-sm text-muted-foreground">
+                    No SCMS sites are available for submission.
+                  </p>
+                )}
+              </div>
+            </fetcher.Form>
+          ) : (
+            <SubmitToSiteEarlyAccessMessage />
+          )}
         </ui.PopoverContent>
       </ui.Popover>
     </primitives.Card>

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -134,6 +134,15 @@ function getFileLabel(key: string, value: unknown): string {
   );
 }
 
+function getSubmittedSiteNamesForWorkVersion(version: WorkVersionForDetailsClient | undefined) {
+  if (!version) return new Set<string>();
+  return new Set(
+    version.submissionVersions
+      .filter((submissionVersion) => submissionVersion.status !== 'DRAFT')
+      .map((submissionVersion) => submissionVersion.submission.site.name),
+  );
+}
+
 function SubmitToSiteEarlyAccessMessage() {
   const [supportOpen, setSupportOpen] = useState(false);
   const location = useLocation();
@@ -255,7 +264,10 @@ export function SubmittedToBar({
   const hasCompletedVersions = versionOptions.length > 0;
   const submittingSiteName = fetcher.formData?.get('siteName');
   const isSubmitting = fetcher.state !== 'idle';
-  const submittedSiteNames = new Set(submissions.map((sub) => sub.site.name));
+  const submittedSiteNamesForSelectedVersion = useMemo(
+    () => getSubmittedSiteNamesForWorkVersion(selectedVersion),
+    [selectedVersion],
+  );
 
   useEffect(() => {
     if (fetcher.state !== 'idle' || fetcher.data?.intent !== 'submit-to-site') return;
@@ -528,17 +540,23 @@ export function SubmittedToBar({
                           abbreviateTitle(siteTitle) || siteTitle.charAt(0).toUpperCase();
                         const metadata = site.metadata as SiteVisualMetadata | undefined;
                         const isCurrentSiteSubmitting = submittingSiteName === site.name;
-                        const alreadySubmitted = submittedSiteNames.has(site.name);
+                        const alreadySubmitted = submittedSiteNamesForSelectedVersion.has(
+                          site.name,
+                        );
+                        const isDisabled =
+                          !hasCompletedVersions || isSubmitting || alreadySubmitted;
                         return (
                           <button
                             key={site.id}
                             type="submit"
                             name="siteName"
                             value={site.name}
-                            disabled={!hasCompletedVersions || isSubmitting}
+                            disabled={isDisabled}
                             className={cn(
                               'flex gap-3 items-start p-2 w-full text-left rounded-md transition-colors',
-                              'hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                              'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                              'disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:bg-transparent',
+                              !isDisabled && 'hover:bg-accent',
                               isSubmitting && 'opacity-70',
                             )}
                           >

--- a/platform/scms/app/routes/app/works.$workId.details/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/route.tsx
@@ -28,6 +28,15 @@ type WorkUser = {
   work_roles: string[];
 };
 
+type SubmissionTargetSite = {
+  id: string;
+  name: string;
+  title: string;
+  description: string | null;
+  metadata: unknown;
+  external: boolean;
+};
+
 type LoaderData = {
   userScopes: string[];
   workflows: Record<string, Workflow>;
@@ -43,6 +52,8 @@ type LoaderData = {
   resumeDraftVersionId?: string;
   latestNonDraftContentCard: WorkVersionContentCardData | null;
   users: WorkUser[];
+  canSubmitToSite: boolean;
+  availableSites: SubmissionTargetSite[];
 };
 
 export const meta: MetaFunction<() => LoaderData> = ({ matches, data }) => {
@@ -66,6 +77,8 @@ export default function WorkDetailRoute() {
     resumeDraftVersionId,
     latestNonDraftContentCard,
     users,
+    canSubmitToSite,
+    availableSites,
   } = useRouteLoaderData('routes/app/works.$workId/route') as LoaderData;
 
   const deploymentConfig = useDeploymentConfig();
@@ -105,7 +118,16 @@ export default function WorkDetailRoute() {
         />
         <div className="space-y-1">
           <WorkDetailsContentCard version={latestNonDraftContentCard} />
-          <SubmittedToBar submissions={submissions} workflows={workflows} basePath={basePath} />
+          <SubmittedToBar
+            submissions={submissions}
+            workflows={workflows}
+            basePath={basePath}
+            canSubmitToSite={canSubmitToSite}
+            availableSites={availableSites}
+            versions={versions}
+            checkServiceRunsByWorkVersionId={checkServiceRunsByWorkVersionId}
+            checkServices={checkServices}
+          />
         </div>
         <div>
           <WorkVersionTimeline

--- a/platform/scms/app/routes/app/works.$workId/route.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/route.test.ts
@@ -15,6 +15,7 @@ const {
   findManySites,
   findUniqueSite,
   loadCheckMaintenanceByServiceIds,
+  promoteDraftSubmissionVersionToPending,
   userHasScope,
   withSecureWorkContext,
 } = vi.hoisted(() => ({
@@ -31,9 +32,18 @@ const {
   findManySites: vi.fn(),
   findUniqueSite: vi.fn(),
   loadCheckMaintenanceByServiceIds: vi.fn(),
+  promoteDraftSubmissionVersionToPending: vi.fn(),
   userHasScope: vi.fn(),
   withSecureWorkContext: vi.fn(),
 }));
+
+vi.mock('./submitToSite.server', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    promoteDraftSubmissionVersionToPending,
+  };
+});
 
 vi.mock('@curvenote/scms-server', () => ({
   withSecureWorkContext,
@@ -439,7 +449,7 @@ describe('work submit-to-site route', () => {
     });
     findFirstSubmission.mockResolvedValue({
       id: 'submission-1',
-      versions: [{ id: 'sv-1', work_version_id: 'wv-1' }],
+      versions: [{ id: 'sv-1', work_version_id: 'wv-1', status: 'PENDING' }],
     });
 
     const response = await action({
@@ -479,7 +489,7 @@ describe('work submit-to-site route', () => {
     });
     findFirstSubmission.mockResolvedValue({
       id: 'submission-1',
-      versions: [{ id: 'sv-1', work_version_id: 'wv-1' }],
+      versions: [{ id: 'sv-1', work_version_id: 'wv-1', status: 'PENDING' }],
     });
     findFirstWorkVersion.mockResolvedValue({ id: 'wv-2' });
     createSubmissionVersion.mockResolvedValue({ id: 'sv-2' });
@@ -501,6 +511,51 @@ describe('work submit-to-site route', () => {
       'submission-1',
       'wv-2',
     );
+    expect(createReturningVersion).not.toHaveBeenCalled();
+  });
+
+  it('promotes a draft submission version when resubmitting the same work version', async () => {
+    findUniqueSite.mockResolvedValue({
+      id: 'site-public',
+      name: 'public-site',
+      title: 'Public Site',
+      private: false,
+      restricted: false,
+      external: false,
+      domains: [],
+      submissionKinds: [{ id: 'kind-1', default: true }],
+      collections: [
+        {
+          id: 'collection-1',
+          default: true,
+          open: true,
+          kindsInCollection: [{ kind: { id: 'kind-1', default: true } }],
+        },
+      ],
+    });
+    findFirstSubmission.mockResolvedValue({
+      id: 'submission-1',
+      versions: [{ id: 'sv-draft', work_version_id: 'wv-1', status: 'DRAFT' }],
+    });
+
+    const response = await action({
+      request: createSubmitToSiteRequest('public-site', 'wv-1'),
+      params: { workId: 'work-1' },
+    } as never);
+
+    expect(response).toMatchObject({
+      success: true,
+      intent: 'submit-to-site',
+      siteName: 'public-site',
+      submissionVersionId: 'sv-draft',
+    });
+    expect(response).not.toHaveProperty('alreadySubmitted');
+    expect(promoteDraftSubmissionVersionToPending).toHaveBeenCalledWith('user-1', 'submission-1', {
+      id: 'sv-draft',
+      work_version_id: 'wv-1',
+      status: 'DRAFT',
+    });
+    expect(createSubmissionVersion).not.toHaveBeenCalled();
     expect(createReturningVersion).not.toHaveBeenCalled();
   });
 });

--- a/platform/scms/app/routes/app/works.$workId/route.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/route.test.ts
@@ -458,6 +458,55 @@ describe('work submit-to-site route', () => {
     expect(createReturningVersion).not.toHaveBeenCalled();
   });
 
+  it('returns the existing submission version when resubmitting an older work version after a newer one', async () => {
+    findUniqueSite.mockResolvedValue({
+      id: 'site-public',
+      name: 'public-site',
+      title: 'Public Site',
+      private: false,
+      restricted: false,
+      external: false,
+      domains: [],
+      submissionKinds: [{ id: 'kind-1', default: true }],
+      collections: [
+        {
+          id: 'collection-1',
+          default: true,
+          open: true,
+          kindsInCollection: [{ kind: { id: 'kind-1', default: true } }],
+        },
+      ],
+    });
+    findFirstSubmission.mockResolvedValue({
+      id: 'submission-1',
+      versions: [{ id: 'sv-1', work_version_id: 'wv-1', status: 'PENDING' }],
+    });
+
+    const response = await action({
+      request: createSubmitToSiteRequest('public-site', 'wv-1'),
+      params: { workId: 'work-1' },
+    } as never);
+
+    expect(response).toMatchObject({
+      success: true,
+      intent: 'submit-to-site',
+      siteName: 'public-site',
+      submissionVersionId: 'sv-1',
+      alreadySubmitted: true,
+    });
+    expect(findFirstSubmission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: {
+          versions: expect.objectContaining({
+            where: { work_version_id: 'wv-1' },
+          }),
+        },
+      }),
+    );
+    expect(createSubmissionVersion).not.toHaveBeenCalled();
+    expect(createReturningVersion).not.toHaveBeenCalled();
+  });
+
   it('creates a new submission version when an already-submitted site receives a newer version', async () => {
     findUniqueSite.mockResolvedValue({
       id: 'site-public',

--- a/platform/scms/app/routes/app/works.$workId/route.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/route.test.ts
@@ -165,6 +165,21 @@ vi.mock('./actionHelpers.server', () => ({
 }));
 
 const { action, loader } = await import('./route');
+const { getUniqueSubmissions } = await import('./utils.server');
+
+function submitReadySiteFields() {
+  return {
+    submissionKinds: [{ id: 'kind-1', default: true }],
+    collections: [
+      {
+        id: 'collection-1',
+        default: true,
+        open: true,
+        kindsInCollection: [{ kind: { id: 'kind-1', default: true } }],
+      },
+    ],
+  };
+}
 
 function createSubmitToSiteRequest(siteName = 'private-site', workVersionId = 'wv-1'): Request {
   const formData = new FormData();
@@ -290,6 +305,7 @@ describe('work submit-to-site route', () => {
         external: true,
         private: false,
         restricted: false,
+        ...submitReadySiteFields(),
       },
       {
         id: 'site-public',
@@ -300,6 +316,7 @@ describe('work submit-to-site route', () => {
         external: false,
         private: false,
         restricted: false,
+        ...submitReadySiteFields(),
       },
       {
         id: 'site-private',
@@ -310,6 +327,10 @@ describe('work submit-to-site route', () => {
         external: false,
         private: true,
         restricted: false,
+        submissionKinds: [],
+        collections: [
+          { id: 'collection-closed', default: true, open: false, kindsInCollection: [] },
+        ],
       },
       {
         id: 'site-allowed',
@@ -320,6 +341,26 @@ describe('work submit-to-site route', () => {
         external: false,
         private: true,
         restricted: false,
+        ...submitReadySiteFields(),
+      },
+      {
+        id: 'site-no-kind',
+        name: 'no-kind-site',
+        title: 'No Kind Site',
+        description: null,
+        metadata: { logo: 'no-kind.png' },
+        external: false,
+        private: false,
+        restricted: false,
+        submissionKinds: [],
+        collections: [
+          {
+            id: 'collection-open',
+            default: true,
+            open: true,
+            kindsInCollection: [],
+          },
+        ],
       },
     ]);
 
@@ -340,6 +381,41 @@ describe('work submit-to-site route', () => {
     ]);
     expect(result.availableSites[0]).not.toHaveProperty('private');
     expect(result.availableSites[0]).not.toHaveProperty('restricted');
+  });
+
+  it('keeps sites with an existing work submission even when collections are closed', async () => {
+    vi.mocked(getUniqueSubmissions).mockReturnValueOnce([
+      {
+        id: 'submission-1',
+        site_id: 'site-existing',
+        site: { id: 'site-existing', name: 'existing-site', title: 'Existing Site' },
+        collection: { workflow: 'SIMPLE' },
+        versions: [{ id: 'sv-1', status: 'PUBLISHED' }],
+      },
+    ] as never);
+    findManySites.mockResolvedValue([
+      {
+        id: 'site-existing',
+        name: 'existing-site',
+        title: 'Existing Site',
+        description: null,
+        metadata: {},
+        external: false,
+        private: false,
+        restricted: false,
+        submissionKinds: [],
+        collections: [
+          { id: 'collection-closed', default: true, open: false, kindsInCollection: [] },
+        ],
+      },
+    ]);
+
+    const result = await loader({
+      request: new Request('http://localhost/app/works/work-1/details'),
+      params: { workId: 'work-1' },
+    } as never);
+
+    expect(result.availableSites.map((site) => site.name)).toEqual(['existing-site']);
   });
 
   it('returns the existing submission version when the selected version is already submitted', async () => {

--- a/platform/scms/app/routes/app/works.$workId/route.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/route.test.ts
@@ -15,7 +15,6 @@ const {
   findManySites,
   findUniqueSite,
   loadCheckMaintenanceByServiceIds,
-  promoteDraftSubmissionVersionToPending,
   userHasScope,
   withSecureWorkContext,
 } = vi.hoisted(() => ({
@@ -32,18 +31,9 @@ const {
   findManySites: vi.fn(),
   findUniqueSite: vi.fn(),
   loadCheckMaintenanceByServiceIds: vi.fn(),
-  promoteDraftSubmissionVersionToPending: vi.fn(),
   userHasScope: vi.fn(),
   withSecureWorkContext: vi.fn(),
 }));
-
-vi.mock('./submitToSite.server', async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...(actual as object),
-    promoteDraftSubmissionVersionToPending,
-  };
-});
 
 vi.mock('@curvenote/scms-server', () => ({
   withSecureWorkContext,
@@ -514,7 +504,7 @@ describe('work submit-to-site route', () => {
     expect(createReturningVersion).not.toHaveBeenCalled();
   });
 
-  it('promotes a draft submission version when resubmitting the same work version', async () => {
+  it('creates a new submission version when the latest version for the work version is draft', async () => {
     findUniqueSite.mockResolvedValue({
       id: 'site-public',
       name: 'public-site',
@@ -537,6 +527,7 @@ describe('work submit-to-site route', () => {
       id: 'submission-1',
       versions: [{ id: 'sv-draft', work_version_id: 'wv-1', status: 'DRAFT' }],
     });
+    createSubmissionVersion.mockResolvedValue({ id: 'sv-pending' });
 
     const response = await action({
       request: createSubmitToSiteRequest('public-site', 'wv-1'),
@@ -547,15 +538,15 @@ describe('work submit-to-site route', () => {
       success: true,
       intent: 'submit-to-site',
       siteName: 'public-site',
-      submissionVersionId: 'sv-draft',
+      submissionVersionId: 'sv-pending',
     });
     expect(response).not.toHaveProperty('alreadySubmitted');
-    expect(promoteDraftSubmissionVersionToPending).toHaveBeenCalledWith('user-1', 'submission-1', {
-      id: 'sv-draft',
-      work_version_id: 'wv-1',
-      status: 'DRAFT',
-    });
-    expect(createSubmissionVersion).not.toHaveBeenCalled();
+    expect(createSubmissionVersion).toHaveBeenCalledWith(
+      expect.objectContaining({ site: expect.objectContaining({ name: 'public-site' }) }),
+      expect.any(Array),
+      'submission-1',
+      'wv-1',
+    );
     expect(createReturningVersion).not.toHaveBeenCalled();
   });
 });

--- a/platform/scms/app/routes/app/works.$workId/route.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/route.test.ts
@@ -1,0 +1,430 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  createSubmission,
+  createSubmissionVersion,
+  dbAttachMetadataToWorkVersions,
+  dbGetCheckServiceRunsByWorkVersionIds,
+  dbGetLinkedJobsByWorkVersionIds,
+  dbGetWorkActivities,
+  dbGetWorkOwnerName,
+  dbGetWorkUsers,
+  findFirstSubmission,
+  findFirstWorkVersion,
+  findManySites,
+  findUniqueSite,
+  loadCheckMaintenanceByServiceIds,
+  userHasScope,
+  withSecureWorkContext,
+} = vi.hoisted(() => ({
+  createSubmission: vi.fn(),
+  createSubmissionVersion: vi.fn(),
+  dbAttachMetadataToWorkVersions: vi.fn(),
+  dbGetCheckServiceRunsByWorkVersionIds: vi.fn(),
+  dbGetLinkedJobsByWorkVersionIds: vi.fn(),
+  dbGetWorkActivities: vi.fn(),
+  dbGetWorkOwnerName: vi.fn(),
+  dbGetWorkUsers: vi.fn(),
+  findFirstSubmission: vi.fn(),
+  findFirstWorkVersion: vi.fn(),
+  findManySites: vi.fn(),
+  findUniqueSite: vi.fn(),
+  loadCheckMaintenanceByServiceIds: vi.fn(),
+  userHasScope: vi.fn(),
+  withSecureWorkContext: vi.fn(),
+}));
+
+vi.mock('@curvenote/scms-server', () => ({
+  withSecureWorkContext,
+  dbCreateDraftWorkVersion: vi.fn(),
+  metadataForNewDraftFileWorkVersion: vi.fn(),
+  userHasScope,
+  getPrismaClient: vi.fn(async () => ({
+    site: {
+      findMany: findManySites,
+      findUnique: findUniqueSite,
+    },
+    submission: {
+      findFirst: findFirstSubmission,
+    },
+    workVersion: {
+      findFirst: findFirstWorkVersion,
+    },
+  })),
+  SiteContextWithUser: vi.fn(function SiteContextWithUser(ctx, site) {
+    return { ...ctx, site };
+  }),
+  sites: {
+    submissions: {
+      create: createSubmission,
+      versions: {
+        create: createSubmissionVersion,
+      },
+    },
+  },
+  works: {
+    formatWorkDTO: vi.fn((_ctx, _work, version) => ({
+      id: 'work-1',
+      title: version.title,
+      links: {},
+    })),
+  },
+}));
+
+vi.mock('@curvenote/scms-core', () => ({
+  MainWrapper: vi.fn(),
+  SecondaryNav: vi.fn(),
+  getBrandingFromMetaMatches: vi.fn(() => ({ title: 'SCMS' })),
+  joinPageTitle: vi.fn((title: string | undefined, suffix: string) => `${title ?? ''} ${suffix}`),
+  TrackEvent: {
+    WORK_VIEWED: 'WORK_VIEWED',
+  },
+  getWorkflows: vi.fn(() => ({ SIMPLE: {} })),
+  registerExtensionWorkflows: vi.fn(() => ({})),
+  getExtensionCheckServicesFromServerConfig: vi.fn(() => []),
+  loadCheckMaintenanceByServiceIds,
+  CheckMaintenanceProvider: vi.fn(({ children }) => children),
+  scopes: {
+    app: {
+      works: {
+        upload: 'app:works:upload',
+        submitToSite: 'app:works:submit-to-site',
+      },
+    },
+    site: {
+      submissions: {
+        create: 'site:submissions:create',
+      },
+    },
+    work: {
+      id: {
+        read: 'work:id:read',
+      },
+    },
+  },
+}));
+
+vi.mock('./menu', () => ({
+  buildMenu: vi.fn(() => []),
+}));
+
+vi.mock('./db.server', () => ({
+  dbAttachMetadataToWorkVersions,
+  dbGetCheckServiceRunsByWorkVersionIds,
+  dbGetLinkedJobsByWorkVersionIds,
+  dbGetLatestWorkVersionForWork: vi.fn(),
+  dbGetWorkActivities,
+  dbGetWorkOwnerName,
+  dbGetWorkVersionsWithSubmissionVersions: vi.fn(async () => [
+    {
+      id: 'wv-1',
+      title: 'Version 1',
+      draft: false,
+      date_created: '2026-01-01T00:00:00.000Z',
+      date_modified: '2026-01-01T00:00:00.000Z',
+      authors: [],
+      author_details: [],
+      submissionVersions: [],
+    },
+  ]),
+  dbDeleteDraftVersionOnWork: vi.fn(),
+}));
+
+vi.mock('../works.$workId.users/db.server', () => ({
+  dbGetWorkUsers,
+  dtoWorkUsers: vi.fn(() => []),
+}));
+
+vi.mock('./WorkDetailsCard', () => ({
+  WorkDetailsCard: vi.fn(),
+}));
+
+vi.mock('./utils.server', () => ({
+  getUniqueSubmissions: vi.fn(() => []),
+}));
+
+vi.mock('./metadata.server', () => ({
+  computeCanResumeDraftUpload: vi.fn(() => false),
+  getLicenseDisplayFromMetadata: vi.fn(() => null),
+  isDraftVersionValidForReuse: vi.fn(() => false),
+  resolveWorkVersionDoi: vi.fn((versionDoi: string | null | undefined) => versionDoi ?? null),
+  signVersionFilesForClient: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../extensions/client', () => ({
+  extensions: [],
+}));
+
+vi.mock('../../../extensions/server', () => ({
+  extensions: [],
+}));
+
+vi.mock('./actionHelpers.server', () => ({
+  exportToPdfAction: vi.fn(),
+}));
+
+const { action, loader } = await import('./route');
+
+function createSubmitToSiteRequest(siteName = 'private-site', workVersionId = 'wv-1'): Request {
+  const formData = new FormData();
+  formData.set('intent', 'submit-to-site');
+  formData.set('siteName', siteName);
+  formData.set('workVersionId', workVersionId);
+  return new Request('http://localhost/app/works/work-1', {
+    method: 'POST',
+    body: formData,
+  });
+}
+
+describe('work submit-to-site route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    withSecureWorkContext.mockResolvedValue({
+      user: {
+        id: 'user-1',
+        system_scopes: ['app:works:submit-to-site'],
+        site_roles: [],
+      },
+      work: { id: 'work-1' },
+      workDTO: { title: 'Work 1' },
+      $config: {},
+      trackEvent: vi.fn(),
+      analytics: { flush: vi.fn() },
+    });
+    userHasScope.mockImplementation((_user, scope, siteName) => {
+      if (scope === 'app:works:submit-to-site') return true;
+      return scope === 'site:submissions:create' && siteName === 'allowed-site';
+    });
+    findUniqueSite.mockResolvedValue({
+      id: 'site-private',
+      name: 'private-site',
+      title: 'Private Site',
+      private: true,
+      restricted: false,
+      external: false,
+      domains: [],
+      submissionKinds: [{ id: 'kind-1', default: true }],
+      collections: [
+        {
+          id: 'collection-1',
+          default: true,
+          open: true,
+          kindsInCollection: [{ kind: { id: 'kind-1', default: true } }],
+        },
+      ],
+    });
+    findFirstSubmission.mockResolvedValue(null);
+    findFirstWorkVersion.mockResolvedValue({ id: 'wv-1' });
+    createSubmission.mockResolvedValue({ versions: [{ id: 'sv-1' }] });
+    createSubmissionVersion.mockResolvedValue({ id: 'sv-2' });
+    dbAttachMetadataToWorkVersions.mockImplementation(async (versions) => versions);
+    dbGetWorkOwnerName.mockResolvedValue('Owner');
+    dbGetWorkActivities.mockResolvedValue([]);
+    dbGetCheckServiceRunsByWorkVersionIds.mockResolvedValue({});
+    dbGetLinkedJobsByWorkVersionIds.mockResolvedValue({});
+    dbGetWorkUsers.mockResolvedValue([]);
+    loadCheckMaintenanceByServiceIds.mockResolvedValue({});
+  });
+
+  it('rejects private site submissions when the user lacks site create scope', async () => {
+    const response = await action({
+      request: createSubmitToSiteRequest(),
+      params: { workId: 'work-1' },
+    } as never);
+    const status = 'init' in response ? response.init?.status : 200;
+    const body = 'data' in response ? response.data : response;
+
+    expect(status).toBe(403);
+    expect(body).toMatchObject({
+      success: false,
+      intent: 'submit-to-site',
+    });
+    expect(createSubmission).not.toHaveBeenCalled();
+  });
+
+  it('allows submissions to public external sites', async () => {
+    findUniqueSite.mockResolvedValue({
+      id: 'site-external',
+      name: 'external-site',
+      title: 'External Site',
+      private: false,
+      restricted: false,
+      external: true,
+      domains: [],
+      submissionKinds: [{ id: 'kind-1', default: true }],
+      collections: [
+        {
+          id: 'collection-1',
+          default: true,
+          open: true,
+          kindsInCollection: [{ kind: { id: 'kind-1', default: true } }],
+        },
+      ],
+    });
+
+    const response = await action({
+      request: createSubmitToSiteRequest('external-site'),
+      params: { workId: 'work-1' },
+    } as never);
+
+    const body = 'data' in response ? response.data : response;
+
+    expect(body).toMatchObject({
+      success: true,
+      intent: 'submit-to-site',
+      siteName: 'external-site',
+      submissionVersionId: 'sv-1',
+    });
+    expect(createSubmission).toHaveBeenCalled();
+  });
+
+  it('exposes external sites first when the user can submit to them', async () => {
+    findManySites.mockResolvedValue([
+      {
+        id: 'site-external',
+        name: 'external-site',
+        title: 'External Site',
+        description: null,
+        metadata: { logo: 'external.png' },
+        external: true,
+        private: false,
+        restricted: false,
+      },
+      {
+        id: 'site-public',
+        name: 'public-site',
+        title: 'Public Site',
+        description: null,
+        metadata: { logo: 'public.png' },
+        external: false,
+        private: false,
+        restricted: false,
+      },
+      {
+        id: 'site-private',
+        name: 'private-site',
+        title: 'Private Site',
+        description: null,
+        metadata: { logo: 'private.png' },
+        external: false,
+        private: true,
+        restricted: false,
+      },
+      {
+        id: 'site-allowed',
+        name: 'allowed-site',
+        title: 'Allowed Site',
+        description: null,
+        metadata: { logo: 'allowed.png' },
+        external: false,
+        private: true,
+        restricted: false,
+      },
+    ]);
+
+    const result = await loader({
+      request: new Request('http://localhost/app/works/work-1/details'),
+      params: { workId: 'work-1' },
+    } as never);
+
+    expect(findManySites).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ external: 'desc' }, { title: 'asc' }, { name: 'asc' }],
+      }),
+    );
+    expect(result.availableSites.map((site) => site.name)).toEqual([
+      'external-site',
+      'public-site',
+      'allowed-site',
+    ]);
+    expect(result.availableSites[0]).not.toHaveProperty('private');
+    expect(result.availableSites[0]).not.toHaveProperty('restricted');
+  });
+
+  it('returns the existing submission version when the selected version is already submitted', async () => {
+    findUniqueSite.mockResolvedValue({
+      id: 'site-public',
+      name: 'public-site',
+      title: 'Public Site',
+      private: false,
+      restricted: false,
+      external: false,
+      domains: [],
+      submissionKinds: [{ id: 'kind-1', default: true }],
+      collections: [
+        {
+          id: 'collection-1',
+          default: true,
+          open: true,
+          kindsInCollection: [{ kind: { id: 'kind-1', default: true } }],
+        },
+      ],
+    });
+    findFirstSubmission.mockResolvedValue({
+      id: 'submission-1',
+      versions: [{ id: 'sv-1', work_version_id: 'wv-1' }],
+    });
+
+    const response = await action({
+      request: createSubmitToSiteRequest('public-site', 'wv-1'),
+      params: { workId: 'work-1' },
+    } as never);
+
+    expect(response).toMatchObject({
+      success: true,
+      intent: 'submit-to-site',
+      siteName: 'public-site',
+      submissionVersionId: 'sv-1',
+      alreadySubmitted: true,
+    });
+    expect(createSubmissionVersion).not.toHaveBeenCalled();
+    expect(createSubmission).not.toHaveBeenCalled();
+  });
+
+  it('creates a new submission version when an already-submitted site receives a newer version', async () => {
+    findUniqueSite.mockResolvedValue({
+      id: 'site-public',
+      name: 'public-site',
+      title: 'Public Site',
+      private: false,
+      restricted: false,
+      external: false,
+      domains: [],
+      submissionKinds: [{ id: 'kind-1', default: true }],
+      collections: [
+        {
+          id: 'collection-1',
+          default: true,
+          open: true,
+          kindsInCollection: [{ kind: { id: 'kind-1', default: true } }],
+        },
+      ],
+    });
+    findFirstSubmission.mockResolvedValue({
+      id: 'submission-1',
+      versions: [{ id: 'sv-1', work_version_id: 'wv-1' }],
+    });
+    findFirstWorkVersion.mockResolvedValue({ id: 'wv-2' });
+    createSubmissionVersion.mockResolvedValue({ id: 'sv-2' });
+
+    const response = await action({
+      request: createSubmitToSiteRequest('public-site', 'wv-2'),
+      params: { workId: 'work-1' },
+    } as never);
+
+    expect(response).toMatchObject({
+      success: true,
+      intent: 'submit-to-site',
+      siteName: 'public-site',
+      submissionVersionId: 'sv-2',
+    });
+    expect(createSubmissionVersion).toHaveBeenCalledWith(
+      expect.objectContaining({ site: expect.objectContaining({ name: 'public-site' }) }),
+      expect.any(Array),
+      'submission-1',
+      'wv-2',
+    );
+    expect(createSubmission).not.toHaveBeenCalled();
+  });
+});

--- a/platform/scms/app/routes/app/works.$workId/route.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/route.test.ts
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
-  createSubmission,
+  createReturningVersion,
   createSubmissionVersion,
   dbAttachMetadataToWorkVersions,
   dbGetCheckServiceRunsByWorkVersionIds,
@@ -18,7 +18,7 @@ const {
   userHasScope,
   withSecureWorkContext,
 } = vi.hoisted(() => ({
-  createSubmission: vi.fn(),
+  createReturningVersion: vi.fn(),
   createSubmissionVersion: vi.fn(),
   dbAttachMetadataToWorkVersions: vi.fn(),
   dbGetCheckServiceRunsByWorkVersionIds: vi.fn(),
@@ -57,7 +57,7 @@ vi.mock('@curvenote/scms-server', () => ({
   }),
   sites: {
     submissions: {
-      create: createSubmission,
+      createReturningVersion,
       versions: {
         create: createSubmissionVersion,
       },
@@ -216,7 +216,7 @@ describe('work submit-to-site route', () => {
     });
     findFirstSubmission.mockResolvedValue(null);
     findFirstWorkVersion.mockResolvedValue({ id: 'wv-1' });
-    createSubmission.mockResolvedValue({ versions: [{ id: 'sv-1' }] });
+    createReturningVersion.mockResolvedValue({ id: 'sv-1' });
     createSubmissionVersion.mockResolvedValue({ id: 'sv-2' });
     dbAttachMetadataToWorkVersions.mockImplementation(async (versions) => versions);
     dbGetWorkOwnerName.mockResolvedValue('Owner');
@@ -240,7 +240,7 @@ describe('work submit-to-site route', () => {
       success: false,
       intent: 'submit-to-site',
     });
-    expect(createSubmission).not.toHaveBeenCalled();
+    expect(createReturningVersion).not.toHaveBeenCalled();
   });
 
   it('allows submissions to public external sites', async () => {
@@ -276,7 +276,7 @@ describe('work submit-to-site route', () => {
       siteName: 'external-site',
       submissionVersionId: 'sv-1',
     });
-    expect(createSubmission).toHaveBeenCalled();
+    expect(createReturningVersion).toHaveBeenCalled();
   });
 
   it('exposes external sites first when the user can submit to them', async () => {
@@ -379,7 +379,7 @@ describe('work submit-to-site route', () => {
       alreadySubmitted: true,
     });
     expect(createSubmissionVersion).not.toHaveBeenCalled();
-    expect(createSubmission).not.toHaveBeenCalled();
+    expect(createReturningVersion).not.toHaveBeenCalled();
   });
 
   it('creates a new submission version when an already-submitted site receives a newer version', async () => {
@@ -425,6 +425,6 @@ describe('work submit-to-site route', () => {
       'submission-1',
       'wv-2',
     );
-    expect(createSubmission).not.toHaveBeenCalled();
+    expect(createReturningVersion).not.toHaveBeenCalled();
   });
 });

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -63,7 +63,6 @@ import {
   canUserSubmitToSite,
   isAlreadySubmittedVersion,
   isSiteAvailableForWorkSubmit,
-  promoteDraftSubmissionVersionToPending,
   resolveOpenCollection,
   resolveSubmissionKind,
 } from './submitToSite.server';
@@ -318,26 +317,13 @@ export async function action(args: ActionFunctionArgs) {
       const siteCtx = new SiteContextWithUser(ctx, site);
       const existingVersion = existingSubmission?.versions?.[0];
       if (existingSubmission) {
-        if (existingVersion?.work_version_id === selectedVersion.id) {
-          if (isAlreadySubmittedVersion(existingVersion, selectedVersion.id)) {
-            return {
-              success: true,
-              intent,
-              siteName,
-              submissionVersionId: existingVersion.id,
-              alreadySubmitted: true,
-            };
-          }
-          await promoteDraftSubmissionVersionToPending(
-            ctx.user.id,
-            existingSubmission.id,
-            existingVersion,
-          );
+        if (isAlreadySubmittedVersion(existingVersion, selectedVersion.id)) {
           return {
             success: true,
             intent,
             siteName,
-            submissionVersionId: existingVersion.id,
+            submissionVersionId: existingVersion!.id,
+            alreadySubmitted: true,
           };
         }
         const submissionVersion = await siteLoaders.submissions.versions.create(

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -317,7 +317,7 @@ export async function action(args: ActionFunctionArgs) {
       }
 
       const siteCtx = new SiteContextWithUser(ctx, site);
-      const existingVersion = existingSubmission?.versions[0];
+      const existingVersion = existingSubmission?.versions?.[0];
       if (existingSubmission) {
         if (existingVersion?.work_version_id === selectedVersion.id) {
           return {
@@ -365,7 +365,7 @@ export async function action(args: ActionFunctionArgs) {
         );
       }
 
-      const submission = await siteLoaders.submissions.create(
+      const submissionVersion = await siteLoaders.submissions.createReturningVersion(
         siteCtx,
         serverExtensions,
         selectedVersion.id,
@@ -378,7 +378,7 @@ export async function action(args: ActionFunctionArgs) {
         success: true,
         intent,
         siteName,
-        submissionVersionId: submission.versions[0]?.id,
+        submissionVersionId: submissionVersion.id,
       };
     } catch (error) {
       console.error('Failed to submit work to site:', error);

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -59,6 +59,12 @@ import type { WorkVersionContentCardData, WorkVersionForDetailsClient } from './
 import { extensions } from '../../../extensions/client';
 import { extensions as serverExtensions } from '../../../extensions/server';
 import { exportToPdfAction } from './actionHelpers.server';
+import {
+  canUserSubmitToSite,
+  isSiteAvailableForWorkSubmit,
+  resolveOpenCollection,
+  resolveSubmissionKind,
+} from './submitToSite.server';
 import { z } from 'zod';
 import { zfd } from 'zod-form-data';
 
@@ -76,21 +82,6 @@ const WorkActionIntentSchema = zfd.formData({
   siteName: zfd.text(z.string().optional()),
   workVersionId: zfd.text(z.string().optional()),
 });
-
-type SubmitTargetSite = {
-  name: string;
-  external: boolean;
-  private: boolean;
-  restricted: boolean;
-};
-
-function canUserSubmitToSite(
-  user: Parameters<typeof userHasScope>[0],
-  site: SubmitTargetSite,
-): boolean {
-  if (!site.private && !site.restricted) return true;
-  return userHasScope(user, scopes.site.submissions.create, site.name);
-}
 
 export async function action(args: ActionFunctionArgs) {
   const formData = await args.request.formData();
@@ -342,9 +333,7 @@ export async function action(args: ActionFunctionArgs) {
         };
       }
 
-      const collection =
-        site.collections.find((item) => item.default && item.open) ??
-        site.collections.find((item) => item.open);
+      const collection = resolveOpenCollection(site.collections);
       if (!collection) {
         return data(
           { success: false, intent, error: 'Selected site has no open collection' },
@@ -352,12 +341,7 @@ export async function action(args: ActionFunctionArgs) {
         );
       }
 
-      const collectionKinds = collection.kindsInCollection.map((item) => item.kind);
-      const kind =
-        collectionKinds.find((item) => item.default) ??
-        collectionKinds[0] ??
-        site.submissionKinds.find((item) => item.default) ??
-        site.submissionKinds[0];
+      const kind = resolveSubmissionKind(collection, site.submissionKinds);
       if (!kind) {
         return data(
           { success: false, intent, error: 'Selected site has no submission kind' },
@@ -511,6 +495,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
     serverExtensions,
     checkServices.map((service) => service.id),
   );
+  const workSubmittedSiteIds = new Set(submissions.map((submission) => submission.site_id));
   const availableSites = canSubmitToSite
     ? (
         await (
@@ -526,10 +511,21 @@ export const loader = async (args: LoaderFunctionArgs) => {
             external: true,
             private: true,
             restricted: true,
+            submissionKinds: { select: { id: true, default: true } },
+            collections: {
+              select: {
+                id: true,
+                default: true,
+                open: true,
+                kindsInCollection: {
+                  select: { kind: { select: { id: true, default: true } } },
+                },
+              },
+            },
           },
         })
       )
-        .filter((site) => canUserSubmitToSite(ctx.user, site))
+        .filter((site) => isSiteAvailableForWorkSubmit(ctx.user, site, workSubmittedSiteIds))
         .map((site) => ({
           id: site.id,
           name: site.name,

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -14,6 +14,9 @@ import {
   userHasScope,
   works,
   getUserScopesSet,
+  getPrismaClient,
+  SiteContextWithUser,
+  sites as siteLoaders,
 } from '@curvenote/scms-server';
 import {
   MainWrapper,
@@ -61,10 +64,33 @@ import { zfd } from 'zod-form-data';
 
 const WorkActionIntentSchema = zfd.formData({
   intent: zfd.text(
-    z.enum(['export-to-pdf', 'get-drafts-for-work', 'create-new-version', 'delete-draft']),
+    z.enum([
+      'export-to-pdf',
+      'get-drafts-for-work',
+      'create-new-version',
+      'delete-draft',
+      'submit-to-site',
+    ]),
   ),
   workId: zfd.text(z.string().optional()),
+  siteName: zfd.text(z.string().optional()),
+  workVersionId: zfd.text(z.string().optional()),
 });
+
+type SubmitTargetSite = {
+  name: string;
+  external: boolean;
+  private: boolean;
+  restricted: boolean;
+};
+
+function canUserSubmitToSite(
+  user: Parameters<typeof userHasScope>[0],
+  site: SubmitTargetSite,
+): boolean {
+  if (!site.private && !site.restricted) return true;
+  return userHasScope(user, scopes.site.submissions.create, site.name);
+}
 
 export async function action(args: ActionFunctionArgs) {
   const formData = await args.request.formData();
@@ -76,7 +102,7 @@ export async function action(args: ActionFunctionArgs) {
     );
   }
 
-  const { intent, workId: formWorkId } = parsed.data;
+  const { intent, workId: formWorkId, siteName, workVersionId } = parsed.data;
   const ctx = await withSecureWorkContext(args, [scopes.work.id.read]);
 
   if (intent === 'get-drafts-for-work') {
@@ -231,6 +257,142 @@ export async function action(args: ActionFunctionArgs) {
     }
   }
 
+  if (intent === 'submit-to-site') {
+    if (!userHasScope(ctx.user, scopes.app.works.submitToSite)) {
+      return data(
+        { success: false, intent, error: 'Submit to site scope required' },
+        { status: 403 },
+      );
+    }
+    if (!siteName) {
+      return data({ success: false, intent, error: 'Site is required' }, { status: 400 });
+    }
+
+    try {
+      const prisma = await getPrismaClient();
+      const site = await prisma.site.findUnique({
+        where: { name: siteName },
+        include: {
+          domains: true,
+          submissionKinds: true,
+          collections: {
+            orderBy: [{ default: 'desc' }, { date_created: 'desc' }],
+            include: { kindsInCollection: { include: { kind: true } } },
+          },
+        },
+      });
+      if (!site) {
+        return data(
+          { success: false, intent, error: 'Selected site does not exist' },
+          { status: 400 },
+        );
+      }
+      if (!canUserSubmitToSite(ctx.user, site)) {
+        return data(
+          { success: false, intent, error: 'You do not have permission to submit to this site' },
+          { status: 403 },
+        );
+      }
+
+      const existingSubmission = await prisma.submission.findFirst({
+        where: { work_id: ctx.work.id, site_id: site.id },
+        include: { versions: { orderBy: { date_created: 'desc' }, take: 1 } },
+      });
+
+      const selectedVersion = workVersionId
+        ? await prisma.workVersion.findFirst({
+            where: { id: workVersionId, work_id: ctx.work.id, draft: false },
+            select: { id: true },
+          })
+        : await prisma.workVersion.findFirst({
+            where: { work_id: ctx.work.id, draft: false },
+            orderBy: { date_created: 'desc' },
+            select: { id: true },
+          });
+      if (!selectedVersion) {
+        return data(
+          { success: false, intent, error: 'No completed work version is available to submit' },
+          { status: 400 },
+        );
+      }
+
+      const siteCtx = new SiteContextWithUser(ctx, site);
+      const existingVersion = existingSubmission?.versions[0];
+      if (existingSubmission) {
+        if (existingVersion?.work_version_id === selectedVersion.id) {
+          return {
+            success: true,
+            intent,
+            siteName,
+            submissionVersionId: existingVersion.id,
+            alreadySubmitted: true,
+          };
+        }
+        const submissionVersion = await siteLoaders.submissions.versions.create(
+          siteCtx,
+          serverExtensions,
+          existingSubmission.id,
+          selectedVersion.id,
+        );
+        return {
+          success: true,
+          intent,
+          siteName,
+          submissionVersionId: submissionVersion.id,
+        };
+      }
+
+      const collection =
+        site.collections.find((item) => item.default && item.open) ??
+        site.collections.find((item) => item.open);
+      if (!collection) {
+        return data(
+          { success: false, intent, error: 'Selected site has no open collection' },
+          { status: 400 },
+        );
+      }
+
+      const collectionKinds = collection.kindsInCollection.map((item) => item.kind);
+      const kind =
+        collectionKinds.find((item) => item.default) ??
+        collectionKinds[0] ??
+        site.submissionKinds.find((item) => item.default) ??
+        site.submissionKinds[0];
+      if (!kind) {
+        return data(
+          { success: false, intent, error: 'Selected site has no submission kind' },
+          { status: 400 },
+        );
+      }
+
+      const submission = await siteLoaders.submissions.create(
+        siteCtx,
+        serverExtensions,
+        selectedVersion.id,
+        kind.id,
+        false,
+        undefined,
+        collection.id,
+      );
+      return {
+        success: true,
+        intent,
+        siteName,
+        submissionVersionId: submission.versions[0]?.id,
+      };
+    } catch (error) {
+      console.error('Failed to submit work to site:', error);
+      return data(
+        {
+          success: false,
+          intent,
+          error: error instanceof Error ? error.message : 'Failed to submit work to site',
+        },
+        { status: 500 },
+      );
+    }
+  }
+
   if (intent === 'export-to-pdf') {
     return exportToPdfAction(ctx, formData);
   }
@@ -302,6 +464,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
 
   const versionIds = workVersionsWithMetadata.map((v) => v.id);
   const canUpload = userHasScope(ctx.user, scopes.app.works.upload);
+  const canSubmitToSite = userHasScope(ctx.user, scopes.app.works.submitToSite);
 
   const latestVersion = workVersionsWithMetadata[0];
   const latestNonDraftWithMetadata = workVersionsWithMetadata.find((v) => !v.draft);
@@ -348,6 +511,34 @@ export const loader = async (args: LoaderFunctionArgs) => {
     serverExtensions,
     checkServices.map((service) => service.id),
   );
+  const availableSites = canSubmitToSite
+    ? (
+        await (
+          await getPrismaClient()
+        ).site.findMany({
+          orderBy: [{ external: 'desc' }, { title: 'asc' }, { name: 'asc' }],
+          select: {
+            id: true,
+            name: true,
+            title: true,
+            description: true,
+            metadata: true,
+            external: true,
+            private: true,
+            restricted: true,
+          },
+        })
+      )
+        .filter((site) => canUserSubmitToSite(ctx.user, site))
+        .map((site) => ({
+          id: site.id,
+          name: site.name,
+          title: site.title,
+          description: site.description,
+          metadata: site.metadata,
+          external: site.external,
+        }))
+    : [];
 
   return {
     userScopes: ctx.scopes,
@@ -364,6 +555,8 @@ export const loader = async (args: LoaderFunctionArgs) => {
     resumeDraftVersionId,
     latestNonDraftContentCard,
     users,
+    canSubmitToSite,
+    availableSites,
     isOnUploadRoute,
     maintenanceByServiceId,
   };

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -310,6 +310,7 @@ export async function action(args: ActionFunctionArgs) {
           where: { work_id: ctx.work.id, site_id: site.id },
           include: {
             versions: {
+              where: { work_version_id: selectedVersion.id },
               orderBy: { date_created: 'desc' },
               take: 1,
               select: { id: true, work_version_id: true, status: true },

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -61,10 +61,11 @@ import { extensions as serverExtensions } from '../../../extensions/server';
 import { exportToPdfAction } from './actionHelpers.server';
 import {
   canUserSubmitToSite,
-  isAlreadySubmittedVersion,
   isSiteAvailableForWorkSubmit,
   resolveOpenCollection,
   resolveSubmissionKind,
+  SubmitToSiteConfigError,
+  submitWorkVersionToSite,
 } from './submitToSite.server';
 import { z } from 'zod';
 import { zfd } from 'zod-form-data';
@@ -286,17 +287,6 @@ export async function action(args: ActionFunctionArgs) {
         );
       }
 
-      const existingSubmission = await prisma.submission.findFirst({
-        where: { work_id: ctx.work.id, site_id: site.id },
-        include: {
-          versions: {
-            orderBy: { date_created: 'desc' },
-            take: 1,
-            select: { id: true, work_version_id: true, status: true },
-          },
-        },
-      });
-
       const selectedVersion = workVersionId
         ? await prisma.workVersion.findFirst({
             where: { id: workVersionId, work_id: ctx.work.id, draft: false },
@@ -315,63 +305,55 @@ export async function action(args: ActionFunctionArgs) {
       }
 
       const siteCtx = new SiteContextWithUser(ctx, site);
-      const existingVersion = existingSubmission?.versions?.[0];
-      if (existingSubmission) {
-        if (isAlreadySubmittedVersion(existingVersion, selectedVersion.id)) {
-          return {
-            success: true,
-            intent,
-            siteName,
-            submissionVersionId: existingVersion!.id,
-            alreadySubmitted: true,
-          };
-        }
-        const submissionVersion = await siteLoaders.submissions.versions.create(
-          siteCtx,
-          serverExtensions,
-          existingSubmission.id,
-          selectedVersion.id,
-        );
-        return {
-          success: true,
-          intent,
-          siteName,
-          submissionVersionId: submissionVersion.id,
-        };
-      }
+      const findExistingSubmission = () =>
+        prisma.submission.findFirst({
+          where: { work_id: ctx.work.id, site_id: site.id },
+          include: {
+            versions: {
+              orderBy: { date_created: 'desc' },
+              take: 1,
+              select: { id: true, work_version_id: true, status: true },
+            },
+          },
+        });
 
-      const collection = resolveOpenCollection(site.collections);
-      if (!collection) {
-        return data(
-          { success: false, intent, error: 'Selected site has no open collection' },
-          { status: 400 },
-        );
-      }
-
-      const kind = resolveSubmissionKind(collection, site.submissionKinds);
-      if (!kind) {
-        return data(
-          { success: false, intent, error: 'Selected site has no submission kind' },
-          { status: 400 },
-        );
-      }
-
-      const submissionVersion = await siteLoaders.submissions.createReturningVersion(
-        siteCtx,
-        serverExtensions,
+      return submitWorkVersionToSite(
+        {
+          findExistingSubmission,
+          createSubmissionVersion: (submissionId) =>
+            siteLoaders.submissions.versions.create(
+              siteCtx,
+              serverExtensions,
+              submissionId,
+              selectedVersion.id,
+            ),
+          createNewSubmissionReturningVersion: async () => {
+            const collection = resolveOpenCollection(site.collections);
+            if (!collection) {
+              throw new SubmitToSiteConfigError('Selected site has no open collection');
+            }
+            const kind = resolveSubmissionKind(collection, site.submissionKinds);
+            if (!kind) {
+              throw new SubmitToSiteConfigError('Selected site has no submission kind');
+            }
+            return siteLoaders.submissions.createReturningVersion(
+              siteCtx,
+              serverExtensions,
+              selectedVersion.id,
+              kind.id,
+              false,
+              undefined,
+              collection.id,
+            );
+          },
+        },
         selectedVersion.id,
-        kind.id,
-        false,
-        undefined,
-        collection.id,
-      );
-      return {
-        success: true,
-        intent,
         siteName,
-        submissionVersionId: submissionVersion.id,
-      };
+      );
     } catch (error) {
+      if (error instanceof SubmitToSiteConfigError) {
+        return data({ success: false, intent, error: error.message }, { status: 400 });
+      }
       console.error('Failed to submit work to site:', error);
       return data(
         {

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -61,7 +61,9 @@ import { extensions as serverExtensions } from '../../../extensions/server';
 import { exportToPdfAction } from './actionHelpers.server';
 import {
   canUserSubmitToSite,
+  isAlreadySubmittedVersion,
   isSiteAvailableForWorkSubmit,
+  promoteDraftSubmissionVersionToPending,
   resolveOpenCollection,
   resolveSubmissionKind,
 } from './submitToSite.server';
@@ -287,7 +289,13 @@ export async function action(args: ActionFunctionArgs) {
 
       const existingSubmission = await prisma.submission.findFirst({
         where: { work_id: ctx.work.id, site_id: site.id },
-        include: { versions: { orderBy: { date_created: 'desc' }, take: 1 } },
+        include: {
+          versions: {
+            orderBy: { date_created: 'desc' },
+            take: 1,
+            select: { id: true, work_version_id: true, status: true },
+          },
+        },
       });
 
       const selectedVersion = workVersionId
@@ -311,12 +319,25 @@ export async function action(args: ActionFunctionArgs) {
       const existingVersion = existingSubmission?.versions?.[0];
       if (existingSubmission) {
         if (existingVersion?.work_version_id === selectedVersion.id) {
+          if (isAlreadySubmittedVersion(existingVersion, selectedVersion.id)) {
+            return {
+              success: true,
+              intent,
+              siteName,
+              submissionVersionId: existingVersion.id,
+              alreadySubmitted: true,
+            };
+          }
+          await promoteDraftSubmissionVersionToPending(
+            ctx.user.id,
+            existingSubmission.id,
+            existingVersion,
+          );
           return {
             success: true,
             intent,
             siteName,
             submissionVersionId: existingVersion.id,
-            alreadySubmitted: true,
           };
         }
         const submissionVersion = await siteLoaders.submissions.versions.create(

--- a/platform/scms/app/routes/app/works.$workId/submitToSite.server.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/submitToSite.server.test.ts
@@ -95,6 +95,30 @@ describe('submitToSite.server', () => {
     expect(isAlreadySubmittedVersion(version, 'wv-2')).toBe(false);
   });
 
+  it('returns an existing submission version for an older work version after a newer one was submitted', async () => {
+    const createSubmissionVersion = vi.fn(async () => ({ id: 'sv-duplicate' }));
+    const result = await submitWorkVersionToSite(
+      {
+        findExistingSubmission: async () => ({
+          id: 'submission-1',
+          versions: [{ id: 'sv-old', work_version_id: 'wv-1', status: 'PENDING' }],
+        }),
+        createSubmissionVersion,
+        createNewSubmissionReturningVersion: vi.fn(),
+      },
+      'wv-1',
+      'public-site',
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      siteName: 'public-site',
+      submissionVersionId: 'sv-old',
+      alreadySubmitted: true,
+    });
+    expect(createSubmissionVersion).not.toHaveBeenCalled();
+  });
+
   it('detects submission work/site unique constraint violations', () => {
     expect(
       isSubmissionWorkSiteUniqueViolation({

--- a/platform/scms/app/routes/app/works.$workId/submitToSite.server.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/submitToSite.server.test.ts
@@ -1,11 +1,13 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   canSiteAcceptNewSubmission,
   isAlreadySubmittedVersion,
   isSiteAvailableForWorkSubmit,
+  isSubmissionWorkSiteUniqueViolation,
   resolveOpenCollection,
   resolveSubmissionKind,
+  submitWorkVersionToSite,
 } from './submitToSite.server';
 
 const baseSite = {
@@ -91,5 +93,46 @@ describe('submitToSite.server', () => {
     expect(isAlreadySubmittedVersion(version, 'wv-1')).toBe(true);
     expect(isAlreadySubmittedVersion({ ...version, status: 'DRAFT' }, 'wv-1')).toBe(false);
     expect(isAlreadySubmittedVersion(version, 'wv-2')).toBe(false);
+  });
+
+  it('detects submission work/site unique constraint violations', () => {
+    expect(
+      isSubmissionWorkSiteUniqueViolation({
+        code: 'P2002',
+        meta: { target: ['work_id', 'site_id'] },
+      }),
+    ).toBe(true);
+    expect(isSubmissionWorkSiteUniqueViolation({ code: 'P2002', meta: { target: ['id'] } })).toBe(
+      false,
+    );
+  });
+
+  it('retries on a concurrent create by adding a version to the existing submission', async () => {
+    let lookupCount = 0;
+    const result = await submitWorkVersionToSite(
+      {
+        findExistingSubmission: async () => {
+          lookupCount += 1;
+          if (lookupCount === 1) return null;
+          return {
+            id: 'submission-1',
+            versions: [{ id: 'sv-draft', work_version_id: 'wv-1', status: 'DRAFT' }],
+          };
+        },
+        createSubmissionVersion: vi.fn(async () => ({ id: 'sv-pending' })),
+        createNewSubmissionReturningVersion: vi.fn(async () => {
+          throw { code: 'P2002', meta: { target: ['work_id', 'site_id'] } };
+        }),
+      },
+      'wv-1',
+      'public-site',
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      siteName: 'public-site',
+      submissionVersionId: 'sv-pending',
+    });
+    expect(lookupCount).toBe(2);
   });
 });

--- a/platform/scms/app/routes/app/works.$workId/submitToSite.server.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/submitToSite.server.test.ts
@@ -1,0 +1,87 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { describe, expect, it } from 'vitest';
+import {
+  canSiteAcceptNewSubmission,
+  isSiteAvailableForWorkSubmit,
+  resolveOpenCollection,
+  resolveSubmissionKind,
+} from './submitToSite.server';
+
+const baseSite = {
+  id: 'site-1',
+  name: 'site-1',
+  external: false,
+  private: false,
+  restricted: false,
+};
+
+describe('submitToSite.server', () => {
+  it('resolves default open collection first', () => {
+    const collections = [
+      { id: 'closed-default', default: true, open: false, kindsInCollection: [] },
+      { id: 'open-other', default: false, open: true, kindsInCollection: [] },
+    ];
+    expect(resolveOpenCollection(collections)?.id).toBe('open-other');
+  });
+
+  it('requires a submission kind for new submissions', () => {
+    expect(
+      canSiteAcceptNewSubmission({
+        collections: [
+          {
+            id: 'collection-1',
+            default: true,
+            open: true,
+            kindsInCollection: [],
+          },
+        ],
+        submissionKinds: [],
+      }),
+    ).toBe(false);
+
+    expect(
+      canSiteAcceptNewSubmission({
+        collections: [
+          {
+            id: 'collection-1',
+            default: true,
+            open: true,
+            kindsInCollection: [{ kind: { id: 'kind-1', default: true } }],
+          },
+        ],
+        submissionKinds: [],
+      }),
+    ).toBe(true);
+  });
+
+  it('falls back to site submission kinds when collection kinds are empty', () => {
+    const collection = {
+      id: 'collection-1',
+      default: true,
+      open: true,
+      kindsInCollection: [],
+    };
+    expect(resolveSubmissionKind(collection, [{ id: 'site-kind', default: true }])).toEqual({
+      id: 'site-kind',
+      default: true,
+    });
+  });
+
+  it('allows sites with an existing work submission regardless of collection state', () => {
+    const site = {
+      ...baseSite,
+      collections: [{ id: 'collection-1', default: true, open: false, kindsInCollection: [] }],
+      submissionKinds: [],
+    };
+    expect(
+      isSiteAvailableForWorkSubmit({ system_scopes: [], site_roles: [] }, site, new Set()),
+    ).toBe(false);
+    expect(
+      isSiteAvailableForWorkSubmit(
+        { system_scopes: [], site_roles: [] },
+        site,
+        new Set(['site-1']),
+      ),
+    ).toBe(true);
+  });
+});

--- a/platform/scms/app/routes/app/works.$workId/submitToSite.server.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/submitToSite.server.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   canSiteAcceptNewSubmission,
+  isAlreadySubmittedVersion,
   isSiteAvailableForWorkSubmit,
   resolveOpenCollection,
   resolveSubmissionKind,
@@ -83,5 +84,12 @@ describe('submitToSite.server', () => {
         new Set(['site-1']),
       ),
     ).toBe(true);
+  });
+
+  it('treats only non-draft submission versions as already submitted', () => {
+    const version = { id: 'sv-1', work_version_id: 'wv-1', status: 'PENDING' };
+    expect(isAlreadySubmittedVersion(version, 'wv-1')).toBe(true);
+    expect(isAlreadySubmittedVersion({ ...version, status: 'DRAFT' }, 'wv-1')).toBe(false);
+    expect(isAlreadySubmittedVersion(version, 'wv-2')).toBe(false);
   });
 });

--- a/platform/scms/app/routes/app/works.$workId/submitToSite.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/submitToSite.server.ts
@@ -28,6 +28,9 @@ export function canUserSubmitToSite(user: UserWithScopes, site: SubmitTargetSite
   return userHasScope(user, scopes.site.submissions.create, site.name);
 }
 
+// TODO(submit-to-site): When a site has multiple open collections (or kinds), let the
+// user choose in SubmittedToBar instead of auto-picking here. For now: default-open
+// collection, else first open; then default/first kind on that collection, else site kind.
 export function resolveOpenCollection(collections: SubmitSiteCollection[]) {
   return (
     collections.find((item) => item.default && item.open) ?? collections.find((item) => item.open)

--- a/platform/scms/app/routes/app/works.$workId/submitToSite.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/submitToSite.server.ts
@@ -1,5 +1,8 @@
-import { userHasScope } from '@curvenote/scms-server';
+import { getPrismaClient, userHasScope } from '@curvenote/scms-server';
 import { scopes } from '@curvenote/scms-core';
+import { formatDate } from '@curvenote/common';
+import { ActivityType } from '@curvenote/scms-db';
+import { uuidv7 as uuid } from 'uuidv7';
 
 type UserWithScopes = Parameters<typeof userHasScope>[0];
 
@@ -22,6 +25,54 @@ export type SubmitSiteWithCollections = SubmitTargetSite & {
   collections: SubmitSiteCollection[];
   submissionKinds: { id: string; default: boolean }[];
 };
+
+export type ExistingSubmissionVersionForSubmit = {
+  id: string;
+  work_version_id: string;
+  status: string;
+};
+
+/** True when this work version is already submitted to the site (non-draft). */
+export function isAlreadySubmittedVersion(
+  existingVersion: ExistingSubmissionVersionForSubmit | undefined,
+  selectedWorkVersionId: string,
+): boolean {
+  if (!existingVersion || existingVersion.work_version_id !== selectedWorkVersionId) {
+    return false;
+  }
+  return existingVersion.status !== 'DRAFT';
+}
+
+export async function promoteDraftSubmissionVersionToPending(
+  userId: string,
+  submissionId: string,
+  submissionVersion: ExistingSubmissionVersionForSubmit,
+) {
+  const timestamp = formatDate();
+  const prisma = await getPrismaClient();
+  await prisma.$transaction(async (tx) => {
+    await tx.submissionVersion.update({
+      where: { id: submissionVersion.id },
+      data: {
+        status: 'PENDING',
+        date_modified: timestamp,
+      },
+    });
+    await tx.activity.create({
+      data: {
+        id: uuid(),
+        date_created: timestamp,
+        date_modified: timestamp,
+        activity_by_id: userId,
+        activity_type: ActivityType.SUBMISSION_VERSION_STATUS_CHANGE,
+        submission_id: submissionId,
+        submission_version_id: submissionVersion.id,
+        status: 'PENDING',
+        work_version_id: submissionVersion.work_version_id,
+      },
+    });
+  });
+}
 
 export function canUserSubmitToSite(user: UserWithScopes, site: SubmitTargetSite): boolean {
   if (!site.private && !site.restricted) return true;

--- a/platform/scms/app/routes/app/works.$workId/submitToSite.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/submitToSite.server.ts
@@ -29,6 +29,32 @@ export type ExistingSubmissionVersionForSubmit = {
   status: string;
 };
 
+export type SubmitToSiteActionResult = {
+  success: true;
+  intent: 'submit-to-site';
+  siteName: string;
+  submissionVersionId: string;
+  alreadySubmitted?: true;
+};
+
+type ExistingSubmissionForSubmit = {
+  id: string;
+  versions: ExistingSubmissionVersionForSubmit[];
+};
+
+type SubmitWorkVersionToSiteDeps = {
+  findExistingSubmission: () => Promise<ExistingSubmissionForSubmit | null>;
+  createSubmissionVersion: (submissionId: string) => Promise<{ id: string }>;
+  createNewSubmissionReturningVersion: () => Promise<{ id: string }>;
+};
+
+export class SubmitToSiteConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SubmitToSiteConfigError';
+  }
+}
+
 /** True when this work version is already submitted to the site (non-draft). */
 export function isAlreadySubmittedVersion(
   existingVersion: ExistingSubmissionVersionForSubmit | undefined,
@@ -38,6 +64,86 @@ export function isAlreadySubmittedVersion(
     return false;
   }
   return existingVersion.status !== 'DRAFT';
+}
+
+export function isSubmissionWorkSiteUniqueViolation(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('code' in error)) {
+    return false;
+  }
+  if ((error as { code?: string }).code !== 'P2002') {
+    return false;
+  }
+  const target = (error as { meta?: { target?: unknown } }).meta?.target;
+  if (Array.isArray(target)) {
+    return target.includes('work_id') && target.includes('site_id');
+  }
+  return typeof target === 'string' && target.includes('work_id') && target.includes('site_id');
+}
+
+async function finishSubmitOnExistingSubmission(
+  existingSubmission: ExistingSubmissionForSubmit,
+  selectedWorkVersionId: string,
+  siteName: string,
+  createSubmissionVersion: SubmitWorkVersionToSiteDeps['createSubmissionVersion'],
+): Promise<SubmitToSiteActionResult> {
+  const existingVersion = existingSubmission.versions[0];
+  if (isAlreadySubmittedVersion(existingVersion, selectedWorkVersionId)) {
+    return {
+      success: true,
+      intent: 'submit-to-site',
+      siteName,
+      submissionVersionId: existingVersion.id,
+      alreadySubmitted: true,
+    };
+  }
+  const submissionVersion = await createSubmissionVersion(existingSubmission.id);
+  return {
+    success: true,
+    intent: 'submit-to-site',
+    siteName,
+    submissionVersionId: submissionVersion.id,
+  };
+}
+
+/** Idempotent submit: reuse an existing submission or create one, with race-safe retry. */
+export async function submitWorkVersionToSite(
+  deps: SubmitWorkVersionToSiteDeps,
+  selectedWorkVersionId: string,
+  siteName: string,
+): Promise<SubmitToSiteActionResult> {
+  const existingSubmission = await deps.findExistingSubmission();
+  if (existingSubmission) {
+    return finishSubmitOnExistingSubmission(
+      existingSubmission,
+      selectedWorkVersionId,
+      siteName,
+      deps.createSubmissionVersion,
+    );
+  }
+
+  try {
+    const submissionVersion = await deps.createNewSubmissionReturningVersion();
+    return {
+      success: true,
+      intent: 'submit-to-site',
+      siteName,
+      submissionVersionId: submissionVersion.id,
+    };
+  } catch (error) {
+    if (!isSubmissionWorkSiteUniqueViolation(error)) {
+      throw error;
+    }
+    const racedSubmission = await deps.findExistingSubmission();
+    if (!racedSubmission) {
+      throw error;
+    }
+    return finishSubmitOnExistingSubmission(
+      racedSubmission,
+      selectedWorkVersionId,
+      siteName,
+      deps.createSubmissionVersion,
+    );
+  }
 }
 
 export function canUserSubmitToSite(user: UserWithScopes, site: SubmitTargetSite): boolean {

--- a/platform/scms/app/routes/app/works.$workId/submitToSite.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/submitToSite.server.ts
@@ -55,6 +55,14 @@ export class SubmitToSiteConfigError extends Error {
   }
 }
 
+/** Pick the submission version for a work version, if any. */
+export function findSubmissionVersionForWorkVersion(
+  versions: ExistingSubmissionVersionForSubmit[],
+  selectedWorkVersionId: string,
+): ExistingSubmissionVersionForSubmit | undefined {
+  return versions.find((version) => version.work_version_id === selectedWorkVersionId);
+}
+
 /** True when this work version is already submitted to the site (non-draft). */
 export function isAlreadySubmittedVersion(
   existingVersion: ExistingSubmissionVersionForSubmit | undefined,
@@ -86,7 +94,10 @@ async function finishSubmitOnExistingSubmission(
   siteName: string,
   createSubmissionVersion: SubmitWorkVersionToSiteDeps['createSubmissionVersion'],
 ): Promise<SubmitToSiteActionResult> {
-  const existingVersion = existingSubmission.versions[0];
+  const existingVersion = findSubmissionVersionForWorkVersion(
+    existingSubmission.versions,
+    selectedWorkVersionId,
+  );
   if (isAlreadySubmittedVersion(existingVersion, selectedWorkVersionId)) {
     return {
       success: true,

--- a/platform/scms/app/routes/app/works.$workId/submitToSite.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/submitToSite.server.ts
@@ -1,8 +1,5 @@
-import { getPrismaClient, userHasScope } from '@curvenote/scms-server';
+import { userHasScope } from '@curvenote/scms-server';
 import { scopes } from '@curvenote/scms-core';
-import { formatDate } from '@curvenote/common';
-import { ActivityType } from '@curvenote/scms-db';
-import { uuidv7 as uuid } from 'uuidv7';
 
 type UserWithScopes = Parameters<typeof userHasScope>[0];
 
@@ -41,37 +38,6 @@ export function isAlreadySubmittedVersion(
     return false;
   }
   return existingVersion.status !== 'DRAFT';
-}
-
-export async function promoteDraftSubmissionVersionToPending(
-  userId: string,
-  submissionId: string,
-  submissionVersion: ExistingSubmissionVersionForSubmit,
-) {
-  const timestamp = formatDate();
-  const prisma = await getPrismaClient();
-  await prisma.$transaction(async (tx) => {
-    await tx.submissionVersion.update({
-      where: { id: submissionVersion.id },
-      data: {
-        status: 'PENDING',
-        date_modified: timestamp,
-      },
-    });
-    await tx.activity.create({
-      data: {
-        id: uuid(),
-        date_created: timestamp,
-        date_modified: timestamp,
-        activity_by_id: userId,
-        activity_type: ActivityType.SUBMISSION_VERSION_STATUS_CHANGE,
-        submission_id: submissionId,
-        submission_version_id: submissionVersion.id,
-        status: 'PENDING',
-        work_version_id: submissionVersion.work_version_id,
-      },
-    });
-  });
 }
 
 export function canUserSubmitToSite(user: UserWithScopes, site: SubmitTargetSite): boolean {

--- a/platform/scms/app/routes/app/works.$workId/submitToSite.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/submitToSite.server.ts
@@ -1,0 +1,67 @@
+import { userHasScope } from '@curvenote/scms-server';
+import { scopes } from '@curvenote/scms-core';
+
+type UserWithScopes = Parameters<typeof userHasScope>[0];
+
+export type SubmitTargetSite = {
+  name: string;
+  external: boolean;
+  private: boolean;
+  restricted: boolean;
+};
+
+export type SubmitSiteCollection = {
+  id: string;
+  default: boolean;
+  open: boolean;
+  kindsInCollection: { kind: { id: string; default: boolean } }[];
+};
+
+export type SubmitSiteWithCollections = SubmitTargetSite & {
+  id: string;
+  collections: SubmitSiteCollection[];
+  submissionKinds: { id: string; default: boolean }[];
+};
+
+export function canUserSubmitToSite(user: UserWithScopes, site: SubmitTargetSite): boolean {
+  if (!site.private && !site.restricted) return true;
+  return userHasScope(user, scopes.site.submissions.create, site.name);
+}
+
+export function resolveOpenCollection(collections: SubmitSiteCollection[]) {
+  return (
+    collections.find((item) => item.default && item.open) ?? collections.find((item) => item.open)
+  );
+}
+
+export function resolveSubmissionKind(
+  collection: SubmitSiteCollection | undefined,
+  submissionKinds: { id: string; default: boolean }[],
+) {
+  const collectionKinds = collection?.kindsInCollection.map((item) => item.kind) ?? [];
+  return (
+    collectionKinds.find((item) => item.default) ??
+    collectionKinds[0] ??
+    submissionKinds.find((item) => item.default) ??
+    submissionKinds[0]
+  );
+}
+
+/** Whether a site can receive a first-time submission for a work (open collection + kind). */
+export function canSiteAcceptNewSubmission(
+  site: Pick<SubmitSiteWithCollections, 'collections' | 'submissionKinds'>,
+): boolean {
+  const collection = resolveOpenCollection(site.collections);
+  if (!collection) return false;
+  return Boolean(resolveSubmissionKind(collection, site.submissionKinds));
+}
+
+export function isSiteAvailableForWorkSubmit(
+  user: UserWithScopes,
+  site: SubmitSiteWithCollections,
+  workSubmittedSiteIds: ReadonlySet<string>,
+): boolean {
+  if (!canUserSubmitToSite(user, site)) return false;
+  if (workSubmittedSiteIds.has(site.id)) return true;
+  return canSiteAcceptNewSubmission(site);
+}

--- a/prisma/schema/migrations/20260702120000_add_work_version_contains/migration.sql
+++ b/prisma/schema/migrations/20260702120000_add_work_version_contains/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "WorkVersion" ADD COLUMN "contains" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema/migrations/20260702120100_backfill_work_version_contains/migration.sql
+++ b/prisma/schema/migrations/20260702120100_backfill_work_version_contains/migration.sql
@@ -1,0 +1,9 @@
+-- One-time backfill: copy parent Work.contains onto each WorkVersion.
+-- Idempotent when re-run (sets the same values again).
+
+SET statement_timeout = 0;
+
+UPDATE "WorkVersion" wv
+SET "contains" = w."contains"
+FROM "Work" w
+WHERE wv."work_id" = w."id";

--- a/prisma/schema/migrations/20260702143000_submission_work_site_unique/migration.sql
+++ b/prisma/schema/migrations/20260702143000_submission_work_site_unique/migration.sql
@@ -1,0 +1,119 @@
+-- One submission per work on a site (when work_id is set). Merge any existing
+-- duplicates before adding the constraint so deploy does not fail on legacy data.
+WITH ranked AS (
+  SELECT
+    id,
+    work_id,
+    site_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY work_id, site_id
+      ORDER BY date_created ASC, id ASC
+    ) AS rn
+  FROM "Submission"
+  WHERE work_id IS NOT NULL
+),
+dupes AS (
+  SELECT id AS duplicate_id, work_id, site_id
+  FROM ranked
+  WHERE rn > 1
+),
+keepers AS (
+  SELECT id AS keep_id, work_id, site_id
+  FROM ranked
+  WHERE rn = 1
+)
+UPDATE "SubmissionVersion" sv
+SET submission_id = k.keep_id
+FROM dupes d
+JOIN keepers k ON k.work_id = d.work_id AND k.site_id = d.site_id
+WHERE sv.submission_id = d.duplicate_id;
+
+WITH ranked AS (
+  SELECT
+    id,
+    work_id,
+    site_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY work_id, site_id
+      ORDER BY date_created ASC, id ASC
+    ) AS rn
+  FROM "Submission"
+  WHERE work_id IS NOT NULL
+),
+dupes AS (
+  SELECT id AS duplicate_id, work_id, site_id
+  FROM ranked
+  WHERE rn > 1
+),
+keepers AS (
+  SELECT id AS keep_id, work_id, site_id
+  FROM ranked
+  WHERE rn = 1
+)
+UPDATE "Activity" a
+SET submission_id = k.keep_id
+FROM dupes d
+JOIN keepers k ON k.work_id = d.work_id AND k.site_id = d.site_id
+WHERE a.submission_id = d.duplicate_id;
+
+WITH ranked AS (
+  SELECT
+    id,
+    work_id,
+    site_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY work_id, site_id
+      ORDER BY date_created ASC, id ASC
+    ) AS rn
+  FROM "Submission"
+  WHERE work_id IS NOT NULL
+),
+dupes AS (
+  SELECT id AS duplicate_id, work_id, site_id
+  FROM ranked
+  WHERE rn > 1
+),
+keepers AS (
+  SELECT id AS keep_id, work_id, site_id
+  FROM ranked
+  WHERE rn = 1
+)
+UPDATE "SubmissionSearch" ss
+SET submission_id = k.keep_id
+FROM dupes d
+JOIN keepers k ON k.work_id = d.work_id AND k.site_id = d.site_id
+WHERE ss.submission_id = d.duplicate_id;
+
+DELETE FROM "Slug"
+WHERE submission_id IN (
+  SELECT duplicate_id
+  FROM (
+    SELECT
+      id AS duplicate_id,
+      ROW_NUMBER() OVER (
+        PARTITION BY work_id, site_id
+        ORDER BY date_created ASC, id ASC
+      ) AS rn
+    FROM "Submission"
+    WHERE work_id IS NOT NULL
+  ) ranked
+  WHERE rn > 1
+);
+
+DELETE FROM "Submission"
+WHERE id IN (
+  SELECT duplicate_id
+  FROM (
+    SELECT
+      id AS duplicate_id,
+      ROW_NUMBER() OVER (
+        PARTITION BY work_id, site_id
+        ORDER BY date_created ASC, id ASC
+      ) AS rn
+    FROM "Submission"
+    WHERE work_id IS NOT NULL
+  ) ranked
+  WHERE rn > 1
+);
+
+CREATE UNIQUE INDEX "Submission_work_id_site_id_key" ON "Submission"("work_id", "site_id");

--- a/prisma/schema/submission.prisma
+++ b/prisma/schema/submission.prisma
@@ -184,6 +184,7 @@ model Submission {
   /// work with an in-progress draft has `is_listed = FALSE` but must still be
   /// listed).
   @@index([site_id, date_published(sort: Desc), date_created(sort: Desc)])
+  @@unique([work_id, site_id])
 }
 
 model Slug {

--- a/prisma/schema/work.prisma
+++ b/prisma/schema/work.prisma
@@ -67,6 +67,7 @@ model WorkVersion {
   canonical          Boolean?
   metadata           Json?
   tags               String[]            @default([])
+  contains           String[]            @default([])
   work               Work                @relation(fields: [work_id], references: [id])
   work_id            String
   submissionVersions SubmissionVersion[]

--- a/prisma/seed.mts
+++ b/prisma/seed.mts
@@ -208,6 +208,29 @@ async function main() {
   console.log(
     `   ✓ Created/updated role: ${extractMetadataRole.title} (${extractMetadataRole.name})`,
   );
+
+  const submitToSiteScopes = ['app:works:submit-to-site'];
+  const submitToSiteRole = await prisma.role.upsert({
+    where: { name: 'submit-to-site' },
+    create: {
+      id: 'submit-to-site-role',
+      name: 'submit-to-site',
+      title: 'Submit to Site',
+      description: 'Submit works to SCMS sites directly from the work details page',
+      scopes: submitToSiteScopes,
+      createdBy: franklin.id,
+      date_created: startDateString,
+      date_modified: startDateString,
+    },
+    update: {
+      scopes: submitToSiteScopes,
+      date_modified: startDateString,
+    },
+  });
+  summary.roles++;
+  console.log(
+    `   ✓ Created/updated role: ${submitToSiteRole.title} (${submitToSiteRole.name})`,
+  );
   console.log(`   Total roles created: ${summary.roles}\n`);
 
   console.log('🔗 Assigning roles to users...');
@@ -259,6 +282,21 @@ async function main() {
       });
       summary.userRoles++;
       console.log(`   ✓ Assigned ${checksPreviewRole.title} to ${user.display_name}`);
+    }
+
+    // Enable direct submit-to-site from work details for local development.
+    for (const user of allUsers) {
+      await prisma.userRole.create({
+        data: {
+          id: uuidv7(),
+          user_id: user.id,
+          role_id: submitToSiteRole.id,
+          date_created: startDateString,
+          date_modified: startDateString,
+        },
+      });
+      summary.userRoles++;
+      console.log(`   ✓ Assigned ${submitToSiteRole.title} to ${user.display_name}`);
     }
   }
 


### PR DESCRIPTION
Based on a scope check, users with the appopriate scope can submit a work directly to a site, this is currently beta and only really works with sites with a single kind/collection. It is feature flagged and ready for user testing before further dev.

<img width="818" height="479" alt="image" src="https://github.com/user-attachments/assets/cbd76f09-b920-43e6-a1ac-fee0e57b49c8" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches submission creation, a data migration that merges duplicate submissions, and a new unique constraint—core publishing paths with deploy-time schema risk, though behavior is heavily tested.
> 
> **Overview**
> Adds **direct submit-to-site** from the work details **Submitted to** bar for users with `app:works:submit-to-site`: pick a completed version, review checks/files, choose a site, then POST `submit-to-site` and navigate to the new submission version. Users without the scope see early-access guidance with **contact support**. Loader supplies eligible sites (external first); UI blocks sites already submitted for that version.
> 
> Server-side **`submitToSite.server`** reuses one submission per work/site: add a submission version when the work was already on that site, create via **`createReturningVersion`** on first submit, treat non-draft duplicates as idempotent, and retry on unique `(work_id, site_id)` races. DB migration merges legacy duplicate submissions then enforces **`@@unique([work_id, site_id])`**.
> 
> Introduces **`WorkVersion.contains`** (backfilled from `Work.contains`) and shared **`resolveVersionContains` / `mergeWorkContains`** on all version-create paths (API, ETL, drafts, forms use explicit `[]`). New scope, seed role, docs, and tests cover submit flow and contains helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d23988e3f63f1d3cae87191a14a7be4594ae3ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->