### PR TITLE
🔧 adjust and improve work role enforcement

### DIFF
--- a/.changeset/work-users-access-controls.md
+++ b/.changeset/work-users-access-controls.md
@@ -1,0 +1,7 @@
+---
+'@curvenote/scms': patch
+'@curvenote/scms-core': patch
+'@curvenote/scms-server': patch
+---
+
+Improve work user access controls and scope consistency. Rename the work users read scope to `work:users:read`, grant viewers read access to the work users list, and gate the "Who can access this?" menu item on that scope. On the work users page, show role removal controls and the add-user form only for owners (or system admins); contributors and viewers can still read the list to identify owners.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24626,9 +24626,9 @@
       "license": "ISC"
     },
     "node_modules/idb-keyval": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.6.tgz",
-      "integrity": "sha512-FY64UEhw+5liMzMQ1R9Mw6AF0+wyBrg1CIA1z4CjI/EvT5ty/SvQcWZgd8s9sgaNhX10Y8UzScTh89tEAls5nA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.3.0.tgz",
+      "integrity": "sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow==",
       "license": "Apache-2.0"
     },
     "node_modules/ieee754": {
@@ -43297,9 +43297,9 @@
       }
     },
     "platform/relay/node_modules/@types/node": {
-      "version": "22.20.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
-      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -43451,6 +43451,16 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "platform/scms/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "platform/scms/node_modules/@types/react": {
@@ -43654,6 +43664,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "platform/scms/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "preinstall": "rm -f ./platform/scms/package.json ./platform/relay/package.json ./turbo.extensions.generated.json",
     "postinstall": "npm run generate:extensions && npm run generate:relay-plugins",
     "wt:create": "bash scripts/wt-add.sh",
+    "wt:go": "npm install; npm run build; cd platform/scms; npm install; npm run type-check; cd ../..",
     "wt:existing": "bash scripts/wt-add.sh --existing",
     "wt:remove": "bash scripts/wt-remove.sh",
     "generate:extensions": "node platform/scms/scripts/generate-extensions.js",

--- a/packages/scms-core/src/scopes.ts
+++ b/packages/scms-core/src/scopes.ts
@@ -86,7 +86,7 @@ export const work = {
       },
     },
     users: {
-      read: 'work:users',
+      read: 'work:users:read',
       update: 'work:users:update',
     },
     checks: {

--- a/packages/scms-server/src/backend/roles.server.spec.ts
+++ b/packages/scms-server/src/backend/roles.server.spec.ts
@@ -44,6 +44,8 @@ describe('work role scope mapping', () => {
     expect(hasWorkScope(WorkRole.OWNER, work.id.users.update)).toBe(true);
     expect(hasWorkScope(WorkRole.CONTRIBUTOR, work.id.users.update)).toBe(false);
     expect(hasWorkScope(WorkRole.CONTRIBUTOR, work.id.users.read)).toBe(true);
+    expect(hasWorkScope(WorkRole.VIEWER, work.id.users.read)).toBe(true);
+    expect(hasWorkScope(WorkRole.VIEWER, work.id.users.update)).toBe(false);
   });
 });
 

--- a/packages/scms-server/src/backend/roles.server.ts
+++ b/packages/scms-server/src/backend/roles.server.ts
@@ -157,7 +157,7 @@ const WORK_ROLES: Record<WorkRole, Set<string>> = {
     work.id.users.read,
     work.id.checks.read,
   ]),
-  [WorkRole.VIEWER]: new Set([work.id.read]),
+  [WorkRole.VIEWER]: new Set([work.id.read, work.id.users.read]),
 };
 
 export function hasDefaultScopeViaSystemRole(

--- a/platform/scms/app/routes/app/works.$workId.users/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.users/route.tsx
@@ -1,5 +1,5 @@
 import type { Route } from './+types/route';
-import { withSecureWorkContext } from '@curvenote/scms-server';
+import { withSecureWorkContext, userHasWorkScope } from '@curvenote/scms-server';
 import {
   PageFrame,
   UserCard,
@@ -17,10 +17,12 @@ import { actionGrantUserRole, actionRevokeUserRole } from './actionHelpers.serve
 
 export async function loader(args: Route.LoaderArgs) {
   const ctx = await withSecureWorkContext(args, [scopes.work.id.users.read]);
+  const canUpdateUsers = userHasWorkScope(ctx.user, scopes.work.id.users.update, ctx.work.id);
   const dbo = await dbGetWorkUsers(ctx.work.id);
-  if (!dbo) return { work: ctx.workDTO, error: 'Failed to get work users', users: [] };
+  if (!dbo)
+    return { work: ctx.workDTO, error: 'Failed to get work users', users: [], canUpdateUsers };
   const users = dtoWorkUsers(dbo);
-  return { work: ctx.workDTO, users };
+  return { work: ctx.workDTO, users, canUpdateUsers };
 }
 
 export const meta: Route.MetaFunction = ({ matches }) => {
@@ -54,7 +56,7 @@ export async function action(args: Route.ActionArgs) {
 }
 
 export default function Users({ loaderData }: Route.ComponentProps) {
-  const { users } = loaderData;
+  const { users, canUpdateUsers } = loaderData;
 
   return (
     <PageFrame title="Users" subtitle="Who can access this work?" className="max-w-none">
@@ -68,7 +70,7 @@ export default function Users({ loaderData }: Route.ComponentProps) {
               <UserCard
                 key={u.id}
                 name={u.display_name}
-                roles={u.work_roles.map((role) => ({ role, canRemove: false }))}
+                roles={u.work_roles.map((role) => ({ role, canRemove: canUpdateUsers }))}
                 email={u.email}
                 userId={u.id}
               />

--- a/platform/scms/app/routes/app/works.$workId.users/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.users/route.tsx
@@ -61,9 +61,11 @@ export default function Users({ loaderData }: Route.ComponentProps) {
   return (
     <PageFrame title="Users" subtitle="Who can access this work?" className="max-w-none">
       <div className="flex flex-col space-y-5">
-        <div>
-          <WorkRolesForm />
-        </div>
+        {canUpdateUsers ? (
+          <div>
+            <WorkRolesForm />
+          </div>
+        ) : null}
         <SectionWithHeading heading="Current Users" icon={User}>
           <div className="overflow-hidden rounded-sm border bg-background">
             {users.map((u) => (

--- a/platform/scms/app/routes/app/works.$workId/menu.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/menu.test.ts
@@ -22,6 +22,7 @@ describe('buildMenu', () => {
         makeSubmission('pmc', 'PMC', 'sv-2'),
       ],
       [scopes.app.works.checks.feature],
+      true,
     );
 
     const items = menu[0].menus;
@@ -48,9 +49,21 @@ describe('buildMenu', () => {
   });
 
   it('omits Submissions when there are no submission versions', () => {
-    const menu = buildMenu(baseUrl, false, [], []);
+    const menu = buildMenu(baseUrl, false, [], [], true);
 
     expect(menu[0].menus.some((item) => item.name === 'work.submissions')).toBe(false);
+  });
+
+  it('includes the users item when the user can read work users', () => {
+    const menu = buildMenu(baseUrl, false, [], [], true);
+
+    expect(menu[0].menus.some((item) => item.name === 'work.users')).toBe(true);
+  });
+
+  it('omits the users item when the user cannot read work users', () => {
+    const menu = buildMenu(baseUrl, false, [], [], false);
+
+    expect(menu[0].menus.some((item) => item.name === 'work.users')).toBe(false);
   });
 
   it('skips submissions without a latest version id', () => {
@@ -64,6 +77,7 @@ describe('buildMenu', () => {
         } as unknown as Parameters<typeof buildMenu>[2][number],
       ],
       [],
+      true,
     );
 
     expect(menu[0].menus.some((item) => item.name === 'work.submissions')).toBe(false);

--- a/platform/scms/app/routes/app/works.$workId/menu.ts
+++ b/platform/scms/app/routes/app/works.$workId/menu.ts
@@ -15,6 +15,7 @@ export function buildMenu(
   drafting: boolean,
   submissions: SubmissionWithVersionsAndSite[],
   userScopes: string[],
+  canReadUsers: boolean,
 ) {
   const contents: MenuContents = [
     {
@@ -38,11 +39,13 @@ export function buildMenu(
         url: `${baseUrl}/checks`,
       });
     }
-    menus.push({
-      name: 'work.users',
-      label: 'Who can access this?',
-      url: `${baseUrl}/users`,
-    });
+    if (canReadUsers) {
+      menus.push({
+        name: 'work.users',
+        label: 'Who can access this?',
+        url: `${baseUrl}/users`,
+      });
+    }
   }
 
   const submissionMenus = submissions.flatMap((submission) => {

--- a/platform/scms/app/routes/app/works.$workId/route.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/route.test.ts
@@ -18,6 +18,7 @@ const {
   notifyNewSubmissionCreated,
   notifySubmissionVersionCreated,
   userHasScope,
+  userHasWorkScope,
   withSecureWorkContext,
 } = vi.hoisted(() => ({
   createReturningVersion: vi.fn(),
@@ -36,6 +37,7 @@ const {
   notifyNewSubmissionCreated: vi.fn(async () => undefined),
   notifySubmissionVersionCreated: vi.fn(async () => undefined),
   userHasScope: vi.fn(),
+  userHasWorkScope: vi.fn(),
   withSecureWorkContext: vi.fn(),
 }));
 
@@ -44,6 +46,7 @@ vi.mock('@curvenote/scms-server', () => ({
   dbCreateDraftWorkVersion: vi.fn(),
   metadataForNewDraftFileWorkVersion: vi.fn(),
   userHasScope,
+  userHasWorkScope,
   getPrismaClient: vi.fn(async () => ({
     $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
       fn({
@@ -114,6 +117,9 @@ vi.mock('@curvenote/scms-core', () => ({
     work: {
       id: {
         read: 'work:id:read',
+        users: {
+          read: 'work:users:read',
+        },
       },
     },
   },

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -12,6 +12,7 @@ import {
   dbCreateDraftWorkVersion,
   metadataForNewDraftFileWorkVersion,
   userHasScope,
+  userHasWorkScope,
   works,
   getUserScopesSet,
   getPrismaClient,
@@ -571,6 +572,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
 
   return {
     userScopes: ctx.scopes,
+    canReadUsers: userHasWorkScope(ctx.user, scopes.work.id.users.read, ctx.work.id),
     workflows,
     work,
     versions: versionsForClient,
@@ -612,12 +614,25 @@ export function shouldRevalidate({
 }
 
 export default function WorkLayout({ loaderData }: Route.ComponentProps) {
-  const { work, versions, submissions, userScopes, isOnUploadRoute, maintenanceByServiceId } =
-    loaderData;
+  const {
+    work,
+    versions,
+    submissions,
+    userScopes,
+    canReadUsers,
+    isOnUploadRoute,
+    maintenanceByServiceId,
+  } = loaderData;
 
   const isDrafting = versions.length > 0 && versions.every((v) => v.draft);
   const showSecondaryNav = !isDrafting && !isOnUploadRoute;
-  const menu = buildMenu(`/app/works/${work.id}`, isDrafting, submissions, userScopes);
+  const menu = buildMenu(
+    `/app/works/${work.id}`,
+    isDrafting,
+    submissions,
+    userScopes,
+    canReadUsers,
+  );
 
   return (
     <CheckMaintenanceProvider maintenanceByServiceId={maintenanceByServiceId}>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Scope string rename may break callers still using `work:users`, and authorization behavior changes who sees and can mutate work membership.
> 
> **Overview**
> **Work user access** is aligned around a renamed read scope **`work:users:read`** (was **`work:users`**) and clearer role boundaries.
> 
> **Viewers** now receive **`work:users:read`** in the default work-role map, so they can open the work users list (e.g. to see owners) but still cannot **`work:users:update`**. The work layout loader exposes **`canReadUsers`** via **`userHasWorkScope`**, and **`buildMenu`** only shows **"Who can access this?"** when that read scope is present.
> 
> On the **work users** page, the loader still requires read access but computes **`canUpdateUsers`** from the update scope. The add-user form and role removal on **`UserCard`** render only when **`canUpdateUsers`** is true; read-only users see the current list without management controls.
> 
> Tests cover viewer read/update expectations, menu visibility, and loader wiring. A root **`wt:go`** script and a changeset were added; lockfile bumps are incidental.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f6ae934d00fd3bc112d3179f98595c352a06b3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->