### PR TITLE
🔧 fix system cron form

### DIFF
--- a/.changeset/fix-system-cron-create-form.md
+++ b/.changeset/fix-system-cron-create-form.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms': patch
+---
+
+Fix system cron create form with Zod validation, display name auto-slug, toasts, and StatefulButton submit feedback.

--- a/.changeset/fix-system-cron-create-form.md
+++ b/.changeset/fix-system-cron-create-form.md
@@ -3,4 +3,4 @@
 '@curvenote/scms-core': patch
 ---
 
-Fix system cron create form with Zod validation, Name and Description fields, toasts, and StatefulButton submit feedback. Add POST /v1/loopback scoped-handshake endpoint for cron job testing.
+Add an expandable system cron create form with Zod validation, live schedule preview, relative target paths, auto-derived scoped-handshake scopes, and submit toasts. Add `/v1/loopback` as a scoped-handshake test endpoint for cron jobs.

--- a/.changeset/fix-system-cron-create-form.md
+++ b/.changeset/fix-system-cron-create-form.md
@@ -1,5 +1,6 @@
 ---
 '@curvenote/scms': patch
+'@curvenote/scms-core': patch
 ---
 
-Fix system cron create form with Zod validation, Name and Description fields, toasts, and StatefulButton submit feedback.
+Fix system cron create form with Zod validation, Name and Description fields, toasts, and StatefulButton submit feedback. Add POST /v1/loopback scoped-handshake endpoint for cron job testing.

--- a/.changeset/fix-system-cron-create-form.md
+++ b/.changeset/fix-system-cron-create-form.md
@@ -2,4 +2,4 @@
 '@curvenote/scms': patch
 ---
 
-Fix system cron create form with Zod validation, display name auto-slug, toasts, and StatefulButton submit feedback.
+Fix system cron create form with Zod validation, Name and Description fields, toasts, and StatefulButton submit feedback.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17978,6 +17978,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/cronstrue": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-3.24.0.tgz",
+      "integrity": "sha512-t/Ji3Ur2c/pzhIAWNwC0ftl3JAE4dLfCjAdZoTZXmPDZwcispnS1PaMcMS4OmIIXyIVouAz+yw+mfQiE3hz5OQ==",
+      "license": "MIT",
+      "bin": {
+        "cronstrue": "bin/cli.js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "license": "MIT",
@@ -42421,6 +42430,7 @@
         "bmp-js": "^0.1.0",
         "classnames": "^2.5.1",
         "cron-parser": "^5.6.1",
+        "cronstrue": "^3.24.0",
         "date-fns": "3.6.0",
         "fuse.js": "^7.1.0",
         "isbot": "^5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17978,6 +17978,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/cronstrue": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-3.24.0.tgz",
+      "integrity": "sha512-t/Ji3Ur2c/pzhIAWNwC0ftl3JAE4dLfCjAdZoTZXmPDZwcispnS1PaMcMS4OmIIXyIVouAz+yw+mfQiE3hz5OQ==",
+      "license": "MIT",
+      "bin": {
+        "cronstrue": "bin/cli.js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "license": "MIT",
@@ -42420,6 +42429,8 @@
         "@vercel/react-router": "^1.2.3",
         "bmp-js": "^0.1.0",
         "classnames": "^2.5.1",
+        "cron-parser": "^5.6.1",
+        "cronstrue": "^3.24.0",
         "date-fns": "3.6.0",
         "fuse.js": "^7.1.0",
         "isbot": "^5",
@@ -42503,6 +42514,16 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "platform/scms/node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "platform/scms/node_modules/@types/react": {
@@ -42706,6 +42727,13 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "platform/scms/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17978,15 +17978,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/cronstrue": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-3.24.0.tgz",
-      "integrity": "sha512-t/Ji3Ur2c/pzhIAWNwC0ftl3JAE4dLfCjAdZoTZXmPDZwcispnS1PaMcMS4OmIIXyIVouAz+yw+mfQiE3hz5OQ==",
-      "license": "MIT",
-      "bin": {
-        "cronstrue": "bin/cli.js"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "license": "MIT",
@@ -42430,7 +42421,6 @@
         "bmp-js": "^0.1.0",
         "classnames": "^2.5.1",
         "cron-parser": "^5.6.1",
-        "cronstrue": "^3.24.0",
         "date-fns": "3.6.0",
         "fuse.js": "^7.1.0",
         "isbot": "^5",

--- a/packages/scms-core/src/cron/scopes.ts
+++ b/packages/scms-core/src/cron/scopes.ts
@@ -2,6 +2,7 @@
 export const CronEndpointScopes = {
   JOB_QUEUE_DRAIN: 'POST:/v1/jobs/push-to-drain',
   PROMOTE_SCHEDULED: 'POST:/v1/jobs/promote-scheduled',
+  LOOPBACK: 'POST:/v1/loopback',
 } as const;
 
 export type CronEndpointScope = (typeof CronEndpointScopes)[keyof typeof CronEndpointScopes];

--- a/packages/scms-server/tests/cron/scopes.test.ts
+++ b/packages/scms-server/tests/cron/scopes.test.ts
@@ -18,6 +18,7 @@ describe('cronEndpointScope', () => {
     expect(cronEndpointScope('post', '/v1/jobs/push-to-drain')).toBe(
       CronEndpointScopes.JOB_QUEUE_DRAIN,
     );
+    expect(cronEndpointScope('post', '/v1/loopback')).toBe(CronEndpointScopes.LOOPBACK);
     expect(cronEndpointScope('GET', 'v1/cron/tick')).toBe('GET:/v1/cron/tick');
   });
 });

--- a/platform/scms/app/routes.ts
+++ b/platform/scms/app/routes.ts
@@ -293,6 +293,7 @@ export default [
     route('jobs/push-to-drain', 'routes/api/v1.jobs.push-to-drain/route.tsx'),
     route('jobs/promote-scheduled', 'routes/api/v1.jobs.promote-scheduled/route.tsx'),
     route('cron/tick', 'routes/api/v1.cron.tick/route.tsx'),
+    route('loopback', 'routes/api/v1.loopback/route.tsx'),
     route('jobs/:jobId', 'routes/api/v1.jobs.$jobId.tsx'),
 
     route('keys', 'routes/api/v1.keys.tsx'),

--- a/platform/scms/app/routes/api/v1.loopback/route.test.ts
+++ b/platform/scms/app/routes/api/v1.loopback/route.test.ts
@@ -1,0 +1,54 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createScopedHandshakeToken } from '@curvenote/scms-server';
+import { CronEndpointScopes } from '@curvenote/scms-core';
+
+const ISSUER = 'https://scms.test/handshake';
+const KEY = 'test-signing-secret';
+
+vi.mock('@curvenote/scms-server', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    getConfig: vi.fn(async () => ({
+      api: {
+        handshakeIssuer: ISSUER,
+        handshakeSigningSecret: KEY,
+      },
+    })),
+  };
+});
+
+const { action } = await import('./route');
+
+function createRequest(auth?: string): Request {
+  return new Request('http://localhost/v1/loopback', {
+    method: 'POST',
+    headers: auth ? { Authorization: auth } : {},
+  });
+}
+
+describe('loopback action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns loopback JSON when scoped handshake is valid', async () => {
+    const token = createScopedHandshakeToken(CronEndpointScopes.LOOPBACK, ISSUER, KEY);
+    const response = await action({ request: createRequest(`Bearer ${token}`) } as never);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.message).toContain('loopback');
+    expect(body.endpoint_scope).toBe(CronEndpointScopes.LOOPBACK);
+    expect(body.version).toBeTruthy();
+  });
+
+  it('returns 401 when Authorization is missing or invalid', async () => {
+    const missing = await action({ request: createRequest() } as never);
+    expect(missing.status).toBe(401);
+
+    const wrong = await action({ request: createRequest('Bearer not-a-token') } as never);
+    expect(wrong.status).toBe(401);
+  });
+});

--- a/platform/scms/app/routes/api/v1.loopback/route.test.ts
+++ b/platform/scms/app/routes/api/v1.loopback/route.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createScopedHandshakeToken } from '@curvenote/scms-server';
-import { CronEndpointScopes } from '@curvenote/scms-core';
+import { CronEndpointScopes, cronEndpointScope } from '@curvenote/scms-core';
 
 const ISSUER = 'https://scms.test/handshake';
 const KEY = 'test-signing-secret';
@@ -19,23 +19,23 @@ vi.mock('@curvenote/scms-server', async (importOriginal) => {
   };
 });
 
-const { action } = await import('./route');
+const { action, loader } = await import('./route');
 
-function createRequest(auth?: string): Request {
+function createRequest(method: string, auth?: string): Request {
   return new Request('http://localhost/v1/loopback', {
-    method: 'POST',
+    method,
     headers: auth ? { Authorization: auth } : {},
   });
 }
 
-describe('loopback action', () => {
+describe('loopback route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('returns loopback JSON when scoped handshake is valid', async () => {
+  it('returns loopback JSON for POST when scoped handshake is valid', async () => {
     const token = createScopedHandshakeToken(CronEndpointScopes.LOOPBACK, ISSUER, KEY);
-    const response = await action({ request: createRequest(`Bearer ${token}`) } as never);
+    const response = await action({ request: createRequest('POST', `Bearer ${token}`) } as never);
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -44,11 +44,22 @@ describe('loopback action', () => {
     expect(body.version).toBeTruthy();
   });
 
+  it('returns loopback JSON for GET when scoped handshake is valid', async () => {
+    const scope = cronEndpointScope('GET', '/v1/loopback');
+    const token = createScopedHandshakeToken(scope, ISSUER, KEY);
+    const response = await loader({ request: createRequest('GET', `Bearer ${token}`) } as never);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.message).toContain('loopback');
+    expect(body.endpoint_scope).toBe(scope);
+  });
+
   it('returns 401 when Authorization is missing or invalid', async () => {
-    const missing = await action({ request: createRequest() } as never);
+    const missing = await action({ request: createRequest('POST') } as never);
     expect(missing.status).toBe(401);
 
-    const wrong = await action({ request: createRequest('Bearer not-a-token') } as never);
+    const wrong = await action({ request: createRequest('POST', 'Bearer not-a-token') } as never);
     expect(wrong.status).toBe(401);
   });
 });

--- a/platform/scms/app/routes/api/v1.loopback/route.tsx
+++ b/platform/scms/app/routes/api/v1.loopback/route.tsx
@@ -1,6 +1,8 @@
-import { CronEndpointScopes, error405, version } from '@curvenote/scms-core';
+import { cronEndpointScope, version } from '@curvenote/scms-core';
 import { getConfig, verifyEndpointScopedHandshake } from '@curvenote/scms-server';
 import type { Route } from './+types/route';
+
+const LOOPBACK_PATH = '/v1/loopback';
 
 function unauthorized(): Response {
   return Response.json({ error: 'Unauthorized' }, { status: 401 });
@@ -14,28 +16,29 @@ function loopbackPayload(endpointScope: string) {
   };
 }
 
-export function loader() {
-  throw error405();
-}
-
-/**
- * POST /v1/loopback — scoped-handshake echo for cron job testing.
- * Secured with endpoint-scoped handshake (POST:/v1/loopback).
- */
-export async function action(args: Route.ActionArgs) {
-  if (args.request.method !== 'POST') {
-    throw error405();
-  }
-
+async function handleLoopback(request: Request): Promise<Response> {
+  const expectedScope = cronEndpointScope(request.method, LOOPBACK_PATH);
   const appConfig = await getConfig();
   try {
     const claims = verifyEndpointScopedHandshake(
-      args.request.headers.get('Authorization'),
+      request.headers.get('Authorization'),
       appConfig,
-      CronEndpointScopes.LOOPBACK,
+      expectedScope,
     );
-    return Response.json(loopbackPayload(claims.endpoint_scope ?? CronEndpointScopes.LOOPBACK));
+    return Response.json(loopbackPayload(claims.endpoint_scope ?? expectedScope));
   } catch {
     return unauthorized();
   }
+}
+
+/**
+ * /v1/loopback — scoped-handshake echo for cron job testing.
+ * Accepts any HTTP method; token endpoint_scope must match METHOD:/v1/loopback.
+ */
+export async function loader(args: Route.LoaderArgs) {
+  return handleLoopback(args.request);
+}
+
+export async function action(args: Route.ActionArgs) {
+  return handleLoopback(args.request);
 }

--- a/platform/scms/app/routes/api/v1.loopback/route.tsx
+++ b/platform/scms/app/routes/api/v1.loopback/route.tsx
@@ -1,0 +1,41 @@
+import { CronEndpointScopes, error405, version } from '@curvenote/scms-core';
+import { getConfig, verifyEndpointScopedHandshake } from '@curvenote/scms-server';
+import type { Route } from './+types/route';
+
+function unauthorized(): Response {
+  return Response.json({ error: 'Unauthorized' }, { status: 401 });
+}
+
+function loopbackPayload(endpointScope: string) {
+  return {
+    version,
+    message: '👋 Cron loopback OK 👋',
+    endpoint_scope: endpointScope,
+  };
+}
+
+export function loader() {
+  throw error405();
+}
+
+/**
+ * POST /v1/loopback — scoped-handshake echo for cron job testing.
+ * Secured with endpoint-scoped handshake (POST:/v1/loopback).
+ */
+export async function action(args: Route.ActionArgs) {
+  if (args.request.method !== 'POST') {
+    throw error405();
+  }
+
+  const appConfig = await getConfig();
+  try {
+    const claims = verifyEndpointScopedHandshake(
+      args.request.headers.get('Authorization'),
+      appConfig,
+      CronEndpointScopes.LOOPBACK,
+    );
+    return Response.json(loopbackPayload(claims.endpoint_scope ?? CronEndpointScopes.LOOPBACK));
+  } catch {
+    return unauthorized();
+  }
+}

--- a/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
+++ b/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useRef, useState } from 'react';
+import { useFetcher, useRevalidator } from 'react-router';
+import { CronEndpointScopes, ui } from '@curvenote/scms-core';
+import { Plus } from 'lucide-react';
+
+type CreateActionData = {
+  success?: boolean;
+  message?: string;
+  error?: { message: string };
+};
+
+function slugifyDisplayName(displayName: string): string {
+  return displayName
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) {
+  const fetcher = useFetcher<CreateActionData>();
+  const revalidator = useRevalidator();
+  const prevFetcherState = useRef(fetcher.state);
+  const [formKey, setFormKey] = useState(0);
+
+  const [displayName, setDisplayName] = useState('');
+  const [name, setName] = useState('');
+  const [isNameManuallyEdited, setIsNameManuallyEdited] = useState(false);
+
+  const isSubmitting = fetcher.state !== 'idle';
+
+  useEffect(() => {
+    if (!isNameManuallyEdited) {
+      setName(slugifyDisplayName(displayName));
+    }
+  }, [displayName, isNameManuallyEdited]);
+
+  useEffect(() => {
+    const wasBusy = prevFetcherState.current !== 'idle';
+    prevFetcherState.current = fetcher.state;
+
+    if (!wasBusy || fetcher.state !== 'idle' || !fetcher.data) {
+      return;
+    }
+
+    if (fetcher.data.error) {
+      ui.toastError(fetcher.data.error.message);
+      return;
+    }
+
+    if (fetcher.data.success) {
+      ui.toastSuccess(fetcher.data.message ?? 'Cron job created successfully');
+      setDisplayName('');
+      setName('');
+      setIsNameManuallyEdited(false);
+      setFormKey((k) => k + 1);
+      revalidator.revalidate();
+    }
+  }, [fetcher.state, fetcher.data, revalidator]);
+
+  const allowedHostsHint =
+    allowedHosts.length > 0 ? allowedHosts.join(', ') : 'configured API hosts from app-config';
+
+  return (
+    <section className="p-4 bg-white rounded-lg border dark:bg-gray-900 dark:border-gray-700">
+      <h3 className="mb-3 font-semibold">Create HTTP cron (HANDSHAKE)</h3>
+      <fetcher.Form key={formKey} method="post" className="grid gap-4 max-w-xl">
+        <input type="hidden" name="intent" value="create" />
+
+        <div>
+          <ui.Label htmlFor="cron-display-name">Display name *</ui.Label>
+          <ui.Input
+            id="cron-display-name"
+            name="description"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="My New Cron"
+            required
+            disabled={isSubmitting}
+            className="mt-1"
+          />
+          <p className="mt-1 text-sm text-muted-foreground">
+            Human-readable label shown in the list
+          </p>
+        </div>
+
+        <div>
+          <ui.Label htmlFor="cron-name">Identifier *</ui.Label>
+          <ui.Input
+            id="cron-name"
+            name="name"
+            value={name}
+            onChange={(e) => {
+              setIsNameManuallyEdited(true);
+              setName(e.target.value);
+            }}
+            placeholder="my-new-cron"
+            required
+            disabled={isSubmitting}
+            className="mt-1 font-mono"
+            pattern="[a-z0-9]+(?:-[a-z0-9]+)*"
+          />
+          <p className="mt-1 text-sm text-muted-foreground">
+            Unique ID: lowercase letters, numbers, and hyphens only (no spaces)
+          </p>
+        </div>
+
+        <div>
+          <ui.Label htmlFor="cron-schedule">Schedule *</ui.Label>
+          <ui.Input
+            id="cron-schedule"
+            name="schedule"
+            placeholder="* * * * *"
+            required
+            disabled={isSubmitting}
+            className="mt-1 font-mono"
+          />
+          <p className="mt-1 text-sm text-muted-foreground">Standard cron expression (UTC)</p>
+        </div>
+
+        <div>
+          <ui.Label htmlFor="cron-http-method">HTTP method</ui.Label>
+          <ui.Input
+            id="cron-http-method"
+            name="http_method"
+            defaultValue="POST"
+            disabled={isSubmitting}
+            className="mt-1 font-mono"
+          />
+        </div>
+
+        <div>
+          <ui.Label htmlFor="cron-target-url">Target URL *</ui.Label>
+          <ui.Input
+            id="cron-target-url"
+            name="target_url"
+            placeholder="http://localhost:3031/v1/..."
+            required
+            disabled={isSubmitting}
+            className="mt-1 font-mono text-xs"
+          />
+          <p className="mt-1 text-sm text-muted-foreground">
+            Must use an allowed API host:{' '}
+            <code className="text-xs bg-muted px-1 rounded">{allowedHostsHint}</code>
+          </p>
+        </div>
+
+        <div>
+          <ui.Label htmlFor="cron-target-scope">Scope</ui.Label>
+          <ui.Input
+            id="cron-target-scope"
+            name="target_scope"
+            placeholder={CronEndpointScopes.JOB_QUEUE_DRAIN}
+            disabled={isSubmitting}
+            className="mt-1 font-mono text-xs"
+          />
+          <p className="mt-1 text-sm text-muted-foreground">
+            Optional. Derived from the target URL when left blank.
+          </p>
+        </div>
+
+        <ui.StatefulButton
+          type="submit"
+          className="w-fit"
+          overlayBusy
+          busy={isSubmitting}
+          disabled={isSubmitting}
+        >
+          <Plus className="mr-2 w-4 h-4" />
+          Create
+        </ui.StatefulButton>
+      </fetcher.Form>
+    </section>
+  );
+}

--- a/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
+++ b/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useFetcher, useRevalidator } from 'react-router';
 import { Plus, PlusCircle } from 'lucide-react';
 import { CronEndpointScopes, cn, primitives, ui, useExpandableForm } from '@curvenote/scms-core';
+import { CRON_HTTP_METHODS, type CronHttpMethod } from './constants';
 
 type CreateActionData = {
   success?: boolean;
@@ -19,6 +20,13 @@ export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) 
   );
 
   const isSubmitting = fetcher.state === 'submitting';
+  const [httpMethod, setHttpMethod] = useState<CronHttpMethod>('POST');
+
+  useEffect(() => {
+    if (!isExpanded) {
+      setHttpMethod('POST');
+    }
+  }, [isExpanded]);
 
   useEffect(() => {
     if (fetcher.state === 'idle' && fetcher.data) {
@@ -105,13 +113,23 @@ export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) 
 
               <div>
                 <ui.Label htmlFor="cron-http-method">HTTP method</ui.Label>
-                <ui.Input
-                  id="cron-http-method"
-                  name="http_method"
-                  defaultValue="POST"
+                <input type="hidden" name="http_method" value={httpMethod} />
+                <ui.Select
+                  value={httpMethod}
+                  onValueChange={(value) => setHttpMethod(value as CronHttpMethod)}
                   disabled={isSubmitting}
-                  className="mt-1 font-mono"
-                />
+                >
+                  <ui.SelectTrigger id="cron-http-method" className="mt-1 font-mono">
+                    <ui.SelectValue placeholder="Select method" />
+                  </ui.SelectTrigger>
+                  <ui.SelectContent>
+                    {CRON_HTTP_METHODS.map((method) => (
+                      <ui.SelectItem key={method} value={method}>
+                        {method}
+                      </ui.SelectItem>
+                    ))}
+                  </ui.SelectContent>
+                </ui.Select>
               </div>
             </div>
 

--- a/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
+++ b/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import { useFetcher, useRevalidator } from 'react-router';
-import { CronEndpointScopes, ui } from '@curvenote/scms-core';
-import { Plus } from 'lucide-react';
+import { Plus, PlusCircle } from 'lucide-react';
+import { CronEndpointScopes, cn, primitives, ui, useExpandableForm } from '@curvenote/scms-core';
 
 type CreateActionData = {
   success?: boolean;
@@ -12,28 +12,22 @@ type CreateActionData = {
 export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) {
   const fetcher = useFetcher<CreateActionData>();
   const revalidator = useRevalidator();
-  const prevFetcherState = useRef(fetcher.state);
-  const [formKey, setFormKey] = useState(0);
 
-  const isSubmitting = fetcher.state !== 'idle';
+  const { isExpanded, isExiting, expand, handleCancel, formRef, onSubmit } = useExpandableForm(
+    fetcher,
+    { animationDuration: 200 },
+  );
+
+  const isSubmitting = fetcher.state === 'submitting';
 
   useEffect(() => {
-    const wasBusy = prevFetcherState.current !== 'idle';
-    prevFetcherState.current = fetcher.state;
-
-    if (!wasBusy || fetcher.state !== 'idle' || !fetcher.data) {
-      return;
-    }
-
-    if (fetcher.data.error) {
-      ui.toastError(fetcher.data.error.message);
-      return;
-    }
-
-    if (fetcher.data.success) {
-      ui.toastSuccess(fetcher.data.message ?? 'Cron job created successfully');
-      setFormKey((k) => k + 1);
-      revalidator.revalidate();
+    if (fetcher.state === 'idle' && fetcher.data) {
+      if (fetcher.data.error) {
+        ui.toastError(fetcher.data.error.message);
+      } else if (fetcher.data.success) {
+        ui.toastSuccess(fetcher.data.message ?? 'Cron job created successfully');
+        revalidator.revalidate();
+      }
     }
   }, [fetcher.state, fetcher.data, revalidator]);
 
@@ -41,105 +35,133 @@ export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) 
     allowedHosts.length > 0 ? allowedHosts.join(', ') : 'configured API hosts from app-config';
 
   return (
-    <div>
-      <h3 className="mb-4 text-lg font-semibold">Create HTTP cron (HANDSHAKE)</h3>
-      <fetcher.Form key={formKey} method="post" className="grid gap-4 max-w-xl">
-        <input type="hidden" name="intent" value="create" />
-
-        <div>
-          <ui.Label htmlFor="cron-name">Name *</ui.Label>
-          <ui.Input
-            id="cron-name"
-            name="name"
-            placeholder="My New Cron"
-            required
-            disabled={isSubmitting}
-            className="mt-1"
-          />
-          <p className="mt-1 text-sm text-muted-foreground">
-            Unique name shown in the cron job list
-          </p>
+    <div className="space-y-0">
+      {!isExpanded && (
+        <div className="flex justify-end">
+          <ui.Button onClick={expand} variant="default" disabled={isSubmitting}>
+            <PlusCircle className="mr-2 w-4 h-4" />
+            Add Cron Job
+          </ui.Button>
         </div>
+      )}
 
-        <div>
-          <ui.Label htmlFor="cron-description">Description</ui.Label>
-          <ui.Input
-            id="cron-description"
-            name="description"
-            placeholder="Runs the nightly sweep for stale jobs"
-            disabled={isSubmitting}
-            className="mt-1"
-          />
-          <p className="mt-1 text-sm text-muted-foreground">
-            Optional details shown below the name in the list
-          </p>
-        </div>
+      {isExpanded && (
+        <primitives.Card className="p-6 bg-white dark:bg-white">
+          <fetcher.Form
+            ref={formRef}
+            onSubmit={onSubmit}
+            method="post"
+            className={cn('space-y-4', isExiting && 'animate-out fade-out duration-200')}
+          >
+            <input type="hidden" name="intent" value="create" />
 
-        <div>
-          <ui.Label htmlFor="cron-schedule">Schedule *</ui.Label>
-          <ui.Input
-            id="cron-schedule"
-            name="schedule"
-            placeholder="* * * * *"
-            required
-            disabled={isSubmitting}
-            className="mt-1 font-mono"
-          />
-          <p className="mt-1 text-sm text-muted-foreground">Standard cron expression (UTC)</p>
-        </div>
+            <div className="text-lg font-semibold">Add Cron Job</div>
 
-        <div>
-          <ui.Label htmlFor="cron-http-method">HTTP method</ui.Label>
-          <ui.Input
-            id="cron-http-method"
-            name="http_method"
-            defaultValue="POST"
-            disabled={isSubmitting}
-            className="mt-1 font-mono"
-          />
-        </div>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div>
+                <ui.Label htmlFor="cron-name">Name *</ui.Label>
+                <ui.Input
+                  id="cron-name"
+                  name="name"
+                  placeholder="My New Cron"
+                  required
+                  autoFocus
+                  disabled={isSubmitting}
+                  className="mt-1"
+                />
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Unique name shown in the cron job list
+                </p>
+              </div>
 
-        <div>
-          <ui.Label htmlFor="cron-target-url">Target URL *</ui.Label>
-          <ui.Input
-            id="cron-target-url"
-            name="target_url"
-            placeholder="http://localhost:3031/v1/..."
-            required
-            disabled={isSubmitting}
-            className="mt-1 font-mono text-xs"
-          />
-          <p className="mt-1 text-sm text-muted-foreground">
-            Must use an allowed API host:{' '}
-            <code className="text-xs bg-muted px-1 rounded">{allowedHostsHint}</code>
-          </p>
-        </div>
+              <div>
+                <ui.Label htmlFor="cron-description">Description</ui.Label>
+                <ui.Input
+                  id="cron-description"
+                  name="description"
+                  placeholder="Runs the nightly sweep for stale jobs"
+                  disabled={isSubmitting}
+                  className="mt-1"
+                />
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Optional details shown below the name in the list
+                </p>
+              </div>
+            </div>
 
-        <div>
-          <ui.Label htmlFor="cron-target-scope">Scope</ui.Label>
-          <ui.Input
-            id="cron-target-scope"
-            name="target_scope"
-            placeholder={CronEndpointScopes.JOB_QUEUE_DRAIN}
-            disabled={isSubmitting}
-            className="mt-1 font-mono text-xs"
-          />
-          <p className="mt-1 text-sm text-muted-foreground">
-            Optional. Derived from the target URL when left blank.
-          </p>
-        </div>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div>
+                <ui.Label htmlFor="cron-schedule">Schedule *</ui.Label>
+                <ui.Input
+                  id="cron-schedule"
+                  name="schedule"
+                  placeholder="* * * * *"
+                  required
+                  disabled={isSubmitting}
+                  className="mt-1 font-mono"
+                />
+                <p className="mt-1 text-sm text-muted-foreground">Standard cron expression (UTC)</p>
+              </div>
 
-        <ui.StatefulButton
-          type="submit"
-          className="w-fit"
-          overlayBusy
-          busy={isSubmitting}
-          disabled={isSubmitting}
-        >
-          <Plus className="mr-2 w-4 h-4" />
-          Create
-        </ui.StatefulButton>
-      </fetcher.Form>
+              <div>
+                <ui.Label htmlFor="cron-http-method">HTTP method</ui.Label>
+                <ui.Input
+                  id="cron-http-method"
+                  name="http_method"
+                  defaultValue="POST"
+                  disabled={isSubmitting}
+                  className="mt-1 font-mono"
+                />
+              </div>
+            </div>
+
+            <div>
+              <ui.Label htmlFor="cron-target-url">Target URL *</ui.Label>
+              <ui.Input
+                id="cron-target-url"
+                name="target_url"
+                placeholder="http://localhost:3031/v1/..."
+                required
+                disabled={isSubmitting}
+                className="mt-1 font-mono text-xs"
+              />
+              <p className="mt-1 text-sm text-muted-foreground">
+                Must use an allowed API host:{' '}
+                <code className="text-xs bg-muted px-1 rounded">{allowedHostsHint}</code>
+              </p>
+            </div>
+
+            <div>
+              <ui.Label htmlFor="cron-target-scope">Scope</ui.Label>
+              <ui.Input
+                id="cron-target-scope"
+                name="target_scope"
+                placeholder={CronEndpointScopes.JOB_QUEUE_DRAIN}
+                disabled={isSubmitting}
+                className="mt-1 font-mono text-xs"
+              />
+              <p className="mt-1 text-sm text-muted-foreground">
+                Optional. Derived from the target URL when left blank.
+              </p>
+            </div>
+
+            <div className="flex gap-2 justify-end">
+              <ui.Button type="button" variant="ghost" onClick={handleCancel}>
+                Cancel
+              </ui.Button>
+              <ui.StatefulButton
+                type="submit"
+                overlayBusy
+                busy={isSubmitting}
+                disabled={isSubmitting}
+              >
+                <Plus className="mr-2 w-4 h-4" />
+                Create Cron Job
+              </ui.StatefulButton>
+            </div>
+          </fetcher.Form>
+        </primitives.Card>
+      )}
     </div>
   );
 }

--- a/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
+++ b/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useFetcher, useRevalidator } from 'react-router';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useFetcher } from 'react-router';
 import { Plus, PlusCircle } from 'lucide-react';
 import { cn, cronEndpointScope, primitives, ui, useExpandableForm } from '@curvenote/scms-core';
 import { CRON_HTTP_METHODS, type CronHttpMethod } from './constants';
@@ -13,7 +13,7 @@ type CreateActionData = {
 
 export function CreateCronJobForm() {
   const fetcher = useFetcher<CreateActionData>();
-  const revalidator = useRevalidator();
+  const prevFetcherState = useRef(fetcher.state);
 
   const { isExpanded, isExiting, expand, handleCancel, formRef, onSubmit } = useExpandableForm(
     fetcher,
@@ -45,15 +45,19 @@ export function CreateCronJobForm() {
   }, [httpMethod, targetPath, isScopeManuallyEdited]);
 
   useEffect(() => {
-    if (fetcher.state === 'idle' && fetcher.data) {
-      if (fetcher.data.error) {
-        ui.toastError(fetcher.data.error.message);
-      } else if (fetcher.data.success) {
-        ui.toastSuccess(fetcher.data.message ?? 'Cron job created successfully');
-        revalidator.revalidate();
-      }
+    const wasBusy = prevFetcherState.current !== 'idle';
+    prevFetcherState.current = fetcher.state;
+
+    if (!wasBusy || fetcher.state !== 'idle' || !fetcher.data) {
+      return;
     }
-  }, [fetcher.state, fetcher.data, revalidator]);
+
+    if (fetcher.data.error) {
+      ui.toastError(fetcher.data.error.message);
+    } else if (fetcher.data.success) {
+      ui.toastSuccess(fetcher.data.message ?? 'Cron job created successfully');
+    }
+  }, [fetcher.state, fetcher.data]);
 
   return (
     <div className="space-y-0">

--- a/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
+++ b/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useFetcher } from 'react-router';
 import { Plus, PlusCircle } from 'lucide-react';
-import { cn, cronEndpointScope, primitives, ui, useExpandableForm } from '@curvenote/scms-core';
+import {
+  cn,
+  cronEndpointScope,
+  CronEndpointScopes,
+  primitives,
+  ui,
+  useExpandableForm,
+} from '@curvenote/scms-core';
 import { CRON_HTTP_METHODS, type CronHttpMethod } from './constants';
 import { previewCronSchedule } from './previewCronSchedule';
 
@@ -177,7 +184,7 @@ export function CreateCronJobForm() {
                   name="target_path"
                   value={targetPath}
                   onChange={(e) => setTargetPath(e.target.value)}
-                  placeholder="/v1/jobs/push-to-drain"
+                  placeholder="/v1/loopback"
                   required
                   disabled={isSubmitting}
                   className="mt-1 font-mono text-xs"
@@ -195,7 +202,7 @@ export function CreateCronJobForm() {
                     setIsScopeManuallyEdited(true);
                     setTargetScope(e.target.value);
                   }}
-                  placeholder="POST:/v1/jobs/push-to-drain"
+                  placeholder={CronEndpointScopes.LOOPBACK}
                   required
                   disabled={isSubmitting}
                   className="mt-1 font-mono text-xs"

--- a/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
+++ b/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useFetcher, useRevalidator } from 'react-router';
 import { Plus, PlusCircle } from 'lucide-react';
-import { CronEndpointScopes, cn, primitives, ui, useExpandableForm } from '@curvenote/scms-core';
+import { cn, cronEndpointScope, primitives, ui, useExpandableForm } from '@curvenote/scms-core';
 import { CRON_HTTP_METHODS, type CronHttpMethod } from './constants';
 
 type CreateActionData = {
@@ -10,7 +10,7 @@ type CreateActionData = {
   error?: { message: string };
 };
 
-export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) {
+export function CreateCronJobForm() {
   const fetcher = useFetcher<CreateActionData>();
   const revalidator = useRevalidator();
 
@@ -21,12 +21,24 @@ export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) 
 
   const isSubmitting = fetcher.state === 'submitting';
   const [httpMethod, setHttpMethod] = useState<CronHttpMethod>('POST');
+  const [targetPath, setTargetPath] = useState('');
+  const [targetScope, setTargetScope] = useState('');
+  const [isScopeManuallyEdited, setIsScopeManuallyEdited] = useState(false);
 
   useEffect(() => {
     if (!isExpanded) {
       setHttpMethod('POST');
+      setTargetPath('');
+      setTargetScope('');
+      setIsScopeManuallyEdited(false);
     }
   }, [isExpanded]);
+
+  useEffect(() => {
+    if (!isScopeManuallyEdited) {
+      setTargetScope(targetPath.trim() ? cronEndpointScope(httpMethod, targetPath) : '');
+    }
+  }, [httpMethod, targetPath, isScopeManuallyEdited]);
 
   useEffect(() => {
     if (fetcher.state === 'idle' && fetcher.data) {
@@ -38,9 +50,6 @@ export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) 
       }
     }
   }, [fetcher.state, fetcher.data, revalidator]);
-
-  const allowedHostsHint =
-    allowedHosts.length > 0 ? allowedHosts.join(', ') : 'configured API hosts from app-config';
 
   return (
     <div className="space-y-0">
@@ -63,7 +72,12 @@ export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) 
           >
             <input type="hidden" name="intent" value="create" />
 
-            <div className="text-lg font-semibold">Add Cron Job</div>
+            <div className="space-y-1">
+              <div className="text-lg font-semibold">Add Cron Job</div>
+              <p className="text-sm text-muted-foreground">
+                Cron jobs are internal only and secured by scoped handshake tokens
+              </p>
+            </div>
 
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
@@ -133,34 +147,38 @@ export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) 
               </div>
             </div>
 
-            <div>
-              <ui.Label htmlFor="cron-target-url">Target URL *</ui.Label>
-              <ui.Input
-                id="cron-target-url"
-                name="target_url"
-                placeholder="http://localhost:3031/v1/..."
-                required
-                disabled={isSubmitting}
-                className="mt-1 font-mono text-xs"
-              />
-              <p className="mt-1 text-sm text-muted-foreground">
-                Must use an allowed API host:{' '}
-                <code className="text-xs bg-muted px-1 rounded">{allowedHostsHint}</code>
-              </p>
-            </div>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div>
+                <ui.Label htmlFor="cron-target-path">Target path *</ui.Label>
+                <ui.Input
+                  id="cron-target-path"
+                  name="target_path"
+                  value={targetPath}
+                  onChange={(e) => setTargetPath(e.target.value)}
+                  placeholder="/v1/jobs/push-to-drain"
+                  required
+                  disabled={isSubmitting}
+                  className="mt-1 font-mono text-xs"
+                  pattern="\/[^\s]+"
+                />
+              </div>
 
-            <div>
-              <ui.Label htmlFor="cron-target-scope">Scope</ui.Label>
-              <ui.Input
-                id="cron-target-scope"
-                name="target_scope"
-                placeholder={CronEndpointScopes.JOB_QUEUE_DRAIN}
-                disabled={isSubmitting}
-                className="mt-1 font-mono text-xs"
-              />
-              <p className="mt-1 text-sm text-muted-foreground">
-                Optional. Derived from the target URL when left blank.
-              </p>
+              <div>
+                <ui.Label htmlFor="cron-target-scope">Scope *</ui.Label>
+                <ui.Input
+                  id="cron-target-scope"
+                  name="target_scope"
+                  value={targetScope}
+                  onChange={(e) => {
+                    setIsScopeManuallyEdited(true);
+                    setTargetScope(e.target.value);
+                  }}
+                  placeholder="POST:/v1/jobs/push-to-drain"
+                  required
+                  disabled={isSubmitting}
+                  className="mt-1 font-mono text-xs"
+                />
+              </div>
             </div>
 
             <div className="flex gap-2 justify-end">

--- a/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
+++ b/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
@@ -41,8 +41,8 @@ export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) 
     allowedHosts.length > 0 ? allowedHosts.join(', ') : 'configured API hosts from app-config';
 
   return (
-    <section className="p-4 bg-white rounded-lg border dark:bg-gray-900 dark:border-gray-700">
-      <h3 className="mb-3 font-semibold">Create HTTP cron (HANDSHAKE)</h3>
+    <div>
+      <h3 className="mb-4 text-lg font-semibold">Create HTTP cron (HANDSHAKE)</h3>
       <fetcher.Form key={formKey} method="post" className="grid gap-4 max-w-xl">
         <input type="hidden" name="intent" value="create" />
 
@@ -140,6 +140,6 @@ export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) 
           Create
         </ui.StatefulButton>
       </fetcher.Form>
-    </section>
+    </div>
   );
 }

--- a/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
+++ b/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
@@ -9,32 +9,13 @@ type CreateActionData = {
   error?: { message: string };
 };
 
-function slugifyDisplayName(displayName: string): string {
-  return displayName
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-}
-
 export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) {
   const fetcher = useFetcher<CreateActionData>();
   const revalidator = useRevalidator();
   const prevFetcherState = useRef(fetcher.state);
   const [formKey, setFormKey] = useState(0);
 
-  const [displayName, setDisplayName] = useState('');
-  const [name, setName] = useState('');
-  const [isNameManuallyEdited, setIsNameManuallyEdited] = useState(false);
-
   const isSubmitting = fetcher.state !== 'idle';
-
-  useEffect(() => {
-    if (!isNameManuallyEdited) {
-      setName(slugifyDisplayName(displayName));
-    }
-  }, [displayName, isNameManuallyEdited]);
 
   useEffect(() => {
     const wasBusy = prevFetcherState.current !== 'idle';
@@ -51,9 +32,6 @@ export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) 
 
     if (fetcher.data.success) {
       ui.toastSuccess(fetcher.data.message ?? 'Cron job created successfully');
-      setDisplayName('');
-      setName('');
-      setIsNameManuallyEdited(false);
       setFormKey((k) => k + 1);
       revalidator.revalidate();
     }
@@ -69,40 +47,31 @@ export function CreateCronJobForm({ allowedHosts }: { allowedHosts: string[] }) 
         <input type="hidden" name="intent" value="create" />
 
         <div>
-          <ui.Label htmlFor="cron-display-name">Display name *</ui.Label>
+          <ui.Label htmlFor="cron-name">Name *</ui.Label>
           <ui.Input
-            id="cron-display-name"
-            name="description"
-            value={displayName}
-            onChange={(e) => setDisplayName(e.target.value)}
+            id="cron-name"
+            name="name"
             placeholder="My New Cron"
             required
             disabled={isSubmitting}
             className="mt-1"
           />
           <p className="mt-1 text-sm text-muted-foreground">
-            Human-readable label shown in the list
+            Unique name shown in the cron job list
           </p>
         </div>
 
         <div>
-          <ui.Label htmlFor="cron-name">Identifier *</ui.Label>
+          <ui.Label htmlFor="cron-description">Description</ui.Label>
           <ui.Input
-            id="cron-name"
-            name="name"
-            value={name}
-            onChange={(e) => {
-              setIsNameManuallyEdited(true);
-              setName(e.target.value);
-            }}
-            placeholder="my-new-cron"
-            required
+            id="cron-description"
+            name="description"
+            placeholder="Runs the nightly sweep for stale jobs"
             disabled={isSubmitting}
-            className="mt-1 font-mono"
-            pattern="[a-z0-9]+(?:-[a-z0-9]+)*"
+            className="mt-1"
           />
           <p className="mt-1 text-sm text-muted-foreground">
-            Unique ID: lowercase letters, numbers, and hyphens only (no spaces)
+            Optional details shown below the name in the list
           </p>
         </div>
 

--- a/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
+++ b/platform/scms/app/routes/app/system.cron/CreateCronJobForm.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useFetcher, useRevalidator } from 'react-router';
 import { Plus, PlusCircle } from 'lucide-react';
 import { cn, cronEndpointScope, primitives, ui, useExpandableForm } from '@curvenote/scms-core';
 import { CRON_HTTP_METHODS, type CronHttpMethod } from './constants';
+import { previewCronSchedule } from './previewCronSchedule';
 
 type CreateActionData = {
   success?: boolean;
@@ -21,13 +22,16 @@ export function CreateCronJobForm() {
 
   const isSubmitting = fetcher.state === 'submitting';
   const [httpMethod, setHttpMethod] = useState<CronHttpMethod>('POST');
+  const [schedule, setSchedule] = useState('');
   const [targetPath, setTargetPath] = useState('');
   const [targetScope, setTargetScope] = useState('');
   const [isScopeManuallyEdited, setIsScopeManuallyEdited] = useState(false);
+  const schedulePreview = useMemo(() => previewCronSchedule(schedule), [schedule]);
 
   useEffect(() => {
     if (!isExpanded) {
       setHttpMethod('POST');
+      setSchedule('');
       setTargetPath('');
       setTargetScope('');
       setIsScopeManuallyEdited(false);
@@ -117,12 +121,26 @@ export function CreateCronJobForm() {
                 <ui.Input
                   id="cron-schedule"
                   name="schedule"
+                  value={schedule}
+                  onChange={(e) => setSchedule(e.target.value)}
                   placeholder="* * * * *"
                   required
                   disabled={isSubmitting}
                   className="mt-1 font-mono"
                 />
-                <p className="mt-1 text-sm text-muted-foreground">Standard cron expression (UTC)</p>
+                {schedulePreview?.valid === false ? (
+                  <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+                    {schedulePreview.error}
+                  </p>
+                ) : schedulePreview?.valid === true ? (
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {schedulePreview.description}
+                  </p>
+                ) : (
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Standard cron expression (UTC)
+                  </p>
+                )}
               </div>
 
               <div>

--- a/platform/scms/app/routes/app/system.cron/CronJobListItem.tsx
+++ b/platform/scms/app/routes/app/system.cron/CronJobListItem.tsx
@@ -78,9 +78,14 @@ export function CronJobListItem({ job }: { job: CronJobListRow }) {
     <div className="flex flex-col w-full gap-3 lg:flex-row lg:gap-6">
       <div className="flex-1 min-w-0 space-y-2">
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <h3 className="text-lg font-medium text-gray-900 truncate dark:text-gray-100">
-            {job.name}
-          </h3>
+          <div className="min-w-0">
+            <h3 className="text-lg font-medium text-gray-900 truncate dark:text-gray-100">
+              {job.description ?? job.name}
+            </h3>
+            {job.description ? (
+              <p className="font-mono text-xs text-muted-foreground truncate">{job.name}</p>
+            ) : null}
+          </div>
           <div className="flex flex-wrap gap-1">
             {job.enabled ? (
               <ui.Badge variant="default">Enabled</ui.Badge>

--- a/platform/scms/app/routes/app/system.cron/CronJobListItem.tsx
+++ b/platform/scms/app/routes/app/system.cron/CronJobListItem.tsx
@@ -80,10 +80,10 @@ export function CronJobListItem({ job }: { job: CronJobListRow }) {
         <div className="flex flex-wrap items-center justify-between gap-2">
           <div className="min-w-0">
             <h3 className="text-lg font-medium text-gray-900 truncate dark:text-gray-100">
-              {job.description ?? job.name}
+              {job.name}
             </h3>
             {job.description ? (
-              <p className="font-mono text-xs text-muted-foreground truncate">{job.name}</p>
+              <p className="text-sm text-muted-foreground truncate">{job.description}</p>
             ) : null}
           </div>
           <div className="flex flex-wrap gap-1">

--- a/platform/scms/app/routes/app/system.cron/actionHelpers.server.test.ts
+++ b/platform/scms/app/routes/app/system.cron/actionHelpers.server.test.ts
@@ -1,0 +1,191 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import {
+  CronJobTargetAuth,
+  CronJobTargetType,
+  dbCreateCronJob,
+  getConfig,
+  validateFormData,
+  type SecureContext,
+} from '@curvenote/scms-server';
+import { CronEndpointScopes, cronEndpointScope } from '@curvenote/scms-core';
+import { CreateCronJobSchema, handleCreateCronJob } from './actionHelpers.server.js';
+
+const API_URL = 'http://localhost:3031/v1';
+const CRON_ID = '01900000-0000-7000-8000-000000000001';
+
+vi.mock('@curvenote/scms-server', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    dbCreateCronJob: vi.fn(),
+    getConfig: vi.fn(),
+    uuidv7: vi.fn(() => CRON_ID),
+  };
+});
+
+vi.mock('uuidv7', () => ({
+  uuidv7: vi.fn(() => CRON_ID),
+}));
+
+const ctx = { user: { id: 'user-1' } } as SecureContext;
+
+function createFormData(overrides: Record<string, string> = {}): FormData {
+  const formData = new FormData();
+  formData.set('intent', 'create');
+  formData.set('name', 'Test Cron');
+  formData.set('schedule', '0 * * * *');
+  formData.set('http_method', 'POST');
+  formData.set('target_path', '/v1/loopback');
+  formData.set('target_scope', CronEndpointScopes.LOOPBACK);
+
+  for (const [key, value] of Object.entries(overrides)) {
+    formData.set(key, value);
+  }
+
+  return formData;
+}
+
+function expectValidationError(formData: FormData, field: string) {
+  try {
+    validateFormData(CreateCronJobSchema, formData);
+    expect.fail('expected validation to fail');
+  } catch (error) {
+    const issues = (error as { issues?: { path: (string | number)[]; message: string }[] }).issues;
+    expect(issues?.some((issue) => issue.path.includes(field))).toBe(true);
+  }
+}
+
+describe('CreateCronJobSchema', () => {
+  it('accepts a valid relative target_path and scope', () => {
+    const payload = validateFormData(CreateCronJobSchema, createFormData());
+    expect(payload.target_path).toBe('/v1/loopback');
+    expect(payload.target_scope).toBe(CronEndpointScopes.LOOPBACK);
+  });
+
+  it.each(['/v1/loopback', '/v1/jobs/push-to-drain', '/v1/cron/tick'])(
+    'accepts target_path %s',
+    (targetPath) => {
+      const payload = validateFormData(
+        CreateCronJobSchema,
+        createFormData({ target_path: targetPath }),
+      );
+      expect(payload.target_path).toBe(targetPath);
+    },
+  );
+
+  it.each([
+    ['v1/loopback', 'missing leading slash'],
+    ['', 'empty path'],
+    ['http://evil.example/v1/hooks', 'absolute URL'],
+    ['/v1/path with space', 'embedded whitespace'],
+  ])('rejects target_path %s (%s)', (targetPath) => {
+    expectValidationError(createFormData({ target_path: targetPath }), 'target_path');
+  });
+
+  it('requires target_scope', () => {
+    expectValidationError(createFormData({ target_scope: '' }), 'target_scope');
+  });
+
+  it('rejects invalid http_method values', () => {
+    expectValidationError(createFormData({ http_method: 'TRACE' }), 'http_method');
+  });
+});
+
+describe('handleCreateCronJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getConfig).mockResolvedValue({
+      api: { url: API_URL },
+    } as Awaited<ReturnType<typeof getConfig>>);
+    vi.mocked(dbCreateCronJob).mockResolvedValue({} as Awaited<ReturnType<typeof dbCreateCronJob>>);
+  });
+
+  it('creates a cron job with resolved target_url and submitted scope', async () => {
+    const targetPath = '/v1/loopback';
+    const targetScope = cronEndpointScope('POST', targetPath);
+
+    const result = await handleCreateCronJob(
+      ctx,
+      createFormData({ target_path: targetPath, target_scope: targetScope }),
+    );
+
+    expect(result).toEqual({
+      success: true,
+      message: 'Cron job created successfully',
+    });
+    expect(dbCreateCronJob).toHaveBeenCalledWith(CRON_ID, {
+      name: 'Test Cron',
+      description: null,
+      schedule: '0 * * * *',
+      target_type: CronJobTargetType.HTTP,
+      target_url: `${API_URL.replace(/\/v1$/, '')}${targetPath}`,
+      http_method: 'POST',
+      target_auth: CronJobTargetAuth.HANDSHAKE,
+      target_scope: targetScope,
+      created_by: 'user-1',
+    });
+  });
+
+  it('passes through a manually overridden scope without re-deriving it', async () => {
+    const manualScope = 'POST:/v1/custom-endpoint';
+
+    const result = await handleCreateCronJob(
+      ctx,
+      createFormData({
+        target_path: '/v1/loopback',
+        target_scope: manualScope,
+      }),
+    );
+
+    expect(result).toEqual({
+      success: true,
+      message: 'Cron job created successfully',
+    });
+    expect(dbCreateCronJob).toHaveBeenCalledWith(
+      CRON_ID,
+      expect.objectContaining({
+        target_scope: manualScope,
+      }),
+    );
+  });
+
+  it('returns a validation error for invalid target_path', async () => {
+    const result = await handleCreateCronJob(ctx, createFormData({ target_path: 'not-a-path' }));
+
+    expect(result).toMatchObject({
+      data: {
+        error: {
+          message: expect.stringContaining('[target_path]'),
+        },
+      },
+    });
+    expect(dbCreateCronJob).not.toHaveBeenCalled();
+  });
+
+  it('returns a validation error when target_scope is missing', async () => {
+    const result = await handleCreateCronJob(ctx, createFormData({ target_scope: '' }));
+
+    expect(result).toMatchObject({
+      data: {
+        error: {
+          message: expect.stringContaining('[target_scope]'),
+        },
+      },
+    });
+    expect(dbCreateCronJob).not.toHaveBeenCalled();
+  });
+
+  it('returns a validation error for an invalid cron schedule', async () => {
+    const result = await handleCreateCronJob(ctx, createFormData({ schedule: 'not-a-cron' }));
+
+    expect(result).toMatchObject({
+      data: {
+        error: {
+          message: 'Invalid cron schedule expression',
+        },
+      },
+    });
+    expect(dbCreateCronJob).not.toHaveBeenCalled();
+  });
+});

--- a/platform/scms/app/routes/app/system.cron/actionHelpers.server.ts
+++ b/platform/scms/app/routes/app/system.cron/actionHelpers.server.ts
@@ -10,13 +10,20 @@ import {
 import { z } from 'zod';
 import { zfd } from 'zod-form-data';
 import { uuidv7 } from 'uuidv7';
+import { CRON_HTTP_METHODS } from './constants.js';
+
+export { CRON_HTTP_METHODS } from './constants.js';
 
 export const CreateCronJobSchema = zfd.formData({
   intent: z.literal('create'),
   name: zfd.text(z.string().trim().min(1, 'Name is required')),
   description: zfd.text(z.string().trim().optional()),
   schedule: zfd.text(z.string().trim().min(1, 'Schedule is required')),
-  http_method: zfd.text(z.string().trim().min(1).default('POST')),
+  http_method: zfd.text(
+    z.enum(CRON_HTTP_METHODS, {
+      errorMap: () => ({ message: 'HTTP method must be GET, POST, PUT, PATCH, or DELETE' }),
+    }),
+  ),
   target_url: zfd.text(z.string().trim().url('Target URL must be a valid absolute URL')),
   target_scope: zfd.text(z.string().trim().optional()),
 });

--- a/platform/scms/app/routes/app/system.cron/actionHelpers.server.ts
+++ b/platform/scms/app/routes/app/system.cron/actionHelpers.server.ts
@@ -1,0 +1,66 @@
+import {
+  withValidFormData,
+  dbCreateCronJob,
+  CronJobTargetType,
+  CronJobTargetAuth,
+  cronEndpointScope,
+  computeInitialNextRunAt,
+  type SecureContext,
+} from '@curvenote/scms-server';
+import { z } from 'zod';
+import { zfd } from 'zod-form-data';
+import { uuidv7 } from 'uuidv7';
+
+const CRON_NAME_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const CreateCronJobSchema = zfd.formData({
+  intent: z.literal('create'),
+  name: zfd.text(
+    z
+      .string()
+      .trim()
+      .min(1, 'Identifier is required')
+      .regex(
+        CRON_NAME_REGEX,
+        'Identifier must use lowercase letters, numbers, and hyphens only (e.g. my-new-cron)',
+      ),
+  ),
+  description: zfd.text(z.string().trim().min(1, 'Display name is required')),
+  schedule: zfd.text(z.string().trim().min(1, 'Schedule is required')),
+  http_method: zfd.text(z.string().trim().min(1).default('POST')),
+  target_url: zfd.text(z.string().trim().url('Target URL must be a valid absolute URL')),
+  target_scope: zfd.text(z.string().trim().optional()),
+});
+
+function assertValidCronSchedule(schedule: string): void {
+  try {
+    computeInitialNextRunAt(schedule, 'UTC');
+  } catch {
+    throw new Error('Invalid cron schedule expression');
+  }
+}
+
+export async function handleCreateCronJob(ctx: SecureContext, formData: FormData) {
+  return withValidFormData(CreateCronJobSchema, formData, async (payload) => {
+    assertValidCronSchedule(payload.schedule);
+
+    const httpMethod = payload.http_method || 'POST';
+    const targetUrl = payload.target_url.trim();
+    const targetScope =
+      payload.target_scope?.trim() || cronEndpointScope(httpMethod, new URL(targetUrl).pathname);
+
+    await dbCreateCronJob(uuidv7(), {
+      name: payload.name,
+      description: payload.description,
+      schedule: payload.schedule,
+      target_type: CronJobTargetType.HTTP,
+      target_url: targetUrl,
+      http_method: httpMethod,
+      target_auth: CronJobTargetAuth.HANDSHAKE,
+      target_scope: targetScope,
+      created_by: ctx.user?.id,
+    });
+
+    return { success: true as const, message: 'Cron job created successfully' };
+  });
+}

--- a/platform/scms/app/routes/app/system.cron/actionHelpers.server.ts
+++ b/platform/scms/app/routes/app/system.cron/actionHelpers.server.ts
@@ -13,8 +13,6 @@ import { zfd } from 'zod-form-data';
 import { uuidv7 } from 'uuidv7';
 import { CRON_HTTP_METHODS } from './constants.js';
 
-export { CRON_HTTP_METHODS } from './constants.js';
-
 const RELATIVE_TARGET_PATH = /^\/[^\s]+$/;
 
 export const CreateCronJobSchema = zfd.formData({
@@ -23,9 +21,7 @@ export const CreateCronJobSchema = zfd.formData({
   description: zfd.text(z.string().trim().optional()),
   schedule: zfd.text(z.string().trim().min(1, 'Schedule is required')),
   http_method: zfd.text(
-    z.enum(CRON_HTTP_METHODS, {
-      errorMap: () => ({ message: 'HTTP method must be GET, POST, PUT, PATCH, or DELETE' }),
-    }),
+    z.enum(CRON_HTTP_METHODS, 'HTTP method must be GET, POST, PUT, PATCH, or DELETE'),
   ),
   target_path: zfd.text(
     z

--- a/platform/scms/app/routes/app/system.cron/actionHelpers.server.ts
+++ b/platform/scms/app/routes/app/system.cron/actionHelpers.server.ts
@@ -3,8 +3,9 @@ import {
   dbCreateCronJob,
   CronJobTargetType,
   CronJobTargetAuth,
-  cronEndpointScope,
   computeInitialNextRunAt,
+  getConfig,
+  resolveApiPath,
   type SecureContext,
 } from '@curvenote/scms-server';
 import { z } from 'zod';
@@ -13,6 +14,8 @@ import { uuidv7 } from 'uuidv7';
 import { CRON_HTTP_METHODS } from './constants.js';
 
 export { CRON_HTTP_METHODS } from './constants.js';
+
+const RELATIVE_TARGET_PATH = /^\/[^\s]+$/;
 
 export const CreateCronJobSchema = zfd.formData({
   intent: z.literal('create'),
@@ -24,8 +27,14 @@ export const CreateCronJobSchema = zfd.formData({
       errorMap: () => ({ message: 'HTTP method must be GET, POST, PUT, PATCH, or DELETE' }),
     }),
   ),
-  target_url: zfd.text(z.string().trim().url('Target URL must be a valid absolute URL')),
-  target_scope: zfd.text(z.string().trim().optional()),
+  target_path: zfd.text(
+    z
+      .string()
+      .trim()
+      .min(1, 'Target path is required')
+      .regex(RELATIVE_TARGET_PATH, 'Target path must start with / (e.g. /v1/jobs/push-to-drain)'),
+  ),
+  target_scope: zfd.text(z.string().trim().min(1, 'Scope is required')),
 });
 
 function assertValidCronSchedule(schedule: string): void {
@@ -40,10 +49,11 @@ export async function handleCreateCronJob(ctx: SecureContext, formData: FormData
   return withValidFormData(CreateCronJobSchema, formData, async (payload) => {
     assertValidCronSchedule(payload.schedule);
 
+    const config = await getConfig();
     const httpMethod = payload.http_method || 'POST';
-    const targetUrl = payload.target_url.trim();
-    const targetScope =
-      payload.target_scope?.trim() || cronEndpointScope(httpMethod, new URL(targetUrl).pathname);
+    const targetPath = payload.target_path.trim();
+    const targetUrl = resolveApiPath(config.api.url, targetPath);
+    const targetScope = payload.target_scope.trim();
 
     await dbCreateCronJob(uuidv7(), {
       name: payload.name,

--- a/platform/scms/app/routes/app/system.cron/actionHelpers.server.ts
+++ b/platform/scms/app/routes/app/system.cron/actionHelpers.server.ts
@@ -11,21 +11,10 @@ import { z } from 'zod';
 import { zfd } from 'zod-form-data';
 import { uuidv7 } from 'uuidv7';
 
-const CRON_NAME_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-
 export const CreateCronJobSchema = zfd.formData({
   intent: z.literal('create'),
-  name: zfd.text(
-    z
-      .string()
-      .trim()
-      .min(1, 'Identifier is required')
-      .regex(
-        CRON_NAME_REGEX,
-        'Identifier must use lowercase letters, numbers, and hyphens only (e.g. my-new-cron)',
-      ),
-  ),
-  description: zfd.text(z.string().trim().min(1, 'Display name is required')),
+  name: zfd.text(z.string().trim().min(1, 'Name is required')),
+  description: zfd.text(z.string().trim().optional()),
   schedule: zfd.text(z.string().trim().min(1, 'Schedule is required')),
   http_method: zfd.text(z.string().trim().min(1).default('POST')),
   target_url: zfd.text(z.string().trim().url('Target URL must be a valid absolute URL')),
@@ -51,7 +40,7 @@ export async function handleCreateCronJob(ctx: SecureContext, formData: FormData
 
     await dbCreateCronJob(uuidv7(), {
       name: payload.name,
-      description: payload.description,
+      description: payload.description || null,
       schedule: payload.schedule,
       target_type: CronJobTargetType.HTTP,
       target_url: targetUrl,

--- a/platform/scms/app/routes/app/system.cron/constants.ts
+++ b/platform/scms/app/routes/app/system.cron/constants.ts
@@ -1,0 +1,3 @@
+export const CRON_HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const;
+
+export type CronHttpMethod = (typeof CRON_HTTP_METHODS)[number];

--- a/platform/scms/app/routes/app/system.cron/previewCronSchedule.ts
+++ b/platform/scms/app/routes/app/system.cron/previewCronSchedule.ts
@@ -1,0 +1,32 @@
+import { CronExpressionParser } from 'cron-parser';
+import cronstrue from 'cronstrue';
+
+export type CronSchedulePreview =
+  | { valid: true; description: string }
+  | { valid: false; error: string };
+
+/** Live client preview — uses the same parser as server-side schedule validation. */
+export function previewCronSchedule(
+  schedule: string,
+  timezone = 'UTC',
+): CronSchedulePreview | null {
+  const trimmed = schedule.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    CronExpressionParser.parse(trimmed, { tz: timezone });
+  } catch {
+    return { valid: false, error: 'Invalid cron schedule expression' };
+  }
+
+  try {
+    return {
+      valid: true,
+      description: cronstrue.toString(trimmed, { use24HourTimeFormat: true }),
+    };
+  } catch {
+    return { valid: true, description: 'Valid schedule' };
+  }
+}

--- a/platform/scms/app/routes/app/system.cron/route.tsx
+++ b/platform/scms/app/routes/app/system.cron/route.tsx
@@ -4,7 +4,6 @@ import { useState, type FormEvent } from 'react';
 import {
   withAppAdminContext,
   dbListCronJobs,
-  dbCreateCronJob,
   dbDeleteCronJob,
   dbSetCronJobEnabled,
   runCronJobNow,
@@ -14,19 +13,18 @@ import {
   pushCronTickSecretFromConfig,
   unscheduleJobQueueDrainBackup,
   rescheduleJobQueueDrainBackup,
-  CronJobTargetType,
-  CronJobTargetAuth,
-  cronEndpointScope,
   resolveScopedCronTargetUrl,
+  collectAllowedCronTickHosts,
   getConfig,
   type CronTickStatus,
   type PgCronHealth,
 } from '@curvenote/scms-server';
-import { CronEndpointScopes, PageFrame, ui } from '@curvenote/scms-core';
+import { PageFrame, ui } from '@curvenote/scms-core';
 import type { CronJob } from '@curvenote/scms-db';
-import { uuidv7 } from 'uuidv7';
 import { Clock, KeyRound, CheckCircle, XCircle, AlertTriangle, RefreshCw } from 'lucide-react';
 import { CronJobListItem } from './CronJobListItem';
+import { CreateCronJobForm } from './CreateCronJobForm';
+import { handleCreateCronJob } from './actionHelpers.server';
 import type { CronJobListRow } from './types';
 
 async function enrichCronJobsForList(jobs: CronJob[]): Promise<CronJobListRow[]> {
@@ -51,12 +49,14 @@ export const meta: Route.MetaFunction = () => [
 
 export async function loader(args: Route.LoaderArgs) {
   await withAppAdminContext(args);
+  const config = await getConfig();
   const [jobs, tickStatus, pgCronHealth] = await Promise.all([
     dbListCronJobs(),
     getCronTickStatus(),
     getPgCronHealth(),
   ]);
-  return { jobs: await enrichCronJobsForList(jobs), tickStatus, pgCronHealth };
+  const allowedHosts = [...collectAllowedCronTickHosts(config.api)].sort();
+  return { jobs: await enrichCronJobsForList(jobs), tickStatus, pgCronHealth, allowedHosts };
 }
 
 export async function action(args: Route.ActionArgs) {
@@ -66,24 +66,7 @@ export async function action(args: Route.ActionArgs) {
 
   try {
     if (intent === 'create') {
-      const name = String(form.get('name') ?? '').trim();
-      const schedule = String(form.get('schedule') ?? '').trim();
-      const targetUrl = String(form.get('target_url') ?? '').trim();
-      const httpMethod = String(form.get('http_method') ?? 'POST').trim();
-      const targetScope =
-        String(form.get('target_scope') ?? '').trim() ||
-        (targetUrl ? cronEndpointScope(httpMethod, new URL(targetUrl).pathname) : '');
-      await dbCreateCronJob(uuidv7(), {
-        name,
-        schedule,
-        target_type: CronJobTargetType.HTTP,
-        target_url: targetUrl || null,
-        http_method: httpMethod,
-        target_auth: CronJobTargetAuth.HANDSHAKE,
-        target_scope: targetScope,
-        created_by: ctx.user?.id,
-      });
-      return data({ ok: true, intent });
+      return handleCreateCronJob(ctx, form);
     }
 
     if (intent === 'toggle') {
@@ -287,9 +270,7 @@ function ConfigTab({
   );
 }
 
-function JobsTab({ jobs }: { jobs: CronJobListRow[] }) {
-  const createFetcher = useFetcher();
-
+function JobsTab({ jobs, allowedHosts }: { jobs: CronJobListRow[]; allowedHosts: string[] }) {
   return (
     <div className="space-y-6">
       <section className="overflow-hidden bg-white rounded-lg border dark:bg-gray-900 dark:border-gray-700">
@@ -312,71 +293,7 @@ function JobsTab({ jobs }: { jobs: CronJobListRow[] }) {
         )}
       </section>
 
-      <section className="p-4 bg-white rounded-lg border dark:bg-gray-900 dark:border-gray-700">
-        <h3 className="mb-3 font-semibold">Create HTTP cron (HANDSHAKE)</h3>
-        <createFetcher.Form method="post" className="grid gap-4 max-w-xl">
-          <input type="hidden" name="intent" value="create" />
-          <div>
-            <ui.Label htmlFor="cron-name">Name *</ui.Label>
-            <ui.Input
-              id="cron-name"
-              name="name"
-              placeholder="my-cron-job"
-              required
-              className="mt-1"
-            />
-            <p className="mt-1 text-sm text-muted-foreground">
-              Unique identifier for this cron job
-            </p>
-          </div>
-          <div>
-            <ui.Label htmlFor="cron-schedule">Schedule *</ui.Label>
-            <ui.Input
-              id="cron-schedule"
-              name="schedule"
-              placeholder="* * * * *"
-              required
-              className="mt-1 font-mono"
-            />
-            <p className="mt-1 text-sm text-muted-foreground">Standard cron expression</p>
-          </div>
-          <div>
-            <ui.Label htmlFor="cron-http-method">HTTP method</ui.Label>
-            <ui.Input
-              id="cron-http-method"
-              name="http_method"
-              defaultValue="POST"
-              className="mt-1 font-mono"
-            />
-          </div>
-          <div>
-            <ui.Label htmlFor="cron-target-url">Target URL *</ui.Label>
-            <ui.Input
-              id="cron-target-url"
-              name="target_url"
-              placeholder="https://host/v1/..."
-              required
-              className="mt-1 font-mono text-xs"
-            />
-          </div>
-          <div>
-            <ui.Label htmlFor="cron-target-scope">Scope</ui.Label>
-            <ui.Input
-              id="cron-target-scope"
-              name="target_scope"
-              placeholder={CronEndpointScopes.JOB_QUEUE_DRAIN}
-              className="mt-1 font-mono text-xs"
-            />
-            <p className="mt-1 text-sm text-muted-foreground">
-              Optional. Defaults to {CronEndpointScopes.JOB_QUEUE_DRAIN} when left blank and a
-              target URL is provided.
-            </p>
-          </div>
-          <ui.Button type="submit" className="w-fit">
-            Create
-          </ui.Button>
-        </createFetcher.Form>
-      </section>
+      <CreateCronJobForm allowedHosts={allowedHosts} />
     </div>
   );
 }
@@ -420,7 +337,9 @@ export default function SystemCronPage({ loaderData }: Route.ComponentProps) {
           </div>
         </div>
         <ui.TabsContent value="jobs" className="mt-4">
-          {tab === 'jobs' ? <JobsTab jobs={loaderData.jobs} /> : null}
+          {tab === 'jobs' ? (
+            <JobsTab jobs={loaderData.jobs} allowedHosts={loaderData.allowedHosts} />
+          ) : null}
         </ui.TabsContent>
         <ui.TabsContent value="config" className="mt-4">
           {tab === 'config' ? (

--- a/platform/scms/app/routes/app/system.cron/route.tsx
+++ b/platform/scms/app/routes/app/system.cron/route.tsx
@@ -19,7 +19,7 @@ import {
   type CronTickStatus,
   type PgCronHealth,
 } from '@curvenote/scms-server';
-import { PageFrame, ui } from '@curvenote/scms-core';
+import { PageFrame, SectionWithHeading, ui } from '@curvenote/scms-core';
 import type { CronJob } from '@curvenote/scms-db';
 import { Clock, KeyRound, CheckCircle, XCircle, AlertTriangle, RefreshCw } from 'lucide-react';
 import { CronJobListItem } from './CronJobListItem';
@@ -272,9 +272,10 @@ function ConfigTab({
 
 function JobsTab({ jobs, allowedHosts }: { jobs: CronJobListRow[]; allowedHosts: string[] }) {
   return (
-    <div className="space-y-8">
-      <div>
-        <h2 className="mb-4 text-lg font-semibold">Cron jobs</h2>
+    <div className="space-y-2">
+      <CreateCronJobForm allowedHosts={allowedHosts} />
+
+      <SectionWithHeading heading="Cron jobs" icon={Clock}>
         {jobs.length === 0 ? (
           <p className="text-sm text-muted-foreground">No cron jobs configured.</p>
         ) : (
@@ -286,9 +287,7 @@ function JobsTab({ jobs, allowedHosts }: { jobs: CronJobListRow[]; allowedHosts:
             ))}
           </div>
         )}
-      </div>
-
-      <CreateCronJobForm allowedHosts={allowedHosts} />
+      </SectionWithHeading>
     </div>
   );
 }

--- a/platform/scms/app/routes/app/system.cron/route.tsx
+++ b/platform/scms/app/routes/app/system.cron/route.tsx
@@ -272,26 +272,21 @@ function ConfigTab({
 
 function JobsTab({ jobs, allowedHosts }: { jobs: CronJobListRow[]; allowedHosts: string[] }) {
   return (
-    <div className="space-y-6">
-      <section className="overflow-hidden bg-white rounded-lg border dark:bg-gray-900 dark:border-gray-700">
-        <div className="px-4 py-3 bg-gray-50 border-b dark:bg-gray-800 dark:border-gray-700">
-          <h2 className="text-lg font-semibold">Cron jobs</h2>
-        </div>
+    <div className="space-y-8">
+      <div>
+        <h2 className="mb-4 text-lg font-semibold">Cron jobs</h2>
         {jobs.length === 0 ? (
-          <p className="px-4 py-8 text-sm text-center text-gray-500">No cron jobs configured.</p>
+          <p className="text-sm text-muted-foreground">No cron jobs configured.</p>
         ) : (
-          <div>
+          <div className="divide-y divide-gray-200 dark:divide-gray-700">
             {jobs.map((job) => (
-              <div
-                key={job.id}
-                className="flex flex-col gap-2 p-4 border-b border-gray-200 dark:border-gray-700 last:border-b-0"
-              >
+              <div key={job.id} className="py-4 first:pt-0">
                 <CronJobListItem job={job} />
               </div>
             ))}
           </div>
         )}
-      </section>
+      </div>
 
       <CreateCronJobForm allowedHosts={allowedHosts} />
     </div>

--- a/platform/scms/app/routes/app/system.cron/route.tsx
+++ b/platform/scms/app/routes/app/system.cron/route.tsx
@@ -276,17 +276,22 @@ function JobsTab({ jobs, allowedHosts }: { jobs: CronJobListRow[]; allowedHosts:
       <CreateCronJobForm allowedHosts={allowedHosts} />
 
       <SectionWithHeading heading="Cron jobs" icon={Clock}>
-        {jobs.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No cron jobs configured.</p>
-        ) : (
-          <div className="divide-y divide-gray-200 dark:divide-gray-700">
-            {jobs.map((job) => (
-              <div key={job.id} className="py-4 first:pt-0">
+        <div className="overflow-hidden bg-white rounded-sm border border-gray-200 dark:bg-gray-900 dark:border-gray-700">
+          {jobs.length === 0 ? (
+            <div className="py-12 text-center">
+              <p className="text-gray-500 dark:text-gray-400">No cron jobs configured.</p>
+            </div>
+          ) : (
+            jobs.map((job) => (
+              <div
+                key={job.id}
+                className="flex flex-col gap-2 p-6 border-b border-gray-200 md:items-center md:flex-row md:gap-6 dark:border-gray-700 last:border-b-0"
+              >
                 <CronJobListItem job={job} />
               </div>
-            ))}
-          </div>
-        )}
+            ))
+          )}
+        </div>
       </SectionWithHeading>
     </div>
   );

--- a/platform/scms/app/routes/app/system.cron/route.tsx
+++ b/platform/scms/app/routes/app/system.cron/route.tsx
@@ -14,7 +14,6 @@ import {
   unscheduleJobQueueDrainBackup,
   rescheduleJobQueueDrainBackup,
   resolveScopedCronTargetUrl,
-  collectAllowedCronTickHosts,
   getConfig,
   type CronTickStatus,
   type PgCronHealth,
@@ -49,14 +48,12 @@ export const meta: Route.MetaFunction = () => [
 
 export async function loader(args: Route.LoaderArgs) {
   await withAppAdminContext(args);
-  const config = await getConfig();
   const [jobs, tickStatus, pgCronHealth] = await Promise.all([
     dbListCronJobs(),
     getCronTickStatus(),
     getPgCronHealth(),
   ]);
-  const allowedHosts = [...collectAllowedCronTickHosts(config.api)].sort();
-  return { jobs: await enrichCronJobsForList(jobs), tickStatus, pgCronHealth, allowedHosts };
+  return { jobs: await enrichCronJobsForList(jobs), tickStatus, pgCronHealth };
 }
 
 export async function action(args: Route.ActionArgs) {
@@ -270,10 +267,10 @@ function ConfigTab({
   );
 }
 
-function JobsTab({ jobs, allowedHosts }: { jobs: CronJobListRow[]; allowedHosts: string[] }) {
+function JobsTab({ jobs }: { jobs: CronJobListRow[] }) {
   return (
     <div className="space-y-2">
-      <CreateCronJobForm allowedHosts={allowedHosts} />
+      <CreateCronJobForm />
 
       <SectionWithHeading heading="Cron jobs" icon={Clock}>
         <div className="overflow-hidden bg-white rounded-sm border border-gray-200 dark:bg-gray-900 dark:border-gray-700">
@@ -336,9 +333,7 @@ export default function SystemCronPage({ loaderData }: Route.ComponentProps) {
           </div>
         </div>
         <ui.TabsContent value="jobs" className="mt-4">
-          {tab === 'jobs' ? (
-            <JobsTab jobs={loaderData.jobs} allowedHosts={loaderData.allowedHosts} />
-          ) : null}
+          {tab === 'jobs' ? <JobsTab jobs={loaderData.jobs} /> : null}
         </ui.TabsContent>
         <ui.TabsContent value="config" className="mt-4">
           {tab === 'config' ? (

--- a/platform/scms/package.template.json
+++ b/platform/scms/package.template.json
@@ -144,6 +144,8 @@
     "@vercel/react-router": "^1.2.3",
     "bmp-js": "^0.1.0",
     "classnames": "^2.5.1",
+    "cron-parser": "^5.6.1",
+    "cronstrue": "^3.24.0",
     "date-fns": "3.6.0",
     "officeparser": "^6.0.4",
     "fuse.js": "^7.1.0",


### PR DESCRIPTION
The form was not fully hooked up on the serverside, and UX was not great. Both now in place / improved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin cron job persistence and introduces a new scoped-handshake API route; misconfigured paths/scopes could break scheduled callbacks, though access remains admin-gated and handshake-scoped.
> 
> **Overview**
> Replaces the system cron **create** flow with an expandable admin form and proper server handling. Creation now goes through **Zod** validation (`CreateCronJobSchema` / `handleCreateCronJob`): relative **target paths** (not full URLs) are resolved via `resolveApiPath`, schedules are checked with the same cron logic as the server, and **HANDSHAKE** jobs persist an explicit **target scope** (including optional manual override). The UI adds live schedule preview (`cron-parser` + `cronstrue`), auto-fills scope from method + path, optional description, and success/error toasts.
> 
> Adds **`POST:/v1/loopback`** as a scoped-handshake echo route for safe cron smoke tests, registers it under `v1/loopback`, and documents it in `CronEndpointScopes`. Cron job rows can show **description** under the name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 474e6257f8f77b8138f08f4eb669be0990c384e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->