### PR TITLE
🛡️ consolidate check scopes enforcement

### DIFF
--- a/.changeset/work-checks-dispatch-scopes.md
+++ b/.changeset/work-checks-dispatch-scopes.md
@@ -1,0 +1,7 @@
+---
+'@curvenote/scms': patch
+'@curvenote/scms-core': patch
+'@curvenote/scms-server': patch
+---
+
+Move checks dispatch from global `app:works:checks:dispatch` to per-work `work:checks:dispatch` for owners and contributors, grant all work roles `work:checks:read`, and gate checks UI visibility on `app:works:checks:feature`. Viewers can see check results and timelines but cannot run checks, retry failed runs, or trigger third-party report flows; platform routes reject dispatch intents without the work scope. Extension activity mounts receive `canDispatchChecks` and omit action paths for read-only users.

--- a/.changeset/work-users-access-controls.md
+++ b/.changeset/work-users-access-controls.md
@@ -4,4 +4,4 @@
 '@curvenote/scms-server': patch
 ---
 
-Improve work user access controls and scope consistency. Rename the work users read scope to `work:users:read`, grant viewers read access to the work users list, and gate the "Who can access this?" menu item on that scope. On the work users page, show role removal controls and the add-user form only for owners (or system admins); contributors and viewers can still read the list to identify owners.
+Improve work user access controls and move checks dispatch to per-work roles. Rename the work users read scope to `work:users:read`, grant all work roles read access to the user list and check results, and gate work-user management UI on `work:users:update`. Replace global `app:works:checks:dispatch` with per-work `work:checks:dispatch` for owners and contributors; gate checks UI on `app:works:checks:feature`.

--- a/.changeset/work-users-access-controls.md
+++ b/.changeset/work-users-access-controls.md
@@ -4,4 +4,4 @@
 '@curvenote/scms-server': patch
 ---
 
-Improve work user access controls and move checks dispatch to per-work roles. Rename the work users read scope to `work:users:read`, grant all work roles read access to the user list and check results, and gate work-user management UI on `work:users:update`. Replace global `app:works:checks:dispatch` with per-work `work:checks:dispatch` for owners and contributors; gate checks UI on `app:works:checks:feature`.
+Improve work user access controls and move checks dispatch to per-work roles. Rename the work users read scope to `work:users:read`, grant all work roles read access to the user list and check results, and gate work-user management UI on `work:users:update`. Replace global `app:works:checks:dispatch` with per-work `work:checks:dispatch` for owners and contributors; gate checks UI on `app:works:checks:feature` and hide or reject run/retry controls for viewers.

--- a/.changeset/work-users-access-controls.md
+++ b/.changeset/work-users-access-controls.md
@@ -4,4 +4,4 @@
 '@curvenote/scms-server': patch
 ---
 
-Improve work user access controls and move checks dispatch to per-work roles. Rename the work users read scope to `work:users:read`, grant all work roles read access to the user list and check results, and gate work-user management UI on `work:users:update`. Replace global `app:works:checks:dispatch` with per-work `work:checks:dispatch` for owners and contributors; gate checks UI on `app:works:checks:feature` and hide or reject run/retry controls for viewers.
+Improve work user access controls and scope consistency. Rename the work users read scope to `work:users:read`, grant viewers read access to the work users list, and gate the "Who can access this?" menu item on that scope. On the work users page, show role removal controls and the add-user form only for users with `work:users:update` (owners and system admins); contributors and viewers can still read the list to identify owners.

--- a/packages/scms-core/src/components/timeline/CheckServiceRunTimelineItem.tsx
+++ b/packages/scms-core/src/components/timeline/CheckServiceRunTimelineItem.tsx
@@ -21,6 +21,8 @@ type CheckServiceRunTimelineItemProps = {
   basePath: string;
   /** Controls default expanded state of this timeline row. */
   defaultExpanded?: boolean;
+  /** When false, extension activity UI must not offer run/retry controls. */
+  canDispatchChecks?: boolean;
   /** Optional route for fallback detail copy; defaults to `${basePath}/work-integrity`. */
   fallbackDetailsHref?: string;
   /** When true, omit the relative run timestamp on the row (e.g. checks page shows version date in section label). */
@@ -43,6 +45,7 @@ export function CheckServiceRunTimelineItem({
   run,
   checkService,
   basePath,
+  canDispatchChecks = false,
   defaultExpanded,
   fallbackDetailsHref,
   hideDate = false,
@@ -85,7 +88,8 @@ export function CheckServiceRunTimelineItem({
           metadata={serviceData}
           workVersionId={run.work_version_id}
           checkRunId={run.id}
-          remoteStatusActionPath={checksActionPath}
+          canDispatchChecks={canDispatchChecks}
+          remoteStatusActionPath={canDispatchChecks ? checksActionPath : undefined}
           checkRunDateModified={run.date_modified}
         />
       </div>
@@ -103,7 +107,8 @@ export function CheckServiceRunTimelineItem({
             workVersionId={run.work_version_id}
             checkKind={run.kind}
             metadata={serviceData}
-            remoteStatusActionPath={checksActionPath}
+            canDispatchChecks={canDispatchChecks}
+            remoteStatusActionPath={canDispatchChecks ? checksActionPath : undefined}
             defaultExpanded={defaultExpanded}
           />
         ) : null}

--- a/packages/scms-core/src/modules/builtinTasks/metadata.ts
+++ b/packages/scms-core/src/modules/builtinTasks/metadata.ts
@@ -6,7 +6,7 @@ import { BUILTIN_TASK_IDS } from './ids.js';
  * Keep in sync with task definitions in `registry.tsx`.
  */
 export const BUILTIN_TASK_META: ReadonlyArray<{ id: string; scopes?: string[] }> = [
-  { id: BUILTIN_TASK_IDS.automatedChecks },
+  { id: BUILTIN_TASK_IDS.automatedChecks, scopes: [scopes.app.works.checks.feature] },
 ];
 
 function taskVisibleForScopes(taskScopes: string[] | undefined, userScopes: string[]): boolean {

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -152,6 +152,11 @@ export type ExtensionCheckSectionActivityProps = {
   checkRunId?: string;
   workVersionId?: string;
   metadata: any;
+  /**
+   * When false, extensions must hide dispatch controls (run, retry, accept EULA, etc.).
+   * The platform also omits `remoteStatusActionPath` so fetcher forms cannot post.
+   */
+  canDispatchChecks?: boolean;
   /** POST target for check UI mutations (extension-owned route or legacy work checks path). */
   remoteStatusActionPath?: string;
   /**
@@ -179,8 +184,10 @@ export type ExtensionCheckRunTimelineMountProps = {
   /** Check service id from the run row. */
   checkKind: string;
   metadata: unknown;
-  /** POST target for check UI mutations. */
-  remoteStatusActionPath: string;
+  /** POST target for check UI mutations. Omitted when the user cannot dispatch checks. */
+  remoteStatusActionPath?: string;
+  /** When false, mount-only sync must not enqueue or retry checks. */
+  canDispatchChecks?: boolean;
   /** See `ExtensionCheckSectionActivityProps.defaultExpanded`. */
   defaultExpanded?: boolean;
 };

--- a/packages/scms-core/src/scopes.ts
+++ b/packages/scms-core/src/scopes.ts
@@ -91,6 +91,7 @@ export const work = {
     },
     checks: {
       read: 'work:checks:read',
+      dispatch: 'work:checks:dispatch',
     },
   },
 };
@@ -131,7 +132,6 @@ export const app = {
     submitToSite: 'app:works:submit-to-site',
     checks: {
       feature: 'app:works:checks:feature',
-      dispatch: 'app:works:checks:dispatch',
     },
     export: 'app:works:export',
     metadataExtract: 'app:works:metadata-extract',

--- a/packages/scms-server/src/backend/roles.server.spec.ts
+++ b/packages/scms-server/src/backend/roles.server.spec.ts
@@ -47,6 +47,14 @@ describe('work role scope mapping', () => {
     expect(hasWorkScope(WorkRole.VIEWER, work.id.users.read)).toBe(true);
     expect(hasWorkScope(WorkRole.VIEWER, work.id.users.update)).toBe(false);
   });
+
+  test('OWNER and CONTRIBUTOR may dispatch checks; all roles may read', () => {
+    expect(hasWorkScope(WorkRole.OWNER, work.id.checks.dispatch)).toBe(true);
+    expect(hasWorkScope(WorkRole.CONTRIBUTOR, work.id.checks.dispatch)).toBe(true);
+    expect(hasWorkScope(WorkRole.VIEWER, work.id.checks.dispatch)).toBe(false);
+    expect(hasWorkScope(WorkRole.VIEWER, work.id.checks.read)).toBe(true);
+    expect(hasWorkScope(WorkRole.CONTRIBUTOR, work.id.checks.read)).toBe(true);
+  });
 });
 
 describe('default system role scope mapping', () => {

--- a/packages/scms-server/src/backend/roles.server.ts
+++ b/packages/scms-server/src/backend/roles.server.ts
@@ -145,6 +145,7 @@ const WORK_ROLES: Record<WorkRole, Set<string>> = {
     work.id.users.read,
     work.id.users.update,
     work.id.checks.read,
+    work.id.checks.dispatch,
   ]),
   [WorkRole.CONTRIBUTOR]: new Set([
     work.id.read,
@@ -156,8 +157,9 @@ const WORK_ROLES: Record<WorkRole, Set<string>> = {
     work.id.submissions.versions.create,
     work.id.users.read,
     work.id.checks.read,
+    work.id.checks.dispatch,
   ]),
-  [WorkRole.VIEWER]: new Set([work.id.read, work.id.users.read]),
+  [WorkRole.VIEWER]: new Set([work.id.read, work.id.users.read, work.id.checks.read]),
 };
 
 export function hasDefaultScopeViaSystemRole(

--- a/platform/scms/app/routes/app/works.$workId.checks/RunCheckOnLatestVersionButton.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/RunCheckOnLatestVersionButton.tsx
@@ -28,6 +28,7 @@ export function RunCheckOnLatestVersionButton({
     <ui.MaintenanceTooltip enabled={blocked} message={message}>
       <fetcher.Form method="post" action={actionPath}>
         <input type="hidden" name="workVersionId" value={workVersionId} />
+        <input type="hidden" name="checkServiceId" value={checkServiceId} />
         <ui.StatefulButton
           type="submit"
           variant="default"

--- a/platform/scms/app/routes/app/works.$workId.checks/checksAction.server.test.ts
+++ b/platform/scms/app/routes/app/works.$workId.checks/checksAction.server.test.ts
@@ -1,0 +1,67 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isCheckDispatchIntent, handleChecksRouteAction } from './checksAction.server';
+
+vi.mock('@curvenote/scms-server', () => ({
+  userHasScope: vi.fn(() => true),
+  userHasWorkScope: vi.fn(() => false),
+}));
+
+vi.mock('@curvenote/scms-core', async () => {
+  const actual = await vi.importActual<typeof import('@curvenote/scms-core')>('@curvenote/scms-core');
+  return {
+    ...actual,
+    getExtensionCheckServicesFromServerConfig: vi.fn(() => [
+      {
+        id: 'text-integrity',
+        handleAction: vi.fn(),
+      },
+    ]),
+    loadCheckMaintenanceByServiceId: vi.fn(async () => undefined),
+  };
+});
+
+describe('isCheckDispatchIntent', () => {
+  it('treats execute and retry intents as dispatch', () => {
+    expect(isCheckDispatchIntent('execute')).toBe(true);
+    expect(isCheckDispatchIntent('retry')).toBe(true);
+    expect(isCheckDispatchIntent('retry-run')).toBe(true);
+  });
+
+  it('does not treat hydrate intents as dispatch', () => {
+    expect(isCheckDispatchIntent('hydrate')).toBe(false);
+    expect(isCheckDispatchIntent('refresh-status')).toBe(false);
+  });
+});
+
+describe('handleChecksRouteAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects dispatch intents without work dispatch scope', async () => {
+    const formData = new FormData();
+    formData.set('intent', 'execute');
+    formData.set('workVersionId', 'wv-1');
+    formData.set('checkServiceId', 'text-integrity');
+
+    const response = await handleChecksRouteAction({
+      ctx: {
+        user: { id: 'user-1' },
+        work: { id: 'work-1' },
+        $config: {},
+      } as never,
+      formData,
+      serverExtensions: [],
+    });
+
+    expect(response).toMatchObject({
+      init: { status: 403 },
+      data: {
+        error: {
+          message: 'You do not have permission to dispatch checks for this work',
+        },
+      },
+    });
+  });
+});

--- a/platform/scms/app/routes/app/works.$workId.checks/checksAction.server.test.ts
+++ b/platform/scms/app/routes/app/works.$workId.checks/checksAction.server.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type * as ScmsCore from '@curvenote/scms-core';
 import { isCheckDispatchIntent, handleChecksRouteAction } from './checksAction.server';
 
 vi.mock('@curvenote/scms-server', () => ({
@@ -8,7 +9,7 @@ vi.mock('@curvenote/scms-server', () => ({
 }));
 
 vi.mock('@curvenote/scms-core', async () => {
-  const actual = await vi.importActual<typeof import('@curvenote/scms-core')>('@curvenote/scms-core');
+  const actual = await vi.importActual<typeof ScmsCore>('@curvenote/scms-core');
   return {
     ...actual,
     getExtensionCheckServicesFromServerConfig: vi.fn(() => [

--- a/platform/scms/app/routes/app/works.$workId.checks/checksAction.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.checks/checksAction.server.ts
@@ -1,9 +1,5 @@
 import { data } from 'react-router';
-import {
-  userHasScope,
-  userHasWorkScope,
-  type WorkContext,
-} from '@curvenote/scms-server';
+import { userHasScope, userHasWorkScope, type WorkContext } from '@curvenote/scms-server';
 import {
   getExtensionCheckServicesFromServerConfig,
   loadCheckMaintenanceByServiceId,
@@ -12,7 +8,14 @@ import {
   type ServerExtension,
 } from '@curvenote/scms-core';
 
-const CHECK_DISPATCH_INTENTS = new Set(['execute', 'retry', 'rerun', 'run', 'accept-eula', 'start']);
+const CHECK_DISPATCH_INTENTS = new Set([
+  'execute',
+  'retry',
+  'rerun',
+  'run',
+  'accept-eula',
+  'start',
+]);
 
 export function isCheckDispatchIntent(intent: string): boolean {
   const normalized = intent.trim().toLowerCase();
@@ -65,11 +68,7 @@ export async function handleChecksRouteAction({
     return data({ error: { type: 'general', message: 'Intent is required' } }, { status: 400 });
   }
 
-  const canDispatchChecks = userHasWorkScope(
-    ctx.user,
-    scopes.work.id.checks.dispatch,
-    ctx.work.id,
-  );
+  const canDispatchChecks = userHasWorkScope(ctx.user, scopes.work.id.checks.dispatch, ctx.work.id);
   if (isCheckDispatchIntent(intent) && !canDispatchChecks) {
     return rejectCheckDispatch();
   }
@@ -92,11 +91,7 @@ export async function handleChecksRouteAction({
   }
 
   if (isCheckDispatchIntent(intent)) {
-    const maintenance = await loadCheckMaintenanceByServiceId(
-      ctx,
-      serverExtensions,
-      service.id,
-    );
+    const maintenance = await loadCheckMaintenanceByServiceId(ctx, serverExtensions, service.id);
     if (maintenance?.underMaintenance) {
       return data(
         {

--- a/platform/scms/app/routes/app/works.$workId.checks/checksAction.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.checks/checksAction.server.ts
@@ -1,0 +1,136 @@
+import { data } from 'react-router';
+import {
+  userHasScope,
+  userHasWorkScope,
+  type WorkContext,
+} from '@curvenote/scms-server';
+import {
+  getExtensionCheckServicesFromServerConfig,
+  loadCheckMaintenanceByServiceId,
+  scopes,
+  type ExtensionCheckService,
+  type ServerExtension,
+} from '@curvenote/scms-core';
+
+const CHECK_DISPATCH_INTENTS = new Set(['execute', 'retry', 'rerun', 'run', 'accept-eula', 'start']);
+
+export function isCheckDispatchIntent(intent: string): boolean {
+  const normalized = intent.trim().toLowerCase();
+  if (!normalized) return false;
+  return CHECK_DISPATCH_INTENTS.has(normalized) || normalized.includes('retry');
+}
+
+export function rejectCheckDispatch() {
+  return data(
+    {
+      error: {
+        type: 'general',
+        message: 'You do not have permission to dispatch checks for this work',
+      },
+    },
+    { status: 403 },
+  );
+}
+
+function resolveCheckServiceFromForm(
+  formData: FormData,
+  checkServices: ExtensionCheckService[],
+): ExtensionCheckService | undefined {
+  const kind =
+    formData.get('checkServiceId')?.toString() ||
+    formData.get('checkKind')?.toString() ||
+    formData.get('kind')?.toString();
+  if (!kind) return undefined;
+  return checkServices.find((service) => service.id === kind);
+}
+
+export async function handleChecksRouteAction({
+  ctx,
+  formData,
+  serverExtensions,
+}: {
+  ctx: WorkContext;
+  formData: FormData;
+  serverExtensions: ServerExtension[];
+}) {
+  if (!userHasScope(ctx.user, scopes.app.works.checks.feature)) {
+    return data(
+      { error: { type: 'general', message: 'Checks are not available' } },
+      { status: 404 },
+    );
+  }
+
+  const intent = formData.get('intent')?.toString() ?? '';
+  if (!intent) {
+    return data({ error: { type: 'general', message: 'Intent is required' } }, { status: 400 });
+  }
+
+  const canDispatchChecks = userHasWorkScope(
+    ctx.user,
+    scopes.work.id.checks.dispatch,
+    ctx.work.id,
+  );
+  if (isCheckDispatchIntent(intent) && !canDispatchChecks) {
+    return rejectCheckDispatch();
+  }
+
+  const checkServices = getExtensionCheckServicesFromServerConfig(ctx.$config, serverExtensions);
+  const service = resolveCheckServiceFromForm(formData, checkServices);
+  if (!service?.handleAction) {
+    return data(
+      { error: { type: 'general', message: 'Check service not found' } },
+      { status: 404 },
+    );
+  }
+
+  const workVersionId = formData.get('workVersionId')?.toString();
+  if (!workVersionId) {
+    return data(
+      { error: { type: 'general', message: 'Work version ID is required' } },
+      { status: 400 },
+    );
+  }
+
+  if (isCheckDispatchIntent(intent)) {
+    const maintenance = await loadCheckMaintenanceByServiceId(
+      ctx,
+      serverExtensions,
+      service.id,
+    );
+    if (maintenance?.underMaintenance) {
+      return data(
+        {
+          error: {
+            type: 'maintenance',
+            message: maintenance.message,
+          },
+        },
+        { status: 503 },
+      );
+    }
+  }
+
+  const checkRunId = formData.get('checkRunId')?.toString();
+  const result = await service.handleAction({
+    intent,
+    workVersionId,
+    formData,
+    ctx,
+    checkRunId,
+    serverExtensions,
+  });
+
+  if (!result.success || result.error) {
+    return data(
+      {
+        error: result.error ?? {
+          type: 'general',
+          message: 'Check action failed',
+        },
+      },
+      { status: result.status ?? 500 },
+    );
+  }
+
+  return data({ success: true, updated: result.updated ?? false });
+}

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -248,7 +248,7 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
   };
 
   const renderTimelineVersionLabel = (entry: ServiceRunEntry) => (
-    <span className="inline-flex flex-wrap gap-x-2 gap-y-1 items-center">
+    <span className="inline-flex flex-wrap gap-y-1 gap-x-2 items-center">
       {renderWorkVersionDate(entry)}
       <DateWithPopover
         date={entry.run.date_modified}

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -36,6 +36,7 @@ import {
 import { extensions } from '../../../extensions/client';
 import { extensions as serverExtensions } from '../../../extensions/server';
 import { RunCheckOnLatestVersionButton } from './RunCheckOnLatestVersionButton';
+import { handleChecksRouteAction } from './checksAction.server';
 
 const DISPATCHING_SKELETON_MS = 1500;
 
@@ -131,6 +132,12 @@ export async function loader(args: Route.LoaderArgs) {
     previousRunsByServiceKind,
     manifestByServiceKind,
   };
+}
+
+export async function action(args: Route.ActionArgs) {
+  const ctx = await withSecureWorkContext(args, [scopes.work.id.checks.read]);
+  const formData = await args.request.formData();
+  return handleChecksRouteAction({ ctx, formData, serverExtensions });
 }
 
 export const meta: Route.MetaFunction = ({ matches }) => {
@@ -320,7 +327,7 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
           const isLatestRunOnLatestVersion =
             latest != null && latest.workVersionId === latestNonDraftWorkVersion.id;
           const headerAction =
-            canDispatchChecks && latest != null && !isLatestRunOnLatestVersion ? (
+            canDispatchChecks && !isLatestRunOnLatestVersion ? (
               <RunCheckOnLatestVersionButton
                 actionPath={service.checksActionPath ?? `${basePath}/checks`}
                 workVersionId={latestNonDraftWorkVersion.id}
@@ -342,7 +349,12 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
                       }
                       workVersionId={workVersionIdForActivity}
                       checkRunId={latest?.run.id}
-                      remoteStatusActionPath={service.checksActionPath ?? `${basePath}/checks`}
+                      canDispatchChecks={canDispatchChecks}
+                      remoteStatusActionPath={
+                        canDispatchChecks
+                          ? (service.checksActionPath ?? `${basePath}/checks`)
+                          : undefined
+                      }
                       checkRunDateModified={latest?.run.date_modified}
                     />
                   </ui.CardContent>
@@ -364,6 +376,7 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
                           run={entry.run}
                           checkService={service}
                           basePath={basePath}
+                          canDispatchChecks={canDispatchChecks}
                           hideDate
                           hideIcon
                         />

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -4,6 +4,8 @@ import { useLocation, useRevalidator } from 'react-router';
 import {
   withSecureWorkContext,
   makeDefaultWorkVersionMetadata,
+  userHasWorkScope,
+  userHasScope,
   type WorkVersionMetadata,
   type ChecksMetadataSection,
 } from '@curvenote/scms-server';
@@ -39,6 +41,10 @@ const DISPATCHING_SKELETON_MS = 1500;
 
 export async function loader(args: Route.LoaderArgs) {
   const ctx = await withSecureWorkContext(args, [scopes.work.id.checks.read]);
+
+  if (!userHasScope(ctx.user, scopes.app.works.checks.feature)) {
+    throw httpError(404, 'Checks are not available');
+  }
 
   if (!ctx.work.versions || ctx.work.versions.length === 0) {
     throw httpError(404, 'No work version found');
@@ -118,6 +124,7 @@ export async function loader(args: Route.LoaderArgs) {
 
   return {
     work: ctx.workDTO,
+    canDispatchChecks: userHasWorkScope(ctx.user, scopes.work.id.checks.dispatch, ctx.work.id),
     latestNonDraftWorkVersion,
     metadata,
     latestRunByServiceKind,
@@ -134,6 +141,7 @@ export const meta: Route.MetaFunction = ({ matches }) => {
 export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
   const {
     work,
+    canDispatchChecks,
     latestNonDraftWorkVersion,
     metadata,
     latestRunByServiceKind,
@@ -312,7 +320,7 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
           const isLatestRunOnLatestVersion =
             latest != null && latest.workVersionId === latestNonDraftWorkVersion.id;
           const headerAction =
-            latest != null && !isLatestRunOnLatestVersion ? (
+            canDispatchChecks && latest != null && !isLatestRunOnLatestVersion ? (
               <RunCheckOnLatestVersionButton
                 actionPath={service.checksActionPath ?? `${basePath}/checks`}
                 workVersionId={latestNonDraftWorkVersion.id}

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -324,10 +324,10 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
             (fallbackManifest ? ({ manifest: fallbackManifest } as any) : undefined);
 
           const workVersionIdForActivity = latest?.workVersionId ?? latestNonDraftWorkVersion.id;
-          const isLatestRunOnLatestVersion =
-            latest != null && latest.workVersionId === latestNonDraftWorkVersion.id;
+          const isLatestRunOnOlderVersion =
+            latest != null && latest.workVersionId !== latestNonDraftWorkVersion.id;
           const headerAction =
-            canDispatchChecks && !isLatestRunOnLatestVersion ? (
+            canDispatchChecks && isLatestRunOnOlderVersion ? (
               <RunCheckOnLatestVersionButton
                 actionPath={service.checksActionPath ?? `${basePath}/checks`}
                 workVersionId={latestNonDraftWorkVersion.id}

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -166,7 +166,7 @@ function SubmitToSiteEarlyAccessMessage() {
         <ui.Button
           type="button"
           variant="link"
-          className="inline h-auto p-0 align-baseline"
+          className="inline p-0 h-auto align-baseline"
           onClick={() => setSupportOpen(true)}
         >
           contact support
@@ -388,13 +388,13 @@ export function SubmittedToBar({
                           id="submit-version-select"
                           type="button"
                           className={cn(
-                            'flex h-16 w-full items-center justify-between gap-3 rounded-md border border-input bg-white px-3 py-2 text-left shadow-xs transition-colors',
+                            'flex gap-3 justify-between items-center px-3 py-2 w-full h-16 text-left bg-white rounded-md border transition-colors border-input shadow-xs',
                             'hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
                           )}
                         >
                           {selectedVersion ? (
-                            <span className="flex min-w-0 flex-col items-start">
-                              <span className="truncate font-medium">
+                            <span className="flex flex-col items-start min-w-0">
+                              <span className="font-medium truncate">
                                 Version {selectedVersionLabel}
                               </span>
                               <span className="text-xs text-muted-foreground">
@@ -432,8 +432,8 @@ export function SubmittedToBar({
                                   setVersionDropdownOpen(false);
                                 }}
                               >
-                                <span className="flex min-w-0 flex-col items-start">
-                                  <span className="truncate font-medium">Version {label}</span>
+                                <span className="flex flex-col items-start min-w-0">
+                                  <span className="font-medium truncate">Version {label}</span>
                                   <span className="text-xs text-muted-foreground">
                                     {new Date(
                                       version.date_modified ?? version.date_created,
@@ -450,7 +450,7 @@ export function SubmittedToBar({
                       </ui.PopoverContent>
                     </ui.Popover>
                   ) : (
-                    <p className="rounded-md border border-dashed border-muted-foreground/40 bg-background px-3 py-4 text-xs leading-relaxed text-muted-foreground">
+                    <p className="px-3 py-4 text-xs leading-relaxed rounded-md border border-dashed border-muted-foreground/40 bg-background text-muted-foreground">
                       No completed version is available to submit. Finish creating a version before
                       submitting to a site.
                     </p>
@@ -477,9 +477,7 @@ export function SubmittedToBar({
                                   {SummaryTitleComponent && row.run ? (
                                     <SummaryTitleComponent metadata={metadata} />
                                   ) : (
-                                    <span className="text-xs font-medium truncate">
-                                      {row.name}
-                                    </span>
+                                    <span className="text-xs font-medium truncate">{row.name}</span>
                                   )}
                                 </span>
                                 {row.run ? (
@@ -577,7 +575,7 @@ export function SubmittedToBar({
                                 </span>
                               )}
                             </span>
-                            <span className="min-w-0 flex-1">
+                            <span className="flex-1 min-w-0">
                               <span className="flex gap-2 items-center">
                                 {metadata?.favicon ? (
                                   <img

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -200,6 +200,7 @@ export function SubmittedToBar({
   versions,
   checkServiceRunsByWorkVersionId,
   checkServices,
+  hasChecksFeature = false,
 }: {
   submissions: SubmissionWithVersionsAndSite[];
   workflows: Record<string, Workflow>;
@@ -209,6 +210,7 @@ export function SubmittedToBar({
   versions: WorkVersionForDetailsClient[];
   checkServiceRunsByWorkVersionId: Record<string, CheckServiceRunRow[]>;
   checkServices: ClientExtensionCheckService[];
+  hasChecksFeature?: boolean;
 }) {
   const navigate = useNavigate();
   const fetcher = useFetcher<SubmitToSiteFetcherData>();
@@ -454,76 +456,74 @@ export function SubmittedToBar({
                     </p>
                   )}
 
-                  {selectedVersion ? (
-                    <>
-                      <div className="space-y-2">
-                        <p className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
-                          Checks
-                        </p>
-                        <div className="space-y-1.5">
-                          {checkRows.length > 0 ? (
-                            checkRows.map((row) => {
-                              const SummaryTitleComponent =
-                                row.service?.sectionSummaryTitleComponent;
-                              const SummaryBadgeComponent =
-                                row.service?.sectionSummaryBadgeComponent;
-                              const metadata = serviceDataFromRun(row.run);
-                              const fallbackScore = row.run ? getCheckScore(row.run) : null;
-                              return (
-                                <div
-                                  key={row.id}
-                                  className="flex gap-2 justify-between items-center p-2 rounded-md border bg-background border-border"
-                                >
-                                  <span className="flex min-w-0 flex-1 items-center overflow-hidden [&_img]:max-h-5 [&_img]:w-auto [&_img]:object-contain [&_svg]:max-h-5 [&_svg]:w-auto">
-                                    {SummaryTitleComponent && row.run ? (
-                                      <SummaryTitleComponent metadata={metadata} />
-                                    ) : (
-                                      <span className="text-xs font-medium truncate">
-                                        {row.name}
-                                      </span>
-                                    )}
-                                  </span>
-                                  {row.run ? (
-                                    SummaryBadgeComponent ? (
-                                      <SummaryBadgeComponent metadata={metadata} />
-                                    ) : (
-                                      <ui.Badge variant="success">
-                                        {fallbackScore ? `Score ${fallbackScore}` : 'Run'}
-                                      </ui.Badge>
-                                    )
+                  {selectedVersion && hasChecksFeature ? (
+                    <div className="space-y-2">
+                      <p className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
+                        Checks
+                      </p>
+                      <div className="space-y-1.5">
+                        {checkRows.length > 0 ? (
+                          checkRows.map((row) => {
+                            const SummaryTitleComponent = row.service?.sectionSummaryTitleComponent;
+                            const SummaryBadgeComponent = row.service?.sectionSummaryBadgeComponent;
+                            const metadata = serviceDataFromRun(row.run);
+                            const fallbackScore = row.run ? getCheckScore(row.run) : null;
+                            return (
+                              <div
+                                key={row.id}
+                                className="flex gap-2 justify-between items-center p-2 rounded-md border bg-background border-border"
+                              >
+                                <span className="flex min-w-0 flex-1 items-center overflow-hidden [&_img]:max-h-5 [&_img]:w-auto [&_img]:object-contain [&_svg]:max-h-5 [&_svg]:w-auto">
+                                  {SummaryTitleComponent && row.run ? (
+                                    <SummaryTitleComponent metadata={metadata} />
                                   ) : (
-                                    <ui.Badge variant="outline-muted">Not run</ui.Badge>
+                                    <span className="text-xs font-medium truncate">
+                                      {row.name}
+                                    </span>
                                   )}
-                                </div>
-                              );
-                            })
-                          ) : (
-                            <p className="text-xs text-muted-foreground">
-                              No check services available.
-                            </p>
-                          )}
-                        </div>
-                      </div>
-
-                      <div className="space-y-2">
-                        <p className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
-                          Files
-                        </p>
-                        {fileLabels.length > 0 ? (
-                          <ul className="space-y-1 text-[11px] leading-4 text-muted-foreground">
-                            {Object.entries(selectedFiles).map(([key, value]) => (
-                              <li key={key} className="truncate">
-                                {getFileLabel(key, value)}
-                              </li>
-                            ))}
-                          </ul>
+                                </span>
+                                {row.run ? (
+                                  SummaryBadgeComponent ? (
+                                    <SummaryBadgeComponent metadata={metadata} />
+                                  ) : (
+                                    <ui.Badge variant="success">
+                                      {fallbackScore ? `Score ${fallbackScore}` : 'Run'}
+                                    </ui.Badge>
+                                  )
+                                ) : (
+                                  <ui.Badge variant="outline-muted">Not run</ui.Badge>
+                                )}
+                              </div>
+                            );
+                          })
                         ) : (
-                          <p className="text-[11px] leading-4 text-muted-foreground">
-                            No files are available for this version.
+                          <p className="text-xs text-muted-foreground">
+                            No check services available.
                           </p>
                         )}
                       </div>
-                    </>
+                    </div>
+                  ) : null}
+
+                  {selectedVersion ? (
+                    <div className="space-y-2">
+                      <p className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
+                        Files
+                      </p>
+                      {fileLabels.length > 0 ? (
+                        <ul className="space-y-1 text-[11px] leading-4 text-muted-foreground">
+                          {Object.entries(selectedFiles).map(([key, value]) => (
+                            <li key={key} className="truncate">
+                              {getFileLabel(key, value)}
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="text-[11px] leading-4 text-muted-foreground">
+                          No files are available for this version.
+                        </p>
+                      )}
+                    </div>
                   ) : null}
                 </div>
 

--- a/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
@@ -204,9 +204,8 @@ function WorkVersionTimelineInner({
           activitiesForVersion,
           checkRunsForVersion,
         );
-        const visibleEntries = (showActivities
-          ? sortedEntries
-          : sortedEntries.filter((e) => e.kind !== 'activity')
+        const visibleEntries = (
+          showActivities ? sortedEntries : sortedEntries.filter((e) => e.kind !== 'activity')
         ).filter((e) => hasChecksFeature || e.kind !== 'check-service-run');
 
         if (visibleEntries.length === 0) return null;

--- a/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
@@ -130,6 +130,7 @@ type WorkVersionTimelineProps = {
   workOwnerName?: string | null;
   basePath: string;
   userScopes: string[];
+  canDispatchChecks?: boolean;
   linkedJobsByWorkVersionId: Promise<LinkedJobsByWorkVersionId>;
   /** Activities for this work (already filtered to work). Shown per version by work_version_id. */
   activities: WorkActivityRow[];
@@ -158,6 +159,7 @@ function WorkVersionTimelineInner({
   workOwnerName,
   basePath,
   userScopes,
+  canDispatchChecks = false,
   linkedJobsByWorkVersionId,
   activities,
   checkServiceRunsByWorkVersionId,
@@ -244,6 +246,7 @@ function WorkVersionTimelineInner({
                     run={entry.run}
                     checkService={service}
                     basePath={basePath}
+                    canDispatchChecks={canDispatchChecks}
                     defaultExpanded={shouldExpandByDefault(
                       entry.run,
                       checkServiceRunsByWorkVersionId,

--- a/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
@@ -167,6 +167,7 @@ function WorkVersionTimelineInner({
   const [searchParams] = useSearchParams();
   const includeDrafts = searchParams.get('drafts') === 'true';
   const canExport = userScopes.includes(scopes.app.works.export);
+  const hasChecksFeature = userScopes.includes(scopes.app.works.checks.feature);
   const checkServiceById = Object.fromEntries(checkServices.map((s) => [s.id, s]));
 
   // Order sections by date_created descending (most recently created first)
@@ -201,9 +202,10 @@ function WorkVersionTimelineInner({
           activitiesForVersion,
           checkRunsForVersion,
         );
-        const visibleEntries = showActivities
+        const visibleEntries = (showActivities
           ? sortedEntries
-          : sortedEntries.filter((e) => e.kind !== 'activity');
+          : sortedEntries.filter((e) => e.kind !== 'activity')
+        ).filter((e) => hasChecksFeature || e.kind !== 'check-service-run');
 
         if (visibleEntries.length === 0) return null;
 

--- a/platform/scms/app/routes/app/works.$workId.details/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/route.tsx
@@ -40,6 +40,7 @@ type SubmissionTargetSite = {
 
 type LoaderData = {
   userScopes: string[];
+  canDispatchChecks: boolean;
   workflows: Record<string, Workflow>;
   work: WorkDTO;
   versions: WorkVersionForDetailsClient[];
@@ -65,6 +66,7 @@ export const meta: MetaFunction<() => LoaderData> = ({ matches, data }) => {
 export default function WorkDetailRoute() {
   const {
     userScopes,
+    canDispatchChecks,
     workflows,
     work,
     versions,
@@ -139,6 +141,7 @@ export default function WorkDetailRoute() {
             workOwnerName={workOwnerName}
             basePath={basePath}
             userScopes={userScopes}
+            canDispatchChecks={canDispatchChecks}
             linkedJobsByWorkVersionId={linkedJobsByWorkVersionId}
             activities={activities}
             checkServiceRunsByWorkVersionId={checkServiceRunsByWorkVersionId}

--- a/platform/scms/app/routes/app/works.$workId.details/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/route.tsx
@@ -4,6 +4,7 @@ import {
   joinPageTitle,
   getExtensionCheckServicesFromServerConfig,
   useDeploymentConfig,
+  scopes,
 } from '@curvenote/scms-core';
 import type { MetaFunction } from 'react-router';
 import type { WorkDTO } from '@curvenote/common';
@@ -99,6 +100,7 @@ export default function WorkDetailRoute() {
 
   const workBasePath = `/app/works/${work.id}`;
   const basePath = `/app/works/${work.id}`;
+  const hasChecksFeature = userScopes.includes(scopes.app.works.checks.feature);
 
   return (
     <div
@@ -127,6 +129,7 @@ export default function WorkDetailRoute() {
             versions={versions}
             checkServiceRunsByWorkVersionId={checkServiceRunsByWorkVersionId}
             checkServices={checkServices}
+            hasChecksFeature={hasChecksFeature}
           />
         </div>
         <div>

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.test.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.test.ts
@@ -83,18 +83,18 @@ vi.mock('@curvenote/scms-core', async () => ({
   MANUSCRIPT_UPLOAD_MIME_TYPES: ['application/pdf'],
   scopes: {
     app: {
-    works: {
-      upload: 'app:works:upload',
-      metadataExtract: 'app:works:metadataExtract',
-    },
-  },
-  work: {
-    id: {
-      checks: {
-        dispatch: 'work:checks:dispatch',
+      works: {
+        upload: 'app:works:upload',
+        metadataExtract: 'app:works:metadataExtract',
       },
     },
-  },
+    work: {
+      id: {
+        checks: {
+          dispatch: 'work:checks:dispatch',
+        },
+      },
+    },
   },
   isValidOrcid: vi.fn(),
 }));

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.test.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.test.ts
@@ -7,6 +7,8 @@ const {
   update,
   safeWorkVersionJsonUpdate,
   userHasScope,
+  userHasWorkScope,
+  dbGetUserWorkRoles,
   waitUntil,
   loadCheckMaintenanceByServiceIds,
   hasInvalidEnabledUploadChecks,
@@ -15,6 +17,8 @@ const {
   update: vi.fn(),
   safeWorkVersionJsonUpdate: vi.fn(),
   userHasScope: vi.fn(),
+  userHasWorkScope: vi.fn(),
+  dbGetUserWorkRoles: vi.fn(),
   waitUntil: vi.fn(),
   loadCheckMaintenanceByServiceIds: vi.fn(),
   hasInvalidEnabledUploadChecks: vi.fn(),
@@ -26,6 +30,8 @@ vi.mock('@curvenote/scms-server', async () => ({
     $config: {},
   })),
   userHasScope,
+  userHasWorkScope,
+  dbGetUserWorkRoles,
   findWorkByVersion: vi.fn(),
   workVersionUploadsStage: vi.fn(),
   workVersionUploadsComplete: vi.fn(),
@@ -73,16 +79,22 @@ vi.mock('@curvenote/scms-core', async () => ({
   loadCheckMaintenanceByServiceIds,
   CheckMaintenanceProvider: vi.fn(),
   capitalize: vi.fn((value: string) => value),
+  MANUSCRIPT_UPLOAD_ACCEPT: '.pdf,.docx',
+  MANUSCRIPT_UPLOAD_MIME_TYPES: ['application/pdf'],
   scopes: {
     app: {
-      works: {
-        upload: 'app:works:upload',
-        metadataExtract: 'app:works:metadataExtract',
-        checks: {
-          dispatch: 'app:works:checks:dispatch',
-        },
+    works: {
+      upload: 'app:works:upload',
+      metadataExtract: 'app:works:metadataExtract',
+    },
+  },
+  work: {
+    id: {
+      checks: {
+        dispatch: 'work:checks:dispatch',
       },
     },
+  },
   },
   isValidOrcid: vi.fn(),
 }));
@@ -154,6 +166,8 @@ describe('work upload confirm-work action', () => {
       },
     });
     userHasScope.mockReturnValue(false);
+    userHasWorkScope.mockReturnValue(false);
+    dbGetUserWorkRoles.mockResolvedValue([]);
     loadCheckMaintenanceByServiceIds.mockResolvedValue({});
     hasInvalidEnabledUploadChecks.mockReturnValue(false);
     safeWorkVersionJsonUpdate.mockResolvedValue(undefined);

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
@@ -526,9 +526,7 @@ export async function action(args: Route.ActionArgs) {
 
         const isChecked = checked === 'true';
 
-        if (
-          !userHasWorkScope(userWithWorkRoles, scopes.work.id.checks.dispatch, workId)
-        ) {
+        if (!userHasWorkScope(userWithWorkRoles, scopes.work.id.checks.dispatch, workId)) {
           return rejectCheckDispatch();
         }
 

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
@@ -8,6 +8,8 @@ import type {
 import {
   withAppScopedContext,
   userHasScope,
+  userHasWorkScope,
+  dbGetUserWorkRoles,
   findWorkByVersion,
   workVersionUploadsStage,
   workVersionUploadsComplete,
@@ -330,6 +332,15 @@ export async function loader(args: Route.LoaderArgs) {
     uploadCheckServices.map((service) => service.id),
   );
 
+  const workRoles = await dbGetUserWorkRoles(ctx.user.id, workId);
+  const userWithWorkRoles = { ...ctx.user, work_roles: workRoles };
+  const hasChecksFeature = userHasScope(ctx.user, scopes.app.works.checks.feature);
+  const canDispatchChecks = userHasWorkScope(
+    userWithWorkRoles,
+    scopes.work.id.checks.dispatch,
+    workId,
+  );
+
   return {
     workVersionId: work.version_id,
     cdnKey: work.cdn_key!,
@@ -345,6 +356,8 @@ export async function loader(args: Route.LoaderArgs) {
     extractedMetadata,
     authorFieldMetadata,
     hasMetadataExtractScope,
+    hasChecksFeature,
+    canDispatchChecks,
     uploadCheckLogoUrls,
     maintenanceByServiceId,
   };
@@ -361,6 +374,20 @@ export async function action(args: Route.ActionArgs) {
       { status: 400 },
     );
   }
+
+  const workRoles = await dbGetUserWorkRoles(baseCtx.user.id, workId);
+  const userWithWorkRoles = { ...baseCtx.user, work_roles: workRoles };
+
+  const rejectCheckDispatch = () =>
+    data(
+      {
+        error: {
+          type: 'general',
+          message: 'You do not have permission to dispatch checks for this work',
+        },
+      },
+      { status: 403 },
+    );
 
   try {
     const payload = WorkUploadActionSchema.parse(formData);
@@ -499,6 +526,12 @@ export async function action(args: Route.ActionArgs) {
 
         const isChecked = checked === 'true';
 
+        if (
+          !userHasWorkScope(userWithWorkRoles, scopes.work.id.checks.dispatch, workId)
+        ) {
+          return rejectCheckDispatch();
+        }
+
         if (isChecked) {
           const maintenanceByServiceId = await loadCheckMaintenanceByServiceIds(
             baseCtx,
@@ -588,17 +621,9 @@ export async function action(args: Route.ActionArgs) {
         // a failed dispatch gate could still leave the work version confirmed.
         if (
           dispatchableChecks.length > 0 &&
-          !userHasScope(baseCtx.user, scopes.app.works.checks.dispatch)
+          !userHasWorkScope(userWithWorkRoles, scopes.work.id.checks.dispatch, workId)
         ) {
-          return data(
-            {
-              error: {
-                type: 'general',
-                message: 'You do not have permission to dispatch checks for this work',
-              },
-            },
-            { status: 403 },
-          );
+          return rejectCheckDispatch();
         }
 
         if (submittedAuthorMetadata) {
@@ -963,6 +988,8 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
     authorFieldMetadata,
     maintenanceByServiceId,
     hasMetadataExtractScope,
+    hasChecksFeature,
+    canDispatchChecks,
   } = loaderData;
   const { workVersionId } = useParams();
   const rawPreviews: DocumentPreviewItem[] = Array.isArray(previews) ? previews : [];
@@ -1151,22 +1178,24 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
               onChange={setSelectedThumbnail}
             />
           ) : null}
-          <SectionWithHeading
-            heading="Select Checks to Run"
-            icon={<CheckSquare className="w-5 h-5" />}
-            className="space-y-4 max-w-5xl"
-          >
-            <p className="text-muted-foreground">
-              Choose which checks you'd like to run on your work.
-            </p>
-            <WorkUploadChecksForm
-              enabled={metadata.checks?.enabled || []}
-              checkServices={checkServices}
-              workVersionId={workVersionId!}
-              metadata={metadata}
-              uploadCheckLogoUrls={loaderData.uploadCheckLogoUrls}
-            />
-          </SectionWithHeading>
+          {hasChecksFeature && canDispatchChecks ? (
+            <SectionWithHeading
+              heading="Select Checks to Run"
+              icon={<CheckSquare className="w-5 h-5" />}
+              className="space-y-4 max-w-5xl"
+            >
+              <p className="text-muted-foreground">
+                Choose which checks you'd like to run on your work.
+              </p>
+              <WorkUploadChecksForm
+                enabled={metadata.checks?.enabled || []}
+                checkServices={checkServices}
+                workVersionId={workVersionId!}
+                metadata={metadata}
+                uploadCheckLogoUrls={loaderData.uploadCheckLogoUrls}
+              />
+            </SectionWithHeading>
+          ) : null}
           <ContinueForm
             title={title}
             authorMetadata={authorMetadata}

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -573,6 +573,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
   return {
     userScopes: ctx.scopes,
     canReadUsers: userHasWorkScope(ctx.user, scopes.work.id.users.read, ctx.work.id),
+    canDispatchChecks: userHasWorkScope(ctx.user, scopes.work.id.checks.dispatch, ctx.work.id),
     workflows,
     work,
     versions: versionsForClient,

--- a/platform/scms/app/routes/app/works._index/WorkList.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkList.tsx
@@ -17,14 +17,21 @@ export function WorkList({
   items,
   workflows,
   checkServices,
+  hasChecksFeature,
 }: {
   items: Promise<WorkWithRole[]>;
   workflows: Record<string, any>;
   checkServices: WorkListCheckService[];
+  hasChecksFeature: boolean;
 }) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const renderItem = (work: WorkWithRole, _globalIndex: number, _localIndex?: number) => (
-    <WorkListItem work={work} workflows={workflows} checkServices={checkServices} />
+    <WorkListItem
+      work={work}
+      workflows={workflows}
+      checkServices={checkServices}
+      hasChecksFeature={hasChecksFeature}
+    />
   );
 
   const renderGroup = (

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -20,10 +20,12 @@ export function WorkListItem({
   work,
   workflows,
   checkServices,
+  hasChecksFeature,
 }: {
   work: WorkCardDBO;
   workflows: Record<string, any>;
   checkServices: WorkListCheckService[];
+  hasChecksFeature: boolean;
 }) {
   const lastActivity = work.submissions
     .map((submission) => submission.activity?.[0])
@@ -156,11 +158,13 @@ export function WorkListItem({
               )}
             </div>
           )}
-          <WorkCheckSummaries
-            workId={work.id}
-            workListCheckRunsByServiceKind={work.workListCheckRunsByServiceKind}
-            checkServices={checkServices}
-          />
+          {hasChecksFeature ? (
+            <WorkCheckSummaries
+              workId={work.id}
+              workListCheckRunsByServiceKind={work.workListCheckRunsByServiceKind}
+              checkServices={checkServices}
+            />
+          ) : null}
         </div>
 
         {/* Column 2: Activity and Date */}
@@ -190,7 +194,7 @@ export function WorkListItem({
           <WorkVersionTimelineHoverCard
             versionsUrl={workVersionsUrl}
             workId={work.id}
-            checkServices={checkServices}
+            checkServices={hasChecksFeature ? checkServices : []}
             align="end"
             side="left"
             title="Work Timeline"

--- a/platform/scms/app/routes/app/works._index/route.tsx
+++ b/platform/scms/app/routes/app/works._index/route.tsx
@@ -60,6 +60,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
 
     const canUpload = userHasScope(ctx.user, scopes.app.works.upload);
     const userScopes = Array.from(getUserScopesSet(ctx.user));
+    const hasChecksFeature = userScopes.includes(scopes.app.works.checks.feature);
     const extensionConfigs = Object.fromEntries(
       Object.entries(ctx.$config?.app?.extensions ?? {}).map(([key, value]) => [
         key,
@@ -74,6 +75,7 @@ export const loader = async (args: LoaderFunctionArgs) => {
       items: worksPromise,
       workflows,
       canUpload,
+      hasChecksFeature,
       createWorkOptions,
       stringReplacements,
     };
@@ -228,7 +230,8 @@ export function shouldRevalidate({
 }
 
 export default function MyWorks({ loaderData }: Route.ComponentProps) {
-  const { items, workflows, error, canUpload, createWorkOptions, stringReplacements } = loaderData;
+  const { items, workflows, error, canUpload, hasChecksFeature, createWorkOptions, stringReplacements } =
+    loaderData;
   const hydratedCreateWorkOptions = hydrateWorkCreateOptions(createWorkOptions ?? [], extensions);
   const deploymentConfig = useDeploymentConfig();
   const checkServices = getExtensionCheckServicesFromClientConfig(
@@ -243,7 +246,14 @@ export default function MyWorks({ loaderData }: Route.ComponentProps) {
     <div className="max-w-[900px]">
       {/* Works List Section without title when no tasks */}
       {error && <div className="p-2 my-2 text-red-600 bg-red-50">{error}</div>}
-      {items && <WorkList items={items} workflows={workflows} checkServices={checkServices} />}
+      {items && (
+        <WorkList
+          items={items}
+          workflows={workflows}
+          checkServices={checkServices}
+          hasChecksFeature={hasChecksFeature ?? false}
+        />
+      )}
     </div>
   );
 

--- a/platform/scms/app/routes/app/works._index/route.tsx
+++ b/platform/scms/app/routes/app/works._index/route.tsx
@@ -230,8 +230,15 @@ export function shouldRevalidate({
 }
 
 export default function MyWorks({ loaderData }: Route.ComponentProps) {
-  const { items, workflows, error, canUpload, hasChecksFeature, createWorkOptions, stringReplacements } =
-    loaderData;
+  const {
+    items,
+    workflows,
+    error,
+    canUpload,
+    hasChecksFeature,
+    createWorkOptions,
+    stringReplacements,
+  } = loaderData;
   const hydratedCreateWorkOptions = hydrateWorkCreateOptions(createWorkOptions ?? [], extensions);
   const deploymentConfig = useDeploymentConfig();
   const checkServices = getExtensionCheckServicesFromClientConfig(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Authorization changes span work roles, upload confirm, and new checks route actions; misconfiguration could block legitimate runs or allow dispatch without the intended work role.
> 
> **Overview**
> This PR **moves check dispatch authorization from a global app scope to per-work `work:checks:dispatch`**, grants **`work:checks:read` to all work roles (including viewers)**, and uses **`app:works:checks:feature`** to decide whether checks UI surfaces appear at all.
> 
> **Server and roles:** `app:works:checks:dispatch` is removed in favor of `work:checks:dispatch` on owner and contributor work roles; viewers keep read-only access. A shared **`handleChecksRouteAction`** on the checks route rejects dispatch intents (execute, retry, accept-eula, etc.) with 403 when the user lacks work dispatch scope, while still allowing non-dispatch intents. Upload **confirm-work** and **toggle-check** now gate on `userHasWorkScope` for dispatch before mutating or enqueueing checks.
> 
> **UI:** Loaders expose **`canDispatchChecks`**; extension activity and timeline mounts get **`canDispatchChecks`** and **`remoteStatusActionPath` is omitted** when false so viewers cannot POST run/retry flows. Run-on-latest-version CTAs, upload “Select checks” section, work list summaries, timeline check rows, and submit-to-site check previews are hidden or read-only unless the user has dispatch and/or the checks feature scope. The automated-checks dashboard builtin task is scoped to **`app:works:checks:feature`**.
> 
> The work-users changeset text is aligned to gate add/remove on **`work:users:update`** rather than “owners only.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3230808bd431903bf96616e4efa209cca4b248c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->