### PR TITLE
📨 fix submit-to checks reporting and more UX

### DIFF
--- a/.changeset/submit-to-site-check-summary.md
+++ b/.changeset/submit-to-site-check-summary.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms': patch
+---
+
+Improve the submit-to-site popover check review panel. Surface the latest run of each check kind on the selected version and any older versions (not newer ones), show a `v{n}` badge when that run came from a different version, use `VersionTagBadge` in the version picker, truncate long status labels with a tooltip while keeping the left column width fixed, and style the send trigger as a ghost button with a primary icon.

--- a/.changeset/version-timeline-hover-card-ux.md
+++ b/.changeset/version-timeline-hover-card-ux.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-core': patch
+---
+
+Refresh shared work and submission version timeline hover cards. Add compact `v{n}` badges with a GitBranch icon, stack created/modified dates and site/check badges for clearer scanning, soften submission site chip rings, and size the popover to its content with a modest minimum width.

--- a/.changeset/works-listing-timeline-layout.md
+++ b/.changeset/works-listing-timeline-layout.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms': patch
+'@curvenote/scms-db': patch
+---
+
+Improve My Works listing metadata and timeline affordances. Broaden the activity pill to the latest work- or submission-level event, reorder the right column to date then activity then timeline (baseline-aligned and centered), show the timeline link only when a work has multiple versions, and add `v{n}` badges to the work-details version timeline headers. Includes an Activity `(work_id, date_created)` index for efficient listing queries.

--- a/packages/scms-core/src/components/SubmissionVersionSiteChip.tsx
+++ b/packages/scms-core/src/components/SubmissionVersionSiteChip.tsx
@@ -51,7 +51,7 @@ export function SubmissionVersionSiteChip({
   const chip = (
     <span
       className={cn(
-        'inline-flex h-4 shrink-0 items-center justify-center gap-0.5 rounded-md ring-2 px-1',
+        'inline-flex h-5 shrink-0 items-center justify-center gap-1 rounded-md ring-1 px-1.5',
         getStatusRingClasses(submissionVersion.statusTags),
         href && 'transition-opacity hover:opacity-80',
       )}

--- a/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
+++ b/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
@@ -167,10 +167,7 @@ export function VersionTimelineHoverCard<T extends { id: string }>({
         align={align}
         side={side}
         sideOffset={8}
-        className={cn(
-          contentClassName ?? 'w-fit max-w-[min(20rem,calc(100vw-2rem))]',
-          'p-3',
-        )}
+        className={cn(contentClassName ?? 'w-fit max-w-[min(20rem,calc(100vw-2rem))]', 'p-3')}
       >
         <div className="mb-2 flex items-center gap-1.5 border-b border-border pb-2 text-xs font-semibold text-foreground">
           <Timeline className="size-3.5 shrink-0" aria-hidden />

--- a/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
+++ b/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
@@ -240,7 +240,7 @@ export function WorkVersionTimelineHoverCard({
       align={align}
       side={side}
       title={title}
-      contentClassName="w-fit max-w-[min(32rem,calc(100vw-2rem))]"
+      contentClassName="w-fit max-w-[min(24rem,calc(100vw-2rem))]"
       renderRow={(entry) => (
         <WorkVersionTimelineRow entry={entry} workId={workId} checkServices={checkServices} />
       )}

--- a/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
+++ b/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
@@ -240,7 +240,7 @@ export function WorkVersionTimelineHoverCard({
       align={align}
       side={side}
       title={title}
-      contentClassName="w-fit max-w-[min(24rem,calc(100vw-2rem))]"
+      contentClassName="w-fit min-w-[min(18rem,calc(100vw-2rem))] max-w-[min(24rem,calc(100vw-2rem))]"
       renderRow={(entry) => (
         <WorkVersionTimelineRow entry={entry} workId={workId} checkServices={checkServices} />
       )}

--- a/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
+++ b/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
@@ -167,7 +167,10 @@ export function VersionTimelineHoverCard<T extends { id: string }>({
         align={align}
         side={side}
         sideOffset={8}
-        className={cn(contentClassName ?? 'w-80', 'p-3')}
+        className={cn(
+          contentClassName ?? 'w-fit max-w-[min(20rem,calc(100vw-2rem))]',
+          'p-3',
+        )}
       >
         <div className="mb-2 flex items-center gap-1.5 border-b border-border pb-2 text-xs font-semibold text-foreground">
           <Timeline className="size-3.5 shrink-0" aria-hidden />
@@ -240,7 +243,7 @@ export function WorkVersionTimelineHoverCard({
       align={align}
       side={side}
       title={title}
-      contentClassName="w-[calc(100vw-2rem)] max-w-[32rem]"
+      contentClassName="w-fit max-w-[min(32rem,calc(100vw-2rem))]"
       renderRow={(entry) => (
         <WorkVersionTimelineRow entry={entry} workId={workId} checkServices={checkServices} />
       )}

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -34,7 +34,7 @@ export function VersionTimelineRowShell({
         )}
         aria-hidden
       />
-      <div className="flex-1 space-y-1 min-w-0 pt-px">{children}</div>
+      <div className="min-w-0 space-y-1 pt-px">{children}</div>
     </div>
   );
 }

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -162,7 +162,12 @@ export function WorkVersionTimelineRow({
   return (
     <VersionTimelineRowShell dotStatus={entry.draft ? 'DRAFT' : 'PUBLISHED'}>
       <div className="flex flex-wrap gap-x-1.5 gap-y-1 items-center min-h-4">
-        <VersionTagBadge tag={`v${entry.versionNumber}`} titlePrefix="Version" icon={GitBranch} />
+        <VersionTagBadge
+          tag={`v${entry.versionNumber}`}
+          titlePrefix="Version"
+          icon={GitBranch}
+          compact
+        />
         <CreatedDate dateCreated={entry.date_created} />
         {submissionVersions.map((submissionVersion) => (
           <SubmissionVersionSiteChip

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { GitBranch } from 'lucide-react';
 import { Link } from 'react-router';
 import type {
   VersionTimelineEntry,
@@ -14,6 +15,7 @@ import { formatDate, formatDatetime } from '../utils/formatDate.js';
 import { getStatusDotClasses, getStatusRingClasses } from '../utils/status.js';
 import { cn } from '../utils/cn.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip.js';
+import { VersionTagBadge } from './ui/VersionTagBadge.js';
 import { SubmissionVersionSiteChip } from './SubmissionVersionSiteChip.js';
 
 export function VersionTimelineRowShell({
@@ -160,6 +162,7 @@ export function WorkVersionTimelineRow({
   return (
     <VersionTimelineRowShell dotStatus={entry.draft ? 'DRAFT' : 'PUBLISHED'}>
       <div className="flex flex-wrap gap-x-1.5 gap-y-1 items-center min-h-4">
+        <VersionTagBadge tag={`v${entry.versionNumber}`} titlePrefix="Version" icon={GitBranch} />
         <CreatedDate dateCreated={entry.date_created} />
         {submissionVersions.map((submissionVersion) => (
           <SubmissionVersionSiteChip

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -159,7 +159,9 @@ export function WorkVersionTimelineRow({
         summary.service != null && isCheckWorkListSummaryVisible(summary.service, summary.metadata),
     );
 
-  const hasMetadataBadges = submissionVersions.length > 0 || checkRuns.length > 0;
+  const renderableCheckRuns = checkRuns.filter(({ service }) => service.workListSummaryComponent);
+
+  const hasMetadataBadges = submissionVersions.length > 0 || renderableCheckRuns.length > 0;
 
   return (
     <VersionTimelineRowShell dotStatus={entry.draft ? 'DRAFT' : 'PUBLISHED'}>
@@ -184,7 +186,7 @@ export function WorkVersionTimelineRow({
               workId={workId}
             />
           ))}
-          {checkRuns.map(({ run, service, metadata }) => {
+          {renderableCheckRuns.map(({ run, service, metadata }) => {
             const SummaryComponent = service.workListSummaryComponent;
             if (!SummaryComponent) return null;
             const chip = (

--- a/packages/scms-core/src/components/VersionTimelineRows.tsx
+++ b/packages/scms-core/src/components/VersionTimelineRows.tsx
@@ -159,6 +159,8 @@ export function WorkVersionTimelineRow({
         summary.service != null && isCheckWorkListSummaryVisible(summary.service, summary.metadata),
     );
 
+  const hasMetadataBadges = submissionVersions.length > 0 || checkRuns.length > 0;
+
   return (
     <VersionTimelineRowShell dotStatus={entry.draft ? 'DRAFT' : 'PUBLISHED'}>
       <div className="flex flex-wrap gap-x-1.5 gap-y-1 items-center min-h-4">
@@ -169,59 +171,63 @@ export function WorkVersionTimelineRow({
           compact
         />
         <CreatedDate dateCreated={entry.date_created} />
-        {submissionVersions.map((submissionVersion) => (
-          <SubmissionVersionSiteChip
-            key={submissionVersion.id}
-            submissionVersion={submissionVersion}
-            workId={workId}
-          />
-        ))}
-        {checkRuns.map(({ run, service, metadata }) => {
-          const SummaryComponent = service.workListSummaryComponent;
-          if (!SummaryComponent) return null;
-          const chip = (
-            <span className="inline-flex h-5 max-w-full shrink-0 items-center gap-1 rounded-md border border-border bg-background px-1.5 text-[10px] text-foreground">
-              <SummaryComponent
-                compact
-                metadata={metadata}
-                checkRunId={run.id}
-                workVersionId={run.work_version_id}
-                checkServiceId={service.id}
-                checkServiceName={service.name}
-                checkRunDateModified={run.date_modified}
-              />
-            </span>
-          );
-          return (
-            <Tooltip key={run.id}>
-              <TooltipTrigger asChild>
-                {workId ? (
-                  <Link
-                    to={`/app/works/${workId}/checks`}
-                    className="inline-flex min-w-0 items-center transition-opacity hover:opacity-80"
-                    aria-label={`${service.name} check summary`}
-                    onClick={(event) => event.stopPropagation()}
-                  >
-                    {chip}
-                  </Link>
-                ) : (
-                  <span className="inline-flex min-w-0 items-center cursor-default">{chip}</span>
-                )}
-              </TooltipTrigger>
-              <TooltipContent sideOffset={4}>
-                <span className="font-medium">{service.name}</span>
-                <span className="text-muted-foreground">
-                  {' '}
-                  · Check run · {formatDatetime(run.date_created)}
-                </span>
-              </TooltipContent>
-            </Tooltip>
-          );
-        })}
       </div>
       <p className="text-[11px] text-muted-foreground" title={formatDatetime(entry.date_modified)}>
         Modified: {formatDate(entry.date_modified)}
       </p>
+      {hasMetadataBadges ? (
+        <div className="flex flex-wrap gap-x-1.5 gap-y-1 items-center pt-0.5">
+          {submissionVersions.map((submissionVersion) => (
+            <SubmissionVersionSiteChip
+              key={submissionVersion.id}
+              submissionVersion={submissionVersion}
+              workId={workId}
+            />
+          ))}
+          {checkRuns.map(({ run, service, metadata }) => {
+            const SummaryComponent = service.workListSummaryComponent;
+            if (!SummaryComponent) return null;
+            const chip = (
+              <span className="inline-flex h-5 max-w-full shrink-0 items-center gap-1 rounded-md border border-border bg-background px-1.5 text-[10px] text-foreground">
+                <SummaryComponent
+                  compact
+                  metadata={metadata}
+                  checkRunId={run.id}
+                  workVersionId={run.work_version_id}
+                  checkServiceId={service.id}
+                  checkServiceName={service.name}
+                  checkRunDateModified={run.date_modified}
+                />
+              </span>
+            );
+            return (
+              <Tooltip key={run.id}>
+                <TooltipTrigger asChild>
+                  {workId ? (
+                    <Link
+                      to={`/app/works/${workId}/checks`}
+                      className="inline-flex min-w-0 items-center transition-opacity hover:opacity-80"
+                      aria-label={`${service.name} check summary`}
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      {chip}
+                    </Link>
+                  ) : (
+                    <span className="inline-flex min-w-0 items-center cursor-default">{chip}</span>
+                  )}
+                </TooltipTrigger>
+                <TooltipContent sideOffset={4}>
+                  <span className="font-medium">{service.name}</span>
+                  <span className="text-muted-foreground">
+                    {' '}
+                    · Check run · {formatDatetime(run.date_created)}
+                  </span>
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </div>
+      ) : null}
     </VersionTimelineRowShell>
   );
 }

--- a/packages/scms-core/src/components/ui/VersionTagBadge.tsx
+++ b/packages/scms-core/src/components/ui/VersionTagBadge.tsx
@@ -64,12 +64,12 @@ export function VersionTagBadge({
         size="xs"
         className={cn(
           'font-normal font-mono leading-none',
-          compact ? 'h-4 gap-0.5 px-1 py-0' : 'px-1 py-0.5',
+          compact ? 'h-[18px] gap-0.5 px-1 py-0.5' : 'px-1 py-0.5',
           className,
         )}
         title={label}
       >
-        {!hideIcon ? <Icon className={compact ? 'size-2.5' : 'size-3'} aria-hidden /> : null}
+        {!hideIcon ? <Icon className={compact ? 'size-[11px]' : 'size-3'} aria-hidden /> : null}
         {tag}
       </Badge>
     );
@@ -79,14 +79,14 @@ export function VersionTagBadge({
     <span
       className={cn(
         'inline-flex gap-1 items-center rounded-xs',
-        compact ? 'h-4 py-0 text-[10px] px-1' : 'py-1 text-xs px-[6px]',
+        compact ? 'h-[18px] py-0.5 text-[10px] px-1' : 'py-1 text-xs px-[6px]',
         filledEmphasisClassName[emphasis],
         className,
       )}
       title={label}
     >
       {!hideIcon ? (
-        <Icon className={cn('shrink-0', compact ? 'size-2.5' : 'size-3')} aria-hidden />
+        <Icon className={cn('shrink-0', compact ? 'size-[11px]' : 'size-3')} aria-hidden />
       ) : null}
       {tag}
     </span>

--- a/packages/scms-core/src/components/ui/VersionTagBadge.tsx
+++ b/packages/scms-core/src/components/ui/VersionTagBadge.tsx
@@ -69,9 +69,7 @@ export function VersionTagBadge({
         )}
         title={label}
       >
-        {!hideIcon ? (
-          <Icon className={compact ? 'size-2.5' : 'size-3'} aria-hidden />
-        ) : null}
+        {!hideIcon ? <Icon className={compact ? 'size-2.5' : 'size-3'} aria-hidden /> : null}
         {tag}
       </Badge>
     );

--- a/packages/scms-core/src/components/ui/VersionTagBadge.tsx
+++ b/packages/scms-core/src/components/ui/VersionTagBadge.tsx
@@ -23,6 +23,8 @@ export type VersionTagBadgeProps = {
    * `solid` / `latest` / `previous` — filled badges for version emphasis (e.g. checks timeline).
    */
   emphasis?: VersionTagBadgeEmphasis;
+  /** Tighter sizing for dense timeline rows (e.g. work timeline hover popover). */
+  compact?: boolean;
   className?: string;
 };
 
@@ -50,6 +52,7 @@ export function VersionTagBadge({
   icon: Icon = Tag,
   disableTooltip = false,
   emphasis = 'outline',
+  compact = false,
   className,
 }: VersionTagBadgeProps) {
   const label = disableTooltip ? undefined : versionTagTitle(tag, title, titlePrefix);
@@ -59,10 +62,16 @@ export function VersionTagBadge({
       <Badge
         variant="outline-muted"
         size="xs"
-        className={cn('font-normal px-1 py-0.5 font-mono', className)}
+        className={cn(
+          'font-normal font-mono leading-none',
+          compact ? 'h-4 gap-0.5 px-1 py-0' : 'px-1 py-0.5',
+          className,
+        )}
         title={label}
       >
-        {!hideIcon ? <Icon className="size-3" aria-hidden /> : null}
+        {!hideIcon ? (
+          <Icon className={compact ? 'size-2.5' : 'size-3'} aria-hidden />
+        ) : null}
         {tag}
       </Badge>
     );
@@ -71,13 +80,16 @@ export function VersionTagBadge({
   return (
     <span
       className={cn(
-        'inline-flex gap-1 items-center py-1 text-xs px-[6px] rounded-xs',
+        'inline-flex gap-1 items-center rounded-xs',
+        compact ? 'h-4 py-0 text-[10px] px-1' : 'py-1 text-xs px-[6px]',
         filledEmphasisClassName[emphasis],
         className,
       )}
       title={label}
     >
-      {!hideIcon ? <Icon className="size-3 shrink-0" aria-hidden /> : null}
+      {!hideIcon ? (
+        <Icon className={cn('shrink-0', compact ? 'size-2.5' : 'size-3')} aria-hidden />
+      ) : null}
       {tag}
     </span>
   );

--- a/packages/scms-core/src/types/versionTimeline.ts
+++ b/packages/scms-core/src/types/versionTimeline.ts
@@ -41,6 +41,8 @@ export type WorkVersionTimelineEntry = {
   date_created: string;
   date_modified: string;
   draft: boolean;
+  /** Display index from reverse-chronological order (v1 = oldest). */
+  versionNumber: number;
   submissionVersions?: WorkVersionTimelineSubmissionVersion[];
   checkRuns?: WorkVersionTimelineCheckRun[];
 };

--- a/packages/scms-core/src/utils/index.ts
+++ b/packages/scms-core/src/utils/index.ts
@@ -24,6 +24,7 @@ export * from './versionTimelineUrls.js';
 export * from './versionTimelineTrim.js';
 export * from './manuscriptFormats.js';
 export * from './workVersionMetadata.js';
+export * from './workVersionNumbers.js';
 
 export const version = 'v1';
 

--- a/packages/scms-core/src/utils/versionTimelineTrim.test.ts
+++ b/packages/scms-core/src/utils/versionTimelineTrim.test.ts
@@ -24,6 +24,7 @@ function workVersion(
   id: string,
   options: {
     submissionVersions?: WorkVersionTimelineEntry['submissionVersions'];
+    versionNumber?: number;
   } = {},
 ): WorkVersionTimelineEntry {
   return {
@@ -31,6 +32,7 @@ function workVersion(
     date_created: id,
     date_modified: id,
     draft: false,
+    versionNumber: options.versionNumber ?? 1,
     submissionVersions: options.submissionVersions,
   };
 }

--- a/packages/scms-core/src/utils/workVersionNumbers.spec.ts
+++ b/packages/scms-core/src/utils/workVersionNumbers.spec.ts
@@ -1,0 +1,36 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import {
+  buildWorkVersionNumberByIdMap,
+  compareWorkVersionsByDateCreatedDesc,
+  workVersionNumberAtNewestFirstIndex,
+} from './workVersionNumbers.js';
+
+describe('workVersionNumbers', () => {
+  const versions = [
+    { id: 'wv-old', date_created: '2026-01-01T00:00:00.000Z' },
+    { id: 'wv-mid', date_created: '2026-01-02T00:00:00.000Z' },
+    { id: 'wv-new', date_created: '2026-01-03T00:00:00.000Z' },
+  ];
+
+  it('sorts versions newest-first', () => {
+    expect([...versions].sort(compareWorkVersionsByDateCreatedDesc).map((v) => v.id)).toEqual([
+      'wv-new',
+      'wv-mid',
+      'wv-old',
+    ]);
+  });
+
+  it('builds v1 = oldest numbering from an unsorted list', () => {
+    expect(buildWorkVersionNumberByIdMap(versions)).toEqual({
+      'wv-old': 1,
+      'wv-mid': 2,
+      'wv-new': 3,
+    });
+  });
+
+  it('maps index in a newest-first list to version numbers', () => {
+    expect(workVersionNumberAtNewestFirstIndex(0, 3)).toBe(3);
+    expect(workVersionNumberAtNewestFirstIndex(2, 3)).toBe(1);
+  });
+});

--- a/packages/scms-core/src/utils/workVersionNumbers.ts
+++ b/packages/scms-core/src/utils/workVersionNumbers.ts
@@ -1,0 +1,33 @@
+export type WorkVersionForNumbering = {
+  id: string;
+  date_created: string;
+};
+
+/** Newest work version first (by `date_created`). */
+export function compareWorkVersionsByDateCreatedDesc(
+  a: WorkVersionForNumbering,
+  b: WorkVersionForNumbering,
+): number {
+  if (a.date_created === b.date_created) return 0;
+  return a.date_created > b.date_created ? -1 : 1;
+}
+
+/**
+ * Assign v1 to the oldest version by `date_created`, vN to the newest.
+ * Returns a map of version id → 1-based version number.
+ */
+export function buildWorkVersionNumberByIdMap(
+  versions: readonly WorkVersionForNumbering[],
+): Record<string, number> {
+  const sorted = [...versions].sort(compareWorkVersionsByDateCreatedDesc);
+  const map: Record<string, number> = {};
+  sorted.forEach((version, index) => {
+    map[version.id] = versions.length - index;
+  });
+  return map;
+}
+
+/** Version number when versions are already ordered newest-first. */
+export function workVersionNumberAtNewestFirstIndex(index: number, totalCount: number): number {
+  return totalCount - index;
+}

--- a/packages/scms-server/src/backend/loaders/index.ts
+++ b/packages/scms-server/src/backend/loaders/index.ts
@@ -9,3 +9,14 @@ export * as previews from './previews/index.js';
 export * from './messages/index.js';
 export * from './roles.server.js';
 export * from './userRoles.server.js';
+export {
+  dbGetUserWorkRoles,
+  dbGetWork,
+  dbGetWorkForUser,
+  formatWorkDTO,
+  getCanonicalOrLatestVersion,
+  getWorkFromSubmission,
+  type WorkAndVersionsDBO,
+  type WorkUserDBO,
+  type UserWithWorkRolesDBO,
+} from './works/get.server.js';

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -369,11 +369,11 @@ export function SubmittedToBar({
       <ui.Popover>
         <ui.PopoverTrigger asChild>
           <ui.Button
-            variant="default"
-            className="rounded-none rounded-r-lg px-3 py-2.5 h-auto shrink-0"
+            variant="ghost"
+            className="rounded-none px-3 py-2.5 h-auto shrink-0 bg-background hover:bg-accent/50"
             aria-label="Submit to a new site"
           >
-            <Send className="w-4 h-4 stroke-[1.5px]" />
+            <Send className="w-4 h-4 stroke-[1.5px] text-primary" />
           </ui.Button>
         </ui.PopoverTrigger>
         <ui.PopoverContent

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -15,6 +15,7 @@ import type {
   WorkVersionForDetailsClient,
 } from '../works.$workId/types';
 import type { CheckServiceRunRow } from '../works.$workId/db.server';
+import { getCheckRunSummaryByKind } from '../works.$workId/checkServiceRunSummaries';
 import { Check, ChevronDown, Loader2, Send } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -166,7 +167,7 @@ function SubmitToSiteEarlyAccessMessage() {
         <ui.Button
           type="button"
           variant="link"
-          className="inline p-0 h-auto align-baseline"
+          className="inline h-auto p-0 align-baseline"
           onClick={() => setSupportOpen(true)}
         >
           contact support
@@ -215,51 +216,55 @@ export function SubmittedToBar({
   const navigate = useNavigate();
   const fetcher = useFetcher<SubmitToSiteFetcherData>();
   const [versionDropdownOpen, setVersionDropdownOpen] = useState(false);
-  const versionOptions = useMemo(() => {
-    const completedVersions = versions.filter((version) => !version.draft);
-    const sorted = [...completedVersions].sort((a, b) =>
-      a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
-    );
-    const versionNumberByVersionId: Record<string, number> = {};
+  const versionNumberByVersionId = useMemo(() => {
+    const map: Record<string, number> = {};
     [...versions]
       .sort((a, b) =>
         a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
       )
       .forEach((version, index) => {
-        versionNumberByVersionId[version.id] = versions.length - index;
+        map[version.id] = versions.length - index;
       });
+    return map;
+  }, [versions]);
+  const versionOptions = useMemo(() => {
+    const completedVersions = versions.filter((version) => !version.draft);
+    const sorted = [...completedVersions].sort((a, b) =>
+      a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
+    );
     return sorted.map((version) => ({
       version,
       label: `v${versionNumberByVersionId[version.id] ?? 0}`,
     }));
-  }, [versions]);
+  }, [versions, versionNumberByVersionId]);
   const [selectedVersionId, setSelectedVersionId] = useState(versionOptions[0]?.version.id ?? '');
   const selectedVersion =
     versionOptions.find((option) => option.version.id === selectedVersionId)?.version ??
     versionOptions[0]?.version;
   const selectedVersionLabel =
     versionOptions.find((option) => option.version.id === selectedVersion?.id)?.label ?? 'version';
-  const selectedCheckRuns = selectedVersion
-    ? (checkServiceRunsByWorkVersionId[selectedVersion.id] ?? [])
-    : [];
   const selectedFiles = selectedVersion ? getVersionFiles(selectedVersion) : {};
   const fileLabels = Object.entries(selectedFiles).map(([key, value]) => getFileLabel(key, value));
-  const selectedCheckRunByKind = new Map<string, CheckServiceRunRow>();
-  [...selectedCheckRuns]
-    .sort((a, b) =>
-      a.date_modified > b.date_modified ? -1 : a.date_modified < b.date_modified ? 1 : 0,
-    )
-    .forEach((run) => {
-      if (!selectedCheckRunByKind.has(run.kind)) selectedCheckRunByKind.set(run.kind, run);
-    });
-  const fallbackCheckRows = selectedCheckRuns
-    .filter((run) => !checkServices.some((service) => service.id === run.kind))
-    .map((run) => ({ id: run.kind, name: run.kind, run, service: undefined }));
+  // Checks surface the most recent run of each kind across all non-draft versions,
+  // not just the selected version, so a check run on an earlier version still shows
+  // its result (with a version badge) instead of "Not run".
+  const latestRunByServiceKind = useMemo(() => {
+    const nonDraftVersions = [...versions]
+      .filter((version) => !version.draft)
+      .sort((a, b) =>
+        a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
+      );
+    return getCheckRunSummaryByKind(nonDraftVersions, checkServiceRunsByWorkVersionId)
+      .latestRunByServiceKind;
+  }, [versions, checkServiceRunsByWorkVersionId]);
+  const fallbackCheckRows = Object.values(latestRunByServiceKind)
+    .filter((entry) => !checkServices.some((service) => service.id === entry.run.kind))
+    .map((entry) => ({ id: entry.run.kind, name: entry.run.kind, entry, service: undefined }));
   const checkRows = [
     ...checkServices.map((service) => ({
       id: service.id,
       name: service.name,
-      run: selectedCheckRunByKind.get(service.id),
+      entry: latestRunByServiceKind[service.id],
       service,
     })),
     ...fallbackCheckRows,
@@ -388,13 +393,13 @@ export function SubmittedToBar({
                           id="submit-version-select"
                           type="button"
                           className={cn(
-                            'flex gap-3 justify-between items-center px-3 py-2 w-full h-16 text-left bg-white rounded-md border transition-colors border-input shadow-xs',
+                            'flex h-16 w-full items-center justify-between gap-3 rounded-md border border-input bg-white px-3 py-2 text-left shadow-xs transition-colors',
                             'hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
                           )}
                         >
                           {selectedVersion ? (
-                            <span className="flex flex-col items-start min-w-0">
-                              <span className="font-medium truncate">
+                            <span className="flex min-w-0 flex-col items-start">
+                              <span className="truncate font-medium">
                                 Version {selectedVersionLabel}
                               </span>
                               <span className="text-xs text-muted-foreground">
@@ -432,8 +437,8 @@ export function SubmittedToBar({
                                   setVersionDropdownOpen(false);
                                 }}
                               >
-                                <span className="flex flex-col items-start min-w-0">
-                                  <span className="font-medium truncate">Version {label}</span>
+                                <span className="flex min-w-0 flex-col items-start">
+                                  <span className="truncate font-medium">Version {label}</span>
                                   <span className="text-xs text-muted-foreground">
                                     {new Date(
                                       version.date_modified ?? version.date_created,
@@ -450,7 +455,7 @@ export function SubmittedToBar({
                       </ui.PopoverContent>
                     </ui.Popover>
                   ) : (
-                    <p className="px-3 py-4 text-xs leading-relaxed rounded-md border border-dashed border-muted-foreground/40 bg-background text-muted-foreground">
+                    <p className="rounded-md border border-dashed border-muted-foreground/40 bg-background px-3 py-4 text-xs leading-relaxed text-muted-foreground">
                       No completed version is available to submit. Finish creating a version before
                       submitting to a site.
                     </p>
@@ -466,28 +471,50 @@ export function SubmittedToBar({
                           checkRows.map((row) => {
                             const SummaryTitleComponent = row.service?.sectionSummaryTitleComponent;
                             const SummaryBadgeComponent = row.service?.sectionSummaryBadgeComponent;
-                            const metadata = serviceDataFromRun(row.run);
-                            const fallbackScore = row.run ? getCheckScore(row.run) : null;
+                            const run = row.entry?.run;
+                            const metadata = serviceDataFromRun(run);
+                            const fallbackScore = run ? getCheckScore(run) : null;
+                            const runVersionNumber = row.entry
+                              ? versionNumberByVersionId[row.entry.workVersionId]
+                              : undefined;
+                            const isFromOtherVersion =
+                              row.entry != null && row.entry.workVersionId !== selectedVersion?.id;
                             return (
                               <div
                                 key={row.id}
                                 className="flex gap-2 justify-between items-center p-2 rounded-md border bg-background border-border"
                               >
                                 <span className="flex min-w-0 flex-1 items-center overflow-hidden [&_img]:max-h-5 [&_img]:w-auto [&_img]:object-contain [&_svg]:max-h-5 [&_svg]:w-auto">
-                                  {SummaryTitleComponent && row.run ? (
+                                  {SummaryTitleComponent && run ? (
                                     <SummaryTitleComponent metadata={metadata} />
                                   ) : (
                                     <span className="text-xs font-medium truncate">{row.name}</span>
                                   )}
                                 </span>
-                                {row.run ? (
-                                  SummaryBadgeComponent ? (
-                                    <SummaryBadgeComponent metadata={metadata} />
-                                  ) : (
-                                    <ui.Badge variant="success">
-                                      {fallbackScore ? `Score ${fallbackScore}` : 'Run'}
-                                    </ui.Badge>
-                                  )
+                                {run ? (
+                                  <span className="flex gap-1.5 items-center shrink-0">
+                                    {isFromOtherVersion && runVersionNumber != null ? (
+                                      <ui.SimpleTooltip
+                                        title={`Latest run was on version v${runVersionNumber}`}
+                                        side="top"
+                                        sideOffset={6}
+                                      >
+                                        <ui.Badge
+                                          variant="outline-muted"
+                                          className="px-1.5 text-[10px] font-medium"
+                                        >
+                                          v{runVersionNumber}
+                                        </ui.Badge>
+                                      </ui.SimpleTooltip>
+                                    ) : null}
+                                    {SummaryBadgeComponent ? (
+                                      <SummaryBadgeComponent metadata={metadata} />
+                                    ) : (
+                                      <ui.Badge variant="success">
+                                        {fallbackScore ? `Score ${fallbackScore}` : 'Run'}
+                                      </ui.Badge>
+                                    )}
+                                  </span>
                                 ) : (
                                   <ui.Badge variant="outline-muted">Not run</ui.Badge>
                                 )}
@@ -575,7 +602,7 @@ export function SubmittedToBar({
                                 </span>
                               )}
                             </span>
-                            <span className="flex-1 min-w-0">
+                            <span className="min-w-0 flex-1">
                               <span className="flex gap-2 items-center">
                                 {metadata?.favicon ? (
                                   <img

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -14,7 +14,7 @@ import type {
   SubmissionWithVersionsAndSite,
   WorkVersionForDetailsClient,
 } from '../works.$workId/types';
-import type { CheckServiceRunRow } from '../works.$workId/db.server';
+import type { CheckServiceRunRow } from '../works.$workId/checkServiceRun.shared';
 import { getCheckRunSummaryByKind } from '../works.$workId/checkServiceRunSummaries';
 import { Check, ChevronDown, Loader2, Send } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -9,7 +9,6 @@ import {
   useMyUser,
   truncate,
   buildWorkVersionNumberByIdMap,
-  compareWorkVersionsByDateCreatedDesc,
 } from '@curvenote/scms-core';
 import type { ClientExtensionCheckService, Workflow } from '@curvenote/scms-core';
 import type {

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -145,6 +145,15 @@ function getSubmittedSiteNamesForWorkVersion(version: WorkVersionForDetailsClien
   );
 }
 
+function SubmitVersionLabel({ label }: { label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 min-w-0">
+      <span className="text-sm font-medium shrink-0">Version</span>
+      <ui.VersionTagBadge tag={label} titlePrefix="Version" hideIcon />
+    </span>
+  );
+}
+
 function SubmitToSiteEarlyAccessMessage() {
   const [supportOpen, setSupportOpen] = useState(false);
   const location = useLocation();
@@ -402,10 +411,8 @@ export function SubmittedToBar({
                           )}
                         >
                           {selectedVersion ? (
-                            <span className="flex min-w-0 flex-col items-start">
-                              <span className="truncate font-medium">
-                                Version {selectedVersionLabel}
-                              </span>
+                            <span className="flex min-w-0 flex-col items-start gap-1">
+                              <SubmitVersionLabel label={selectedVersionLabel} />
                               <span className="text-xs text-muted-foreground">
                                 {new Date(
                                   selectedVersion.date_modified ?? selectedVersion.date_created,
@@ -441,8 +448,8 @@ export function SubmittedToBar({
                                   setVersionDropdownOpen(false);
                                 }}
                               >
-                                <span className="flex min-w-0 flex-col items-start">
-                                  <span className="truncate font-medium">Version {label}</span>
+                                <span className="flex min-w-0 flex-col items-start gap-1">
+                                  <SubmitVersionLabel label={label} />
                                   <span className="text-xs text-muted-foreground">
                                     {new Date(
                                       version.date_modified ?? version.date_created,

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -365,14 +365,14 @@ export function SubmittedToBar({
         );
       })}
       <ui.Popover>
-        <ui.PopoverTrigger
-          className={cn(
-            'inline-flex items-center justify-center p-2.5 border-dashed border-muted-foreground/40',
-            'cursor-pointer bg-muted/30 text-muted-foreground shrink-0 hover:bg-muted/50 hover:text-foreground transition-colors rounded-r-lg',
-          )}
-          aria-label="Submit to a new site"
-        >
-          <Send className="w-4 h-4 stroke-[1.5px]" />
+        <ui.PopoverTrigger asChild>
+          <ui.Button
+            variant="default"
+            className="rounded-none rounded-r-lg px-3 py-2.5 h-auto shrink-0"
+            aria-label="Submit to a new site"
+          >
+            <Send className="w-4 h-4 stroke-[1.5px]" />
+          </ui.Button>
         </ui.PopoverTrigger>
         <ui.PopoverContent
           className={cn(

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -245,18 +245,22 @@ export function SubmittedToBar({
     versionOptions.find((option) => option.version.id === selectedVersion?.id)?.label ?? 'version';
   const selectedFiles = selectedVersion ? getVersionFiles(selectedVersion) : {};
   const fileLabels = Object.entries(selectedFiles).map(([key, value]) => getFileLabel(key, value));
-  // Checks surface the most recent run of each kind across all non-draft versions,
-  // not just the selected version, so a check run on an earlier version still shows
-  // its result (with a version badge) instead of "Not run".
+  // Checks surface the most recent run of each kind on the selected version and
+  // any older versions — not on versions newer than the one chosen for submit.
   const latestRunByServiceKind = useMemo(() => {
+    const selectedCreatedAt = selectedVersion?.date_created;
     const nonDraftVersions = [...versions]
       .filter((version) => !version.draft)
+      .filter(
+        (version) =>
+          selectedCreatedAt == null || version.date_created <= selectedCreatedAt,
+      )
       .sort((a, b) =>
         a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
       );
     return getCheckRunSummaryByKind(nonDraftVersions, checkServiceRunsByWorkVersionId)
       .latestRunByServiceKind;
-  }, [versions, checkServiceRunsByWorkVersionId]);
+  }, [versions, checkServiceRunsByWorkVersionId, selectedVersion?.date_created, selectedVersion?.id]);
   const fallbackCheckRows = Object.values(latestRunByServiceKind)
     .filter((entry) => !checkServices.some((service) => service.id === entry.run.kind))
     .map((entry) => ({ id: entry.run.kind, name: entry.run.kind, entry, service: undefined }));

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -17,7 +17,7 @@ import type {
 import type { CheckServiceRunRow } from '../works.$workId/checkServiceRun.shared';
 import { getCheckRunSummaryByKind } from '../works.$workId/checkServiceRunSummaries';
 import { Check, ChevronDown, GitBranch, Loader2, Send } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 
 type SubmissionTargetSite = {
   id: string;
@@ -154,6 +154,37 @@ function SubmitVersionLabel({ label }: { label: string }) {
   );
 }
 
+function SubmitCheckSummaryBadgeSlot({ children }: { children: ReactNode }) {
+  const slotRef = useRef<HTMLSpanElement>(null);
+  const [fullLabel, setFullLabel] = useState<string | undefined>();
+
+  useLayoutEffect(() => {
+    const text = slotRef.current?.textContent?.replace(/\s+/g, ' ').trim();
+    setFullLabel(text || undefined);
+  });
+
+  const slot = (
+    <span
+      ref={slotRef}
+      className={cn(
+        'inline-flex min-w-0 max-w-[9rem] overflow-hidden',
+        '[&_[data-slot=badge]]:max-w-full [&_[data-slot=badge]]:w-full [&_[data-slot=badge]]:!min-w-0',
+        '[&_[data-slot=badge]]:shrink [&_[data-slot=badge]]:truncate [&_[data-slot=badge]]:justify-start',
+      )}
+    >
+      {children}
+    </span>
+  );
+
+  if (!fullLabel) return slot;
+
+  return (
+    <ui.SimpleTooltip title={fullLabel} side="top" sideOffset={6}>
+      {slot}
+    </ui.SimpleTooltip>
+  );
+}
+
 function SubmitToSiteEarlyAccessMessage() {
   const [supportOpen, setSupportOpen] = useState(false);
   const location = useLocation();
@@ -176,7 +207,7 @@ function SubmitToSiteEarlyAccessMessage() {
         <ui.Button
           type="button"
           variant="link"
-          className="inline h-auto p-0 align-baseline"
+          className="inline p-0 h-auto align-baseline"
           onClick={() => setSupportOpen(true)}
         >
           contact support
@@ -408,12 +439,12 @@ export function SubmittedToBar({
                           id="submit-version-select"
                           type="button"
                           className={cn(
-                            'flex h-16 w-full items-center justify-between gap-3 rounded-md border border-input bg-white px-3 py-2 text-left shadow-xs transition-colors',
+                            'flex gap-3 justify-between items-center px-3 py-2 w-full h-16 text-left bg-white rounded-md border transition-colors border-input shadow-xs',
                             'hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
                           )}
                         >
                           {selectedVersion ? (
-                            <span className="flex min-w-0 flex-col items-start gap-1">
+                            <span className="flex flex-col gap-1 items-start min-w-0">
                               <SubmitVersionLabel label={selectedVersionLabel} />
                               <span className="text-xs text-muted-foreground">
                                 {new Date(
@@ -450,7 +481,7 @@ export function SubmittedToBar({
                                   setVersionDropdownOpen(false);
                                 }}
                               >
-                                <span className="flex min-w-0 flex-col items-start gap-1">
+                                <span className="flex flex-col gap-1 items-start min-w-0">
                                   <SubmitVersionLabel label={label} />
                                   <span className="text-xs text-muted-foreground">
                                     {new Date(
@@ -468,102 +499,111 @@ export function SubmittedToBar({
                       </ui.PopoverContent>
                     </ui.Popover>
                   ) : (
-                    <p className="rounded-md border border-dashed border-muted-foreground/40 bg-background px-3 py-4 text-xs leading-relaxed text-muted-foreground">
+                    <p className="px-3 py-4 text-xs leading-relaxed rounded-md border border-dashed border-muted-foreground/40 bg-background text-muted-foreground">
                       No completed version is available to submit. Finish creating a version before
                       submitting to a site.
                     </p>
                   )}
 
-                  {selectedVersion && hasChecksFeature ? (
-                    <div className="space-y-2">
-                      <p className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
-                        Checks
-                      </p>
-                      <div className="space-y-1.5">
-                        {checkRows.length > 0 ? (
-                          checkRows.map((row) => {
-                            const SummaryTitleComponent = row.service?.sectionSummaryTitleComponent;
-                            const SummaryBadgeComponent = row.service?.sectionSummaryBadgeComponent;
-                            const run = row.entry?.run;
-                            const metadata = serviceDataFromRun(run);
-                            const fallbackScore = run ? getCheckScore(run) : null;
-                            const runVersionNumber = row.entry
-                              ? versionNumberByVersionId[row.entry.workVersionId]
-                              : undefined;
-                            const isFromOtherVersion =
-                              row.entry != null && row.entry.workVersionId !== selectedVersion?.id;
-                            return (
-                              <div
-                                key={row.id}
-                                className="flex gap-2 justify-between items-center p-2 rounded-md border bg-background border-border"
-                              >
-                                <span className="flex min-w-0 flex-1 items-center overflow-hidden [&_img]:max-h-5 [&_img]:w-auto [&_img]:object-contain [&_svg]:max-h-5 [&_svg]:w-auto">
-                                  {SummaryTitleComponent && run ? (
-                                    <SummaryTitleComponent metadata={metadata} />
-                                  ) : (
-                                    <span className="text-xs font-medium truncate">{row.name}</span>
-                                  )}
-                                </span>
-                                {run ? (
-                                  <span className="flex gap-1.5 items-center shrink-0">
-                                    {isFromOtherVersion && runVersionNumber != null ? (
-                                      <ui.SimpleTooltip
-                                        title={`Latest run was on version v${runVersionNumber}`}
-                                        side="top"
-                                        sideOffset={6}
-                                      >
-                                        <span className="inline-flex">
-                                          <ui.VersionTagBadge
-                                            tag={`v${runVersionNumber}`}
-                                            titlePrefix="Version"
-                                            icon={GitBranch}
-                                            disableTooltip
-                                          />
+                  {selectedVersion ? (
+                    <>
+                      {hasChecksFeature ? (
+                        <div className="space-y-2">
+                          <p className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
+                            Checks
+                          </p>
+                          <div className="space-y-1.5">
+                            {checkRows.length > 0 ? (
+                              checkRows.map((row) => {
+                                const SummaryTitleComponent =
+                                  row.service?.sectionSummaryTitleComponent;
+                                const SummaryBadgeComponent =
+                                  row.service?.sectionSummaryBadgeComponent;
+                                const run = row.entry?.run;
+                                const metadata = serviceDataFromRun(run);
+                                const fallbackScore = run ? getCheckScore(run) : null;
+                                const runVersionNumber = row.entry
+                                  ? versionNumberByVersionId[row.entry.workVersionId]
+                                  : undefined;
+                                const isFromOtherVersion =
+                                  row.entry != null &&
+                                  row.entry.workVersionId !== selectedVersion?.id;
+                                return (
+                                  <div
+                                    key={row.id}
+                                    className="flex gap-2 justify-between items-center p-2 rounded-md border bg-background border-border"
+                                  >
+                                    <span className="flex min-w-0 flex-1 items-center overflow-hidden [&_img]:max-h-5 [&_img]:w-auto [&_img]:object-contain [&_svg]:max-h-5 [&_svg]:w-auto [&_*]:truncate">
+                                      {SummaryTitleComponent && run ? (
+                                        <SummaryTitleComponent metadata={metadata} />
+                                      ) : (
+                                        <span className="text-xs font-medium truncate">
+                                          {row.name}
                                         </span>
-                                      </ui.SimpleTooltip>
-                                    ) : null}
-                                    {SummaryBadgeComponent ? (
-                                      <SummaryBadgeComponent metadata={metadata} />
+                                      )}
+                                    </span>
+                                    {run ? (
+                                      <span className="flex gap-1.5 items-center min-w-0 shrink">
+                                        {isFromOtherVersion && runVersionNumber != null ? (
+                                          <ui.SimpleTooltip
+                                            title={`Latest run was on version v${runVersionNumber}`}
+                                            side="top"
+                                            sideOffset={6}
+                                          >
+                                            <span className="inline-flex shrink-0">
+                                              <ui.VersionTagBadge
+                                                tag={`v${runVersionNumber}`}
+                                                titlePrefix="Version"
+                                                icon={GitBranch}
+                                                disableTooltip
+                                              />
+                                            </span>
+                                          </ui.SimpleTooltip>
+                                        ) : null}
+                                        <SubmitCheckSummaryBadgeSlot>
+                                          {SummaryBadgeComponent ? (
+                                            <SummaryBadgeComponent metadata={metadata} />
+                                          ) : (
+                                            <ui.Badge variant="success">
+                                              {fallbackScore ? `Score ${fallbackScore}` : 'Run'}
+                                            </ui.Badge>
+                                          )}
+                                        </SubmitCheckSummaryBadgeSlot>
+                                      </span>
                                     ) : (
-                                      <ui.Badge variant="success">
-                                        {fallbackScore ? `Score ${fallbackScore}` : 'Run'}
-                                      </ui.Badge>
+                                      <ui.Badge variant="outline-muted">Not run</ui.Badge>
                                     )}
-                                  </span>
-                                ) : (
-                                  <ui.Badge variant="outline-muted">Not run</ui.Badge>
-                                )}
-                              </div>
-                            );
-                          })
+                                  </div>
+                                );
+                              })
+                            ) : (
+                              <p className="text-xs text-muted-foreground">
+                                No check services available.
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                      ) : null}
+
+                      <div className="space-y-2">
+                        <p className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
+                          Files
+                        </p>
+                        {fileLabels.length > 0 ? (
+                          <ul className="space-y-1 text-[11px] leading-4 text-muted-foreground">
+                            {Object.entries(selectedFiles).map(([key, value]) => (
+                              <li key={key} className="truncate">
+                                {getFileLabel(key, value)}
+                              </li>
+                            ))}
+                          </ul>
                         ) : (
-                          <p className="text-xs text-muted-foreground">
-                            No check services available.
+                          <p className="text-[11px] leading-4 text-muted-foreground">
+                            No files are available for this version.
                           </p>
                         )}
                       </div>
-                    </div>
-                  ) : null}
-
-                  {selectedVersion ? (
-                    <div className="space-y-2">
-                      <p className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
-                        Files
-                      </p>
-                      {fileLabels.length > 0 ? (
-                        <ul className="space-y-1 text-[11px] leading-4 text-muted-foreground">
-                          {Object.entries(selectedFiles).map(([key, value]) => (
-                            <li key={key} className="truncate">
-                              {getFileLabel(key, value)}
-                            </li>
-                          ))}
-                        </ul>
-                      ) : (
-                        <p className="text-[11px] leading-4 text-muted-foreground">
-                          No files are available for this version.
-                        </p>
-                      )}
-                    </div>
+                    </>
                   ) : null}
                 </div>
 
@@ -617,7 +657,7 @@ export function SubmittedToBar({
                                 </span>
                               )}
                             </span>
-                            <span className="min-w-0 flex-1">
+                            <span className="flex-1 min-w-0">
                               <span className="flex gap-2 items-center">
                                 {metadata?.favicon ? (
                                   <img

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -8,6 +8,8 @@ import {
   useDeploymentConfig,
   useMyUser,
   truncate,
+  buildWorkVersionNumberByIdMap,
+  compareWorkVersionsByDateCreatedDesc,
 } from '@curvenote/scms-core';
 import type { ClientExtensionCheckService, Workflow } from '@curvenote/scms-core';
 import type {
@@ -256,17 +258,10 @@ export function SubmittedToBar({
   const navigate = useNavigate();
   const fetcher = useFetcher<SubmitToSiteFetcherData>();
   const [versionDropdownOpen, setVersionDropdownOpen] = useState(false);
-  const versionNumberByVersionId = useMemo(() => {
-    const map: Record<string, number> = {};
-    [...versions]
-      .sort((a, b) =>
-        a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
-      )
-      .forEach((version, index) => {
-        map[version.id] = versions.length - index;
-      });
-    return map;
-  }, [versions]);
+  const versionNumberByVersionId = useMemo(
+    () => buildWorkVersionNumberByIdMap(versions),
+    [versions],
+  );
   const versionOptions = useMemo(() => {
     const completedVersions = versions.filter((version) => !version.draft);
     const sorted = [...completedVersions].sort((a, b) =>

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -16,7 +16,7 @@ import type {
 } from '../works.$workId/types';
 import type { CheckServiceRunRow } from '../works.$workId/checkServiceRun.shared';
 import { getCheckRunSummaryByKind } from '../works.$workId/checkServiceRunSummaries';
-import { Check, ChevronDown, Loader2, Send } from 'lucide-react';
+import { Check, ChevronDown, GitBranch, Loader2, Send } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 type SubmissionTargetSite = {
@@ -149,7 +149,7 @@ function SubmitVersionLabel({ label }: { label: string }) {
   return (
     <span className="inline-flex items-center gap-1.5 min-w-0">
       <span className="text-sm font-medium shrink-0">Version</span>
-      <ui.VersionTagBadge tag={label} titlePrefix="Version" hideIcon />
+      <ui.VersionTagBadge tag={label} titlePrefix="Version" icon={GitBranch} />
     </span>
   );
 }
@@ -260,16 +260,18 @@ export function SubmittedToBar({
     const selectedCreatedAt = selectedVersion?.date_created;
     const nonDraftVersions = [...versions]
       .filter((version) => !version.draft)
-      .filter(
-        (version) =>
-          selectedCreatedAt == null || version.date_created <= selectedCreatedAt,
-      )
+      .filter((version) => selectedCreatedAt == null || version.date_created <= selectedCreatedAt)
       .sort((a, b) =>
         a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
       );
     return getCheckRunSummaryByKind(nonDraftVersions, checkServiceRunsByWorkVersionId)
       .latestRunByServiceKind;
-  }, [versions, checkServiceRunsByWorkVersionId, selectedVersion?.date_created, selectedVersion?.id]);
+  }, [
+    versions,
+    checkServiceRunsByWorkVersionId,
+    selectedVersion?.date_created,
+    selectedVersion?.id,
+  ]);
   const fallbackCheckRows = Object.values(latestRunByServiceKind)
     .filter((entry) => !checkServices.some((service) => service.id === entry.run.kind))
     .map((entry) => ({ id: entry.run.kind, name: entry.run.kind, entry, service: undefined }));
@@ -510,12 +512,14 @@ export function SubmittedToBar({
                                         side="top"
                                         sideOffset={6}
                                       >
-                                        <ui.Badge
-                                          variant="outline-muted"
-                                          className="px-1.5 text-[10px] font-medium"
-                                        >
-                                          v{runVersionNumber}
-                                        </ui.Badge>
+                                        <span className="inline-flex">
+                                          <ui.VersionTagBadge
+                                            tag={`v${runVersionNumber}`}
+                                            titlePrefix="Version"
+                                            icon={GitBranch}
+                                            disableTooltip
+                                          />
+                                        </span>
                                       </ui.SimpleTooltip>
                                     ) : null}
                                     {SummaryBadgeComponent ? (

--- a/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { GitBranch } from 'lucide-react';
 import { useSearchParams } from 'react-router';
 import {
   formatDate,
@@ -207,7 +208,7 @@ function WorkVersionTimelineInner({
         const label = (
           <span className="flex gap-2 items-center">
             <ui.TagChips tags={v.tags} titlePrefix="Work version tag" />
-            <ui.VersionTagBadge tag={versionLabel} titlePrefix="Version" hideIcon />
+            <ui.VersionTagBadge tag={versionLabel} titlePrefix="Version" icon={GitBranch} />
             <span className="text-sm text-muted-foreground">
               {formatDate(v.date_created, 'MMM d, yyyy HH:mm')}
             </span>

--- a/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
@@ -12,6 +12,8 @@ import {
   CheckServiceRunTimelineItem,
   TimelineSection,
   useTimelineActivitiesVisibility,
+  buildWorkVersionNumberByIdMap,
+  compareWorkVersionsByDateCreatedDesc,
 } from '@curvenote/scms-core';
 import type { WorkVersionForDetailsClient } from '../works.$workId/types';
 import type { WorkActivityRow, CheckServiceRunRow } from '../works.$workId/db.server';
@@ -174,21 +176,15 @@ function WorkVersionTimelineInner({
   const hasChecksFeature = userScopes.includes(scopes.app.works.checks.feature);
   const checkServiceById = Object.fromEntries(checkServices.map((s) => [s.id, s]));
 
-  const versionNumberByVersionId = useMemo(() => {
-    const map: Record<string, number> = {};
-    [...versions]
-      .sort((a, b) =>
-        a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
-      )
-      .forEach((version, index) => {
-        map[version.id] = versions.length - index;
-      });
-    return map;
-  }, [versions]);
+  const versionNumberByVersionId = useMemo(
+    () => buildWorkVersionNumberByIdMap(versions),
+    [versions],
+  );
 
   // Order sections by date_created descending (most recently created first)
-  const versionsByCreated = [...versions].sort((a, b) =>
-    a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
+  const versionsByCreated = useMemo(
+    () => [...versions].sort(compareWorkVersionsByDateCreatedDesc),
+    [versions],
   );
 
   // Show all versions; draft versions display only their activities (and submissions), not the "Version created" row

--- a/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/WorkVersionTimeline.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 import {
   formatDate,
@@ -172,6 +173,18 @@ function WorkVersionTimelineInner({
   const hasChecksFeature = userScopes.includes(scopes.app.works.checks.feature);
   const checkServiceById = Object.fromEntries(checkServices.map((s) => [s.id, s]));
 
+  const versionNumberByVersionId = useMemo(() => {
+    const map: Record<string, number> = {};
+    [...versions]
+      .sort((a, b) =>
+        a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
+      )
+      .forEach((version, index) => {
+        map[version.id] = versions.length - index;
+      });
+    return map;
+  }, [versions]);
+
   // Order sections by date_created descending (most recently created first)
   const versionsByCreated = [...versions].sort((a, b) =>
     a.date_created > b.date_created ? -1 : a.date_created < b.date_created ? 1 : 0,
@@ -190,9 +203,11 @@ function WorkVersionTimelineInner({
           : v.submissionVersions.filter((sv) => sv.status !== 'DRAFT');
         const activitiesForVersion = activities.filter((a) => a.work_version_id === v.id);
         const checkRunsForVersion = checkServiceRunsByWorkVersionId[v.id] ?? [];
+        const versionLabel = `v${versionNumberByVersionId[v.id] ?? 0}`;
         const label = (
           <span className="flex gap-2 items-center">
             <ui.TagChips tags={v.tags} titlePrefix="Work version tag" />
+            <ui.VersionTagBadge tag={versionLabel} titlePrefix="Version" hideIcon />
             <span className="text-sm text-muted-foreground">
               {formatDate(v.date_created, 'MMM d, yyyy HH:mm')}
             </span>

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
@@ -115,11 +115,12 @@ export async function dbLoadWorkVersionsTimeline(
   const workVersionIds = rows.map((row) => row.id);
   const runsByVersionId = await dbGetCheckServiceRunsByWorkVersionIds(workVersionIds);
 
-  return rows.map((row) => ({
+  return rows.map((row, index) => ({
     id: row.id,
     date_created: row.date_created,
     date_modified: row.date_modified,
     draft: row.draft,
+    versionNumber: rows.length - index,
     submissionVersions: mapSubmissionVersions(row.submissionVersions, workflows),
     checkRuns: latestCheckRunsByKind(runsByVersionId[row.id]),
   }));

--- a/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.versions/db.server.ts
@@ -1,5 +1,9 @@
 import { getPrismaClient } from '@curvenote/scms-server';
-import type { WorkVersionTimelineEntry, Workflow } from '@curvenote/scms-core';
+import {
+  type WorkVersionTimelineEntry,
+  type Workflow,
+  workVersionNumberAtNewestFirstIndex,
+} from '@curvenote/scms-core';
 import { dbGetCheckServiceRunsByWorkVersionIds } from '../works.$workId/db.server.js';
 
 function siteLogoFromMetadata(metadata: unknown): string | undefined {
@@ -120,7 +124,7 @@ export async function dbLoadWorkVersionsTimeline(
     date_created: row.date_created,
     date_modified: row.date_modified,
     draft: row.draft,
-    versionNumber: rows.length - index,
+    versionNumber: workVersionNumberAtNewestFirstIndex(index, rows.length),
     submissionVersions: mapSubmissionVersions(row.submissionVersions, workflows),
     checkRuns: latestCheckRunsByKind(runsByVersionId[row.id]),
   }));

--- a/platform/scms/app/routes/app/works.$workId/checkServiceRun.shared.ts
+++ b/platform/scms/app/routes/app/works.$workId/checkServiceRun.shared.ts
@@ -1,0 +1,19 @@
+/** Check service run row for timeline and summaries (client + server safe). */
+export type CheckServiceRunRow = {
+  id: string;
+  work_version_id: string;
+  kind: string;
+  date_created: string;
+  date_modified: string;
+  data: unknown;
+  created_by_id: string | null;
+  retried?: boolean;
+  successor_id?: string | null;
+};
+
+/** True when a failed run was superseded by a retry and should not appear in summaries. */
+export function isCheckServiceRunSupersededByRetry(
+  run: Pick<CheckServiceRunRow, 'retried' | 'successor_id'>,
+): boolean {
+  return run.retried === true || Boolean(run.successor_id?.trim());
+}

--- a/platform/scms/app/routes/app/works.$workId/checkServiceRunSummaries.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId/checkServiceRunSummaries.spec.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, expect, it } from 'vitest';
-import type { CheckServiceRunRow } from './db.server';
-import { isCheckServiceRunSupersededByRetry } from './db.server';
+import type { CheckServiceRunRow } from './checkServiceRun.shared';
+import { isCheckServiceRunSupersededByRetry } from './checkServiceRun.shared';
 import {
   getCheckRunSummaryByKind,
   selectWorkListVisibleRunsByServiceKind,

--- a/platform/scms/app/routes/app/works.$workId/checkServiceRunSummaries.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId/checkServiceRunSummaries.spec.ts
@@ -59,6 +59,19 @@ describe('getCheckRunSummaryByKind', () => {
     expect(summary.previousRunsByServiceKind['service-a']).toHaveLength(1);
   });
 
+  it('excludes runs from versions outside the scoped version list (submit cap)', () => {
+    const summary = getCheckRunSummaryByKind(
+      [{ id: 'wv-1', date_created: '2026-01-01T00:00:00.000Z' }],
+      {
+        'wv-1': [run('proofig-v1', 'proofig', 'wv-1', '2026-01-02T00:00:00.000Z')],
+        'wv-2': [run('text-int-v2', 'text-integrity', 'wv-2', '2026-01-05T00:00:00.000Z')],
+      },
+    );
+
+    expect(summary.latestRunByServiceKind.proofig?.run.id).toBe('proofig-v1');
+    expect(summary.latestRunByServiceKind['text-integrity']).toBeUndefined();
+  });
+
   it('dedupes multiple same-kind runs on a version to the first row supplied', () => {
     const summary = getCheckRunSummaryByKind(
       [

--- a/platform/scms/app/routes/app/works.$workId/checkServiceRunSummaries.ts
+++ b/platform/scms/app/routes/app/works.$workId/checkServiceRunSummaries.ts
@@ -1,4 +1,4 @@
-import { getCheckServiceRunServiceData } from '@curvenote/scms-core';
+import { getCheckServiceRunServiceData, buildWorkVersionNumberByIdMap } from '@curvenote/scms-core';
 import type { CheckServiceRunRow } from './checkServiceRun.shared';
 import { isCheckServiceRunSupersededByRetry } from './checkServiceRun.shared';
 
@@ -26,14 +26,7 @@ export function getCheckRunSummaryByKind(
   nonDraftVersions: WorkVersionForCheckRunSummary[],
   runsByVersionId: Record<string, CheckServiceRunRow[]>,
 ): CheckRunSummaryByKind {
-  // Version numbering: v1 = oldest (by date_created).
-  // Callers pass versions newest-first, so the highest number is first.
-  const versionNumberByWorkVersionId: Record<string, number> = {};
-  nonDraftVersions.forEach((version, index) => {
-    versionNumberByWorkVersionId[version.id] = nonDraftVersions.length - index;
-  });
-
-  // For each version, keep only that version's latest run per kind, then sort
+  const versionNumberByWorkVersionId = buildWorkVersionNumberByIdMap(nonDraftVersions);
   // each kind by run date so the newest run across all versions is first.
   const entriesByKind: Record<string, ServiceRunEntry[]> = {};
   for (const version of nonDraftVersions) {

--- a/platform/scms/app/routes/app/works.$workId/checkServiceRunSummaries.ts
+++ b/platform/scms/app/routes/app/works.$workId/checkServiceRunSummaries.ts
@@ -1,6 +1,6 @@
 import { getCheckServiceRunServiceData } from '@curvenote/scms-core';
-import type { CheckServiceRunRow } from './db.server';
-import { isCheckServiceRunSupersededByRetry } from './db.server';
+import type { CheckServiceRunRow } from './checkServiceRun.shared';
+import { isCheckServiceRunSupersededByRetry } from './checkServiceRun.shared';
 
 export type WorkVersionForCheckRunSummary = {
   id: string;

--- a/platform/scms/app/routes/app/works.$workId/db.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/db.server.ts
@@ -1,28 +1,13 @@
 import { getPrismaClient, StorageBackend, KnownBuckets, Folder } from '@curvenote/scms-server';
 import type { SecureContext } from '@curvenote/scms-server';
 import type { Prisma, WorkVersion } from '@curvenote/scms-db';
+import type { CheckServiceRunRow } from './checkServiceRun.shared';
+import { isCheckServiceRunSupersededByRetry } from './checkServiceRun.shared';
 
 export type LinkedJobWithStatus = { id: string; status: string };
 
-/** Check service run row for timeline (id, work_version_id, kind, dates, data, created_by_id). */
-export type CheckServiceRunRow = {
-  id: string;
-  work_version_id: string;
-  kind: string;
-  date_created: string;
-  date_modified: string;
-  data: unknown;
-  created_by_id: string | null;
-  retried?: boolean;
-  successor_id?: string | null;
-};
-
-/** True when a failed run was superseded by a retry and should not appear in work timelines. */
-export function isCheckServiceRunSupersededByRetry(
-  run: Pick<CheckServiceRunRow, 'retried' | 'successor_id'>,
-): boolean {
-  return run.retried === true || Boolean(run.successor_id?.trim());
-}
+export type { CheckServiceRunRow } from './checkServiceRun.shared';
+export { isCheckServiceRunSupersededByRetry } from './checkServiceRun.shared';
 
 export function filterVisibleCheckServiceRuns(runs: CheckServiceRunRow[]): CheckServiceRunRow[] {
   return runs.filter((run) => !isCheckServiceRunSupersededByRetry(run));

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -61,7 +61,7 @@ export function WorkListItem({
 
   return (
     <div className="px-6 py-4">
-      <div className="flex flex-col gap-1 items-start md:gap-6 md:flex-row">
+      <div className="flex flex-col gap-1 items-start md:items-baseline md:gap-6 md:flex-row">
         {/* Column 1: Title, Authors, DOI Links */}
         <div className="flex flex-col flex-grow gap-1">
           <div className="flex flex-wrap gap-2 items-start">
@@ -169,7 +169,7 @@ export function WorkListItem({
         </div>
 
         {/* Column 2: Date, activity, timeline */}
-        <div className="flex flex-col flex-shrink-0 items-start self-stretch w-48 pt-[1px]">
+        <div className="flex flex-col flex-shrink-0 items-start w-48">
           {publishedDate ? (
             <div className="text-xs text-gray-600 dark:text-gray-400">
               Published: {formatDate(publishedDate)}

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -27,10 +27,11 @@ export function WorkListItem({
   checkServices: WorkListCheckService[];
   hasChecksFeature: boolean;
 }) {
-  const lastActivity = work.submissions
-    .map((submission) => submission.activity?.[0])
-    .filter((activity) => !!activity)
-    .slice()
+  const lastActivity = [
+    work.activity?.[0],
+    ...work.submissions.map((submission) => submission.activity?.[0]),
+  ]
+    .filter((activity): activity is NonNullable<typeof activity> => !!activity)
     .sort((a, b) => Date.parse(b.date_created) - Date.parse(a.date_created))[0];
 
   const activityTime = lastActivity

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -169,19 +169,19 @@ export function WorkListItem({
         </div>
 
         {/* Column 2: Date, activity, timeline */}
-        <div className="flex flex-col flex-shrink-0 items-start w-48">
+        <div className="flex flex-col flex-shrink-0 items-center w-48">
           {publishedDate ? (
-            <div className="text-xs text-gray-600 dark:text-gray-400">
+            <div className="text-xs text-center text-gray-600 dark:text-gray-400">
               Published: {formatDate(publishedDate)}
             </div>
           ) : latestVersion ? (
-            <div className="text-xs text-gray-600 dark:text-gray-400">
+            <div className="text-xs text-center text-gray-600 dark:text-gray-400">
               Created: {formatDate(latestVersion.date_created)}
             </div>
           ) : null}
 
           {activityTime ? (
-            <div className="mt-2 flex flex-wrap gap-2 justify-start w-full">
+            <div className="mt-2 flex flex-wrap gap-2 justify-center w-full">
               <primitives.Chip
                 className="text-gray-500 border-[1px] border-gray-200 dark:border-gray-500 dark:text-gray-500"
                 title={`Last activity was ${activityTime}`}

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -62,9 +62,9 @@ export function WorkListItem({
     <div className="px-6 py-4">
       <div className="flex flex-col gap-1 items-start md:gap-6 md:flex-row">
         {/* Column 1: Title, Authors, DOI Links */}
-        <div className="flex flex-col flex-grow gap-1">
-          <div className="flex flex-wrap gap-2 items-start">
-            <h3 className="font-normal leading-tight transition-colors line-clamp-2">
+        <div className="flex flex-col flex-grow gap-1 min-w-0">
+          <div className="flex flex-col gap-1 w-full sm:flex-row sm:items-end sm:gap-4">
+            <h3 className="min-w-0 flex-1 font-normal leading-tight transition-colors line-clamp-2">
               <Link
                 to={`${work.id}`}
                 className="text-blue-600 hover:text-blue-800 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
@@ -72,6 +72,15 @@ export function WorkListItem({
                 {latestVersion?.title || latestWorkVersion?.title || 'Untitled Work'}
               </Link>
             </h3>
+            {publishedDate ? (
+              <div className="shrink-0 text-xs text-gray-600 dark:text-gray-400">
+                Published: {formatDate(publishedDate)}
+              </div>
+            ) : latestVersion ? (
+              <div className="shrink-0 text-xs text-gray-600 dark:text-gray-400">
+                Created: {formatDate(latestVersion.date_created)}
+              </div>
+            ) : null}
           </div>
 
           <div className="flex flex-wrap gap-1 text-sm text-gray-600 dark:text-gray-400">
@@ -167,8 +176,8 @@ export function WorkListItem({
           ) : null}
         </div>
 
-        {/* Column 2: Activity and Date */}
-        <div className="flex flex-col flex-shrink-0 items-start self-stretch w-48 pt-[1px]">
+        {/* Column 2: Activity and timeline */}
+        <div className="flex flex-col flex-shrink-0 items-start self-stretch w-48">
           <div className="flex flex-wrap gap-2 justify-start mb-2 w-full">
             {activityTime && (
               <primitives.Chip
@@ -179,17 +188,6 @@ export function WorkListItem({
               </primitives.Chip>
             )}
           </div>
-
-          {publishedDate && (
-            <div className="text-xs text-gray-600 dark:text-gray-400">
-              Published: {formatDate(publishedDate)}
-            </div>
-          )}
-          {!publishedDate && latestVersion && (
-            <div className="text-xs text-gray-600 dark:text-gray-400">
-              Created: {formatDate(latestVersion.date_created)}
-            </div>
-          )}
 
           {work.versions.length > 1 ? (
             <WorkVersionTimelineHoverCard

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -191,22 +191,24 @@ export function WorkListItem({
             </div>
           )}
 
-          <WorkVersionTimelineHoverCard
-            versionsUrl={workVersionsUrl}
-            workId={work.id}
-            checkServices={hasChecksFeature ? checkServices : []}
-            align="end"
-            side="left"
-            title="Work Timeline"
-          >
-            <button
-              type="button"
-              className="mt-2 inline-flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400"
+          {work.versions.length > 1 ? (
+            <WorkVersionTimelineHoverCard
+              versionsUrl={workVersionsUrl}
+              workId={work.id}
+              checkServices={hasChecksFeature ? checkServices : []}
+              align="end"
+              side="left"
+              title="Work Timeline"
             >
-              <Timeline className="size-3.5 shrink-0" aria-hidden />
-              Timeline
-            </button>
-          </WorkVersionTimelineHoverCard>
+              <button
+                type="button"
+                className="mt-2 inline-flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400"
+              >
+                <Timeline className="size-3.5 shrink-0" aria-hidden />
+                Timeline
+              </button>
+            </WorkVersionTimelineHoverCard>
+          ) : null}
         </div>
       </div>
     </div>

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -63,9 +63,9 @@ export function WorkListItem({
     <div className="px-6 py-4">
       <div className="flex flex-col gap-1 items-start md:gap-6 md:flex-row">
         {/* Column 1: Title, Authors, DOI Links */}
-        <div className="flex flex-col flex-grow gap-1 min-w-0">
-          <div className="flex flex-col gap-1 w-full sm:flex-row sm:items-end sm:gap-4">
-            <h3 className="min-w-0 flex-1 font-normal leading-tight transition-colors line-clamp-2">
+        <div className="flex flex-col flex-grow gap-1">
+          <div className="flex flex-wrap gap-2 items-start">
+            <h3 className="font-normal leading-tight transition-colors line-clamp-2">
               <Link
                 to={`${work.id}`}
                 className="text-blue-600 hover:text-blue-800 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
@@ -73,15 +73,6 @@ export function WorkListItem({
                 {latestVersion?.title || latestWorkVersion?.title || 'Untitled Work'}
               </Link>
             </h3>
-            {publishedDate ? (
-              <div className="shrink-0 text-xs text-gray-600 dark:text-gray-400">
-                Published: {formatDate(publishedDate)}
-              </div>
-            ) : latestVersion ? (
-              <div className="shrink-0 text-xs text-gray-600 dark:text-gray-400">
-                Created: {formatDate(latestVersion.date_created)}
-              </div>
-            ) : null}
           </div>
 
           <div className="flex flex-wrap gap-1 text-sm text-gray-600 dark:text-gray-400">
@@ -177,8 +168,8 @@ export function WorkListItem({
           ) : null}
         </div>
 
-        {/* Column 2: Activity and timeline */}
-        <div className="flex flex-col flex-shrink-0 items-start self-stretch w-48">
+        {/* Column 2: Activity and date */}
+        <div className="flex flex-col flex-shrink-0 items-start self-stretch w-48 pt-[1px]">
           <div className="flex flex-wrap gap-2 justify-start mb-2 w-full">
             {activityTime && (
               <primitives.Chip
@@ -189,6 +180,17 @@ export function WorkListItem({
               </primitives.Chip>
             )}
           </div>
+
+          {publishedDate && (
+            <div className="text-xs text-gray-600 dark:text-gray-400">
+              Published: {formatDate(publishedDate)}
+            </div>
+          )}
+          {!publishedDate && latestVersion && (
+            <div className="text-xs text-gray-600 dark:text-gray-400">
+              Created: {formatDate(latestVersion.date_created)}
+            </div>
+          )}
 
           {work.versions.length > 1 ? (
             <WorkVersionTimelineHoverCard

--- a/platform/scms/app/routes/app/works._index/WorkListItem.tsx
+++ b/platform/scms/app/routes/app/works._index/WorkListItem.tsx
@@ -168,29 +168,28 @@ export function WorkListItem({
           ) : null}
         </div>
 
-        {/* Column 2: Activity and date */}
+        {/* Column 2: Date, activity, timeline */}
         <div className="flex flex-col flex-shrink-0 items-start self-stretch w-48 pt-[1px]">
-          <div className="flex flex-wrap gap-2 justify-start mb-2 w-full">
-            {activityTime && (
+          {publishedDate ? (
+            <div className="text-xs text-gray-600 dark:text-gray-400">
+              Published: {formatDate(publishedDate)}
+            </div>
+          ) : latestVersion ? (
+            <div className="text-xs text-gray-600 dark:text-gray-400">
+              Created: {formatDate(latestVersion.date_created)}
+            </div>
+          ) : null}
+
+          {activityTime ? (
+            <div className="mt-2 flex flex-wrap gap-2 justify-start w-full">
               <primitives.Chip
                 className="text-gray-500 border-[1px] border-gray-200 dark:border-gray-500 dark:text-gray-500"
                 title={`Last activity was ${activityTime}`}
               >
                 Activity {activityTime}
               </primitives.Chip>
-            )}
-          </div>
-
-          {publishedDate && (
-            <div className="text-xs text-gray-600 dark:text-gray-400">
-              Published: {formatDate(publishedDate)}
             </div>
-          )}
-          {!publishedDate && latestVersion && (
-            <div className="text-xs text-gray-600 dark:text-gray-400">
-              Created: {formatDate(latestVersion.date_created)}
-            </div>
-          )}
+          ) : null}
 
           {work.versions.length > 1 ? (
             <WorkVersionTimelineHoverCard

--- a/platform/scms/app/routes/app/works._index/db.server.ts
+++ b/platform/scms/app/routes/app/works._index/db.server.ts
@@ -37,6 +37,12 @@ export async function dbGetWorksAndSubmissionVersions(userId: string, config: Ap
           role: true,
         },
       },
+      activity: {
+        orderBy: {
+          date_created: 'desc',
+        },
+        take: 1,
+      },
       submissions: {
         include: {
           site: true,

--- a/prisma/schema/activity.prisma
+++ b/prisma/schema/activity.prisma
@@ -84,4 +84,7 @@ model Activity {
   /// Powers the submissions-index listing "last activity" lookup:
   ///   `activity: { take: 1, orderBy: { date_created: 'desc' } }` per submission row.
   @@index([submission_id, date_created(sort: Desc)])
+  /// Powers the works-index listing "last activity" lookup:
+  ///   `activity: { take: 1, orderBy: { date_created: 'desc' } }` per work row.
+  @@index([work_id, date_created(sort: Desc)])
 }

--- a/prisma/schema/migrations/20260708120000_add_activity_work_id_listing_index/migration.sql
+++ b/prisma/schema/migrations/20260708120000_add_activity_work_id_listing_index/migration.sql
@@ -1,0 +1,9 @@
+-- Composite index powering the works-index listing "last activity" lookup:
+--   `activity: { take: 1, orderBy: { date_created: 'desc' } }` per work row.
+--
+-- IF NOT EXISTS mirrors the listing lookup index migrations: Prisma also
+-- declares this index from the schema edit, so the migration is robust to
+-- whichever side runs first.
+
+CREATE INDEX IF NOT EXISTS "Activity_work_id_date_created_idx"
+  ON "Activity" (work_id, date_created DESC);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Submit-to-site check aggregation changes what users see before submission; the new Activity index is a schema migration but read-path only for listings.
> 
> **Overview**
> Fixes **submit-to-site** check review so each service kind shows the latest run on the **selected version or any older version** (never newer), with a **`v{n}` badge** when that run lives on another version. The version picker and check rows use shared **`VersionTagBadge`** / **`buildWorkVersionNumberByIdMap`** (`v1` = oldest), truncated status badges get tooltips, and the send control is a **ghost button** with a primary icon.
> 
> **Shared timeline UX** (`scms-core`): compact version badges on hover-card rows, clearer stacking of dates vs site/check chips, softer site chip rings, and **content-sized** popover widths. Work-details timeline headers gain **`v{n}`** badges; the versions API adds **`versionNumber`** on timeline entries.
> 
> **My Works** listing: the activity chip reflects the latest **work- or submission-level** event, the right column is **date → activity → timeline** (centered), and the timeline link appears only when there are **multiple versions**. Adds an **`Activity (work_id, date_created)`** index and loads the latest work activity in the listing query.
> 
> Check run row types move to **`checkServiceRun.shared`** for client-safe reuse; summary logic is covered by an updated test for the submit version cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7f7bfbfece0f002021c59092ecee83ed8f66d65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->