### PR TITLE
🐳 Add CLI docker build

### DIFF
--- a/.changeset/ready-lines-tie.md
+++ b/.changeset/ready-lines-tie.md
@@ -1,5 +1,0 @@
----
-"@fake-scope/fake-pkg": patch
----
-
-🐳 Build and publish docker container with Curvenote CLI installed on release. This can is consumed by our github actions.

--- a/.changeset/ready-lines-tie.md
+++ b/.changeset/ready-lines-tie.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+🐳 Build and publish docker container with Curvenote CLI installed on release. This can is consumed by our github actions.

--- a/.github/workflows/publish-cli-image.yml
+++ b/.github/workflows/publish-cli-image.yml
@@ -1,0 +1,94 @@
+name: Publish CLI Image
+
+# Manual rebuild of ghcr.io/curvenote/cli from an existing npm release.
+# Useful for updating typst or other releases independent of the CLI.
+#
+# Separate from this action, the release action will automatically
+# publish an image on new CLI release.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Curvenote CLI version on npm (empty = latest)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and push CLI images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Resolve version
+        id: curvenote
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [ -z "${VERSION}" ]; then
+            VERSION="$(npm view curvenote version)"
+          fi
+          if [ -z "${VERSION}" ]; then
+            echo "Failed to resolve curvenote version" >&2
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "minor=$(echo "${VERSION}" | cut -d. -f1-2)" >> "$GITHUB_OUTPUT"
+          echo "major=$(echo "${VERSION}" | cut -d. -f1)" >> "$GITHUB_OUTPUT"
+          echo "Using curvenote@${VERSION}"
+      - name: Wait for curvenote on npm
+        run: |
+          VERSION="${{ steps.curvenote.outputs.version }}"
+          for i in 1 2 3 4 5 6 7 8; do
+            if npm view "curvenote@${VERSION}" version; then
+              exit 0
+            fi
+            echo "curvenote@${VERSION} not visible yet (attempt ${i}); retrying..."
+            sleep $((i * 5))
+          done
+          echo "curvenote@${VERSION} not available on npm" >&2
+          exit 1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push full CLI image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker/cli
+          file: ./docker/cli/Dockerfile
+          target: full
+          push: true
+          build-args: |
+            CURVENOTE_VERSION=${{ steps.curvenote.outputs.version }}
+          tags: |
+            ghcr.io/curvenote/cli:${{ steps.curvenote.outputs.version }}
+            ghcr.io/curvenote/cli:${{ steps.curvenote.outputs.minor }}
+            ghcr.io/curvenote/cli:${{ steps.curvenote.outputs.major }}
+            ghcr.io/curvenote/cli:latest
+      - name: Build and push slim CLI image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker/cli
+          file: ./docker/cli/Dockerfile
+          target: slim
+          push: true
+          build-args: |
+            CURVENOTE_VERSION=${{ steps.curvenote.outputs.version }}
+          tags: |
+            ghcr.io/curvenote/cli:${{ steps.curvenote.outputs.version }}-slim
+            ghcr.io/curvenote/cli:${{ steps.curvenote.outputs.minor }}-slim
+            ghcr.io/curvenote/cli:${{ steps.curvenote.outputs.major }}-slim
+            ghcr.io/curvenote/cli:latest-slim

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
   id-token: write # Required for OIDC
   pull-requests: write
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -51,3 +52,74 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Check if curvenote CLI was published
+        id: curvenote
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          VERSION="$(
+            echo '${{ steps.changesets.outputs.publishedPackages }}' \
+              | jq -r '.[] | select(.name == "curvenote") | .version'
+          )"
+          if [ -n "${VERSION}" ] && [ "${VERSION}" != "null" ]; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            MINOR="$(echo "${VERSION}" | cut -d. -f1-2)"
+            MAJOR="$(echo "${VERSION}" | cut -d. -f1)"
+            echo "minor=${MINOR}" >> "$GITHUB_OUTPUT"
+            echo "major=${MAJOR}" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Wait for curvenote on npm
+        if: steps.curvenote.outputs.published == 'true'
+        run: |
+          VERSION="${{ steps.curvenote.outputs.version }}"
+          for i in 1 2 3 4 5 6 7 8; do
+            if npm view "curvenote@${VERSION}" version; then
+              exit 0
+            fi
+            echo "curvenote@${VERSION} not visible yet (attempt ${i}); retrying..."
+            sleep $((i * 5))
+          done
+          echo "curvenote@${VERSION} not available on npm" >&2
+          exit 1
+      - name: Set up Docker Buildx
+        if: steps.curvenote.outputs.published == 'true'
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        if: steps.curvenote.outputs.published == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push full CLI image
+        if: steps.curvenote.outputs.published == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker/cli
+          file: ./docker/cli/Dockerfile
+          target: full
+          push: true
+          build-args: |
+            CURVENOTE_VERSION=${{ steps.curvenote.outputs.version }}
+          tags: |
+            ghcr.io/curvenote/cli:${{ steps.curvenote.outputs.version }}
+            ghcr.io/curvenote/cli:${{ steps.curvenote.outputs.minor }}
+            ghcr.io/curvenote/cli:${{ steps.curvenote.outputs.major }}
+            ghcr.io/curvenote/cli:latest
+      - name: Build and push slim CLI image
+        if: steps.curvenote.outputs.published == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker/cli
+          file: ./docker/cli/Dockerfile
+          target: slim
+          push: true
+          build-args: |
+            CURVENOTE_VERSION=${{ steps.curvenote.outputs.version }}
+          tags: |
+            ghcr.io/curvenote/cli:${{ steps.curvenote.outputs.version }}-slim
+            ghcr.io/curvenote/cli:${{ steps.curvenote.outputs.minor }}-slim
+            ghcr.io/curvenote/cli:${{ steps.curvenote.outputs.major }}-slim
+            ghcr.io/curvenote/cli:latest-slim

--- a/docker/cli/.dockerignore
+++ b/docker/cli/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!install-typst.sh

--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -1,0 +1,45 @@
+FROM node:24-bookworm-slim AS base
+
+ARG CURVENOTE_VERSION
+RUN test -n "$CURVENOTE_VERSION"
+
+LABEL org.opencontainers.image.source="https://github.com/curvenote/curvenote"
+LABEL org.opencontainers.image.description="Curvenote CLI"
+LABEL org.opencontainers.image.version="${CURVENOTE_VERSION}"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g "curvenote@${CURVENOTE_VERSION}"
+
+WORKDIR /work
+ENTRYPOINT ["curvenote"]
+CMD ["--help"]
+
+# CLI only.
+FROM base AS slim
+
+# Full toolchain — Typst, fonts, and image conversion tools.
+FROM base AS full
+
+ARG TYPST_VERSION=latest
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    fonts-noto \
+    ghostscript \
+    imagemagick \
+    inkscape \
+    webp \
+    xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Allow PDF -> PNG conversions via ImageMagick.
+RUN sed -i '/domain="coder" rights="none"/d' /etc/ImageMagick-6/policy.xml
+
+COPY install-typst.sh /tmp/install-typst.sh
+RUN chmod +x /tmp/install-typst.sh \
+    && TYPST_VERSION="${TYPST_VERSION}" /tmp/install-typst.sh \
+    && rm /tmp/install-typst.sh

--- a/docker/cli/README.md
+++ b/docker/cli/README.md
@@ -1,0 +1,48 @@
+# Curvenote CLI container images
+
+General-purpose images for running the [Curvenote CLI](https://www.npmjs.com/package/curvenote).
+
+Image: `ghcr.io/curvenote/cli`
+
+## Usage
+
+```bash
+docker run --rm -v "$PWD":/work -w /work ghcr.io/curvenote/cli:latest --help
+docker run --rm -v "$PWD":/work -w /work ghcr.io/curvenote/cli:latest submit my-venue
+```
+
+Use the slim image when you do not need PDF/image tooling:
+
+```bash
+docker run --rm -v "$PWD":/work -w /work ghcr.io/curvenote/cli:latest-slim --help
+```
+
+## Variants
+
+| Target | Tag suffix | Contents |
+|--------|------------|----------|
+| `full` (default tags) | none (e.g. `latest`, `0.16.5`) | Curvenote CLI, Typst, Noto fonts, Inkscape, ImageMagick, WebP, Ghostscript |
+| `slim` | `-slim` (e.g. `latest-slim`) | Curvenote CLI only |
+
+Typst is whatever version was latest when the image was built. The Curvenote CLI version matches the image tag (and the npm release).
+
+## Tags
+
+Published when the `curvenote` npm package is released:
+
+| Tag | Meaning |
+|-----|---------|
+| `0.16.5` / `0.16.5-slim` | Exact CLI version |
+| `0.16` / `0.16-slim` | Latest patch for that minor |
+| `0` / `0-slim` | Latest minor/patch for that major |
+| `latest` / `latest-slim` | Latest CLI release |
+
+## Publishing
+
+Images are built by `.github/workflows/release.yml` after a successful changesets publish of the `curvenote` package. The workflow waits for the version to appear on npm, then builds and pushes both variants.
+
+For a one-off rebuild without a new CLI release, run **Actions → Publish CLI Image → Run workflow** (optional version input; defaults to npm `latest`).
+
+After the first publish, make the GHCR package public:
+
+**GitHub → Packages → curvenote/cli → Package settings → Change visibility → Public**

--- a/docker/cli/install-typst.sh
+++ b/docker/cli/install-typst.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Mirrors typst-community/setup-typst asset selection for linux/x64.
+TYPST_VERSION="${TYPST_VERSION:-latest}"
+TARGET="x86_64-unknown-linux-musl"
+ARCHIVE="typst-${TARGET}.tar.xz"
+FOLDER="typst-${TARGET}"
+
+if [ "${TYPST_VERSION}" = "latest" ]; then
+  TYPST_VERSION="$(
+    curl -fsSL https://api.github.com/repos/typst/typst/releases/latest \
+      | sed -n 's/.*"tag_name": "v\([^"]*\)".*/\1/p' \
+      | head -n 1
+  )"
+fi
+
+if [ -z "${TYPST_VERSION}" ]; then
+  echo "Failed to resolve Typst version" >&2
+  exit 1
+fi
+
+URL="https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/${ARCHIVE}"
+echo "Installing Typst v${TYPST_VERSION} from ${URL}"
+
+curl -fsSL "${URL}" -o "/tmp/${ARCHIVE}"
+tar -xJf "/tmp/${ARCHIVE}" -C /usr/local/bin --strip-components=1 "${FOLDER}/typst"
+rm "/tmp/${ARCHIVE}"
+
+typst --version


### PR DESCRIPTION
Build and publish docker container with Curvenote CLI installed on release. This can is consumed by our github actions: https://github.com/curvenote/actions/pull/54

It can also be used independently for other potential docker use-cases!