### PR TITLE
🎨 smaller UX fixes

### DIFF
--- a/.changeset/submission-timeline-exclude-drafts.md
+++ b/.changeset/submission-timeline-exclude-drafts.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-sites-ext': patch
+---
+
+Exclude DRAFT submission versions from the submission version timeline hover card API so My Works and site submission listings no longer show draft entries in the site submission popover.

--- a/.changeset/tooltip-hover-timing.md
+++ b/.changeset/tooltip-hover-timing.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-core': patch
+---
+
+Raise default tooltip and hover-card open delays to 800ms so works-area hover hints and timeline popovers are less sensitive.

--- a/.changeset/upload-form-responsive-ux.md
+++ b/.changeset/upload-form-responsive-ux.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-core': patch
+'@curvenote/scms': patch
+---
+
+Upload form polish: lay out upload check option cards in a single column below the `sm` breakpoint, and show the thumbnail row/grid layout toggle only when the gallery overflows in row mode.

--- a/.changeset/works-checks-page-ux.md
+++ b/.changeset/works-checks-page-ux.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-core': patch
+'@curvenote/scms': patch
+---
+
+Improve the work checks page. Show `v{n}` version badges on timeline headers, latest-run card footers, and the Check Latest Version button; order check sections alphabetically by extension name; compute the latest version number in the loader so the CTA no longer falls back to `v0`; and tighten activity card padding. Add `sortExtensionCheckServicesByExtensionName` in core for stable section ordering.

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.spec.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.spec.ts
@@ -95,6 +95,37 @@ describe('dbLoadSubmissionVersionsTimeline', () => {
     ]);
   });
 
+  it('excludes DRAFT submission versions from the timeline payload', async () => {
+    const { dbLoadSubmissionVersionsTimeline } = await import('./db.server.js');
+    mockPrisma.submission.findFirst.mockResolvedValue({
+      collection: { workflow: 'SIMPLE' },
+      versions: [
+        {
+          id: 'v-failed',
+          date_created: '2026-07-10T00:00:00.000Z',
+          date_modified: '2026-07-10T00:00:00.000Z',
+          date_published: null,
+          status: 'DEPOSIT_FAILED',
+          tags: [],
+        },
+      ],
+    });
+
+    const result = await dbLoadSubmissionVersionsTimeline(ctx, 'sub-1');
+
+    expect(result).toHaveLength(1);
+    expect(result?.[0]?.id).toBe('v-failed');
+    expect(mockPrisma.submission.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          versions: expect.objectContaining({
+            where: { status: { not: 'DRAFT' } },
+          }),
+        }),
+      }),
+    );
+  });
+
   it('issues a single tenancy-scoped query with nested versions ordered desc', async () => {
     const { dbLoadSubmissionVersionsTimeline } = await import('./db.server.js');
     mockPrisma.submission.findFirst.mockResolvedValue({
@@ -110,6 +141,7 @@ describe('dbLoadSubmissionVersionsTimeline', () => {
       select: {
         collection: { select: { workflow: true } },
         versions: {
+          where: { status: { not: 'DRAFT' } },
           orderBy: { date_created: 'desc' },
           select: {
             id: true,

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/db.server.ts
@@ -4,7 +4,9 @@ import { firstVersionTag } from '../$siteName.submissions._index/index.versions.
 import type { VersionTimelineEntry } from '@curvenote/scms-core';
 
 /**
- * All submission versions for the version-timeline hover card (newest first).
+ * Non-draft submission versions for the version-timeline hover card (newest first).
+ * Draft versions are excluded so listing badges and hover popovers stay consistent
+ * with the My Works rule of not surfacing draft submission state.
  *
  * Single Prisma call:
  *   - Submission lookup is tenancy-scoped (`id` + `site_id`) — PK lookup with a
@@ -28,6 +30,7 @@ export async function dbLoadSubmissionVersionsTimeline(
     select: {
       collection: { select: { workflow: true } },
       versions: {
+        where: { status: { not: 'DRAFT' } },
         orderBy: { date_created: 'desc' },
         select: {
           id: true,

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/route.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId.versions/route.ts
@@ -13,7 +13,7 @@ import { dbLoadSubmissionVersionsTimeline } from './db.server.js';
  *
  * JSON-only, no default export. Contract:
  *   GET /app/sites/:siteName/submissions/:submissionId/versions
- *     200 -> TrimmedVersionTimeline<VersionTimelineEntry>   (newest first, max 8 visible)
+ *     200 -> TrimmedVersionTimeline<VersionTimelineEntry>   (non-draft, newest first, max 8 visible)
  *     400 -> { error }                              (missing route param)
  *     401/403 -> auth/scope failure (NOT a redirect — see below)
  *     404 -> { error: 'Submission not found' }      (cross-site or unknown id)

--- a/package-lock.json
+++ b/package-lock.json
@@ -43296,6 +43296,16 @@
         "typescript": "^5.7.0"
       }
     },
+    "platform/relay/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "platform/relay/node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -43307,6 +43317,13 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "platform/relay/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "platform/scms": {
       "name": "@curvenote/scms",

--- a/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
+++ b/packages/scms-core/src/components/VersionTimelineHoverCard.tsx
@@ -157,7 +157,7 @@ export function VersionTimelineHoverCard<T extends { id: string }>({
   const { data, loading, error } = useVersionTimeline<T>(versionsUrl, { open });
 
   return (
-    <HoverCard open={open} onOpenChange={setOpen} openDelay={400} closeDelay={100}>
+    <HoverCard open={open} onOpenChange={setOpen} closeDelay={100}>
       <HoverCardTrigger asChild>
         <span className="inline-flex cursor-default transition-[filter] duration-150 hover:brightness-[0.97] dark:hover:brightness-[1.06]">
           {children}

--- a/packages/scms-core/src/components/ui/hover-card.tsx
+++ b/packages/scms-core/src/components/ui/hover-card.tsx
@@ -3,10 +3,18 @@ import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
 
 import { cn } from '../../utils/cn.js';
 
+/** Default hover delay before hover cards open (ms). */
+export const DEFAULT_HOVER_CARD_OPEN_DELAY_MS = 800;
+
 const floatingPanelShadowClass =
   'shadow-[0_1px_3px_rgba(27,31,36,0.08),0_8px_24px_rgba(140,149,159,0.2)] dark:shadow-[0_1px_3px_rgba(0,0,0,0.4),0_8px_24px_rgba(0,0,0,0.5)]';
 
-const HoverCard = HoverCardPrimitive.Root;
+function HoverCard({
+  openDelay = DEFAULT_HOVER_CARD_OPEN_DELAY_MS,
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
+  return <HoverCardPrimitive.Root openDelay={openDelay} {...props} />;
+}
 
 const HoverCardTrigger = HoverCardPrimitive.Trigger;
 

--- a/packages/scms-core/src/components/ui/tooltip.tsx
+++ b/packages/scms-core/src/components/ui/tooltip.tsx
@@ -4,8 +4,11 @@ import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { cn } from '../../utils/cn.js';
 import { InfoIcon } from 'lucide-react';
 
+/** Default hover delay before Radix tooltips open (ms). */
+export const DEFAULT_TOOLTIP_DELAY_MS = 800;
+
 function TooltipProvider({
-  delayDuration = 0,
+  delayDuration = DEFAULT_TOOLTIP_DELAY_MS,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
   return (
@@ -17,7 +20,10 @@ function TooltipProvider({
   );
 }
 
-function Tooltip({ delayDuration, ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+function Tooltip({
+  delayDuration = DEFAULT_TOOLTIP_DELAY_MS,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
   return (
     <TooltipProvider delayDuration={delayDuration}>
       <TooltipPrimitive.Root data-slot="tooltip" {...props} />
@@ -74,7 +80,7 @@ function SimpleTooltip({
   title,
   side,
   sideOffset,
-  delayDuration = 100,
+  delayDuration = DEFAULT_TOOLTIP_DELAY_MS,
   children,
   asChild = true,
   className,
@@ -103,7 +109,7 @@ function SimpleTooltipWithIcon({
   title,
   side,
   sideOffset,
-  delayDuration = 100,
+  delayDuration = DEFAULT_TOOLTIP_DELAY_MS,
 }: {
   title: string;
   side?: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>['side'];

--- a/packages/scms-core/src/components/upload/WorkFileCard.tsx
+++ b/packages/scms-core/src/components/upload/WorkFileCard.tsx
@@ -190,7 +190,7 @@ function RemoveButton({
       onSubmit={removeFile}
       className="absolute -top-2 -right-2"
     >
-      <SimpleTooltip title="Delete file" side="right" sideOffset={10} delayDuration={250}>
+      <SimpleTooltip title="Delete file" side="right" sideOffset={10}>
         <button
           type="submit"
           className="p-1.5 bg-stone-100 border border-stone-400 dark:bg-stone-600 dark:border-stone-600 rounded-full hover:bg-stone-50 dark:hover:bg-stone-500 shadow-sm z-20 cursor-pointer"

--- a/packages/scms-core/src/components/upload/uploadCheckCardStyles.ts
+++ b/packages/scms-core/src/components/upload/uploadCheckCardStyles.ts
@@ -1,7 +1,7 @@
 import { cn } from '../../utils/cn.js';
 
-/** Upload checks section: two columns at all breakpoints (section is wide; avoids md: SSR flash). */
-export const UPLOAD_CHECKS_GRID_CLASS = 'grid grid-cols-2 items-stretch gap-4';
+/** Upload checks section: one column on narrow viewports, two from `sm` up. */
+export const UPLOAD_CHECKS_GRID_CLASS = 'grid grid-cols-1 items-stretch gap-4 sm:grid-cols-2';
 
 /** Selected / unselected card chrome aligned with wizard option cards. */
 export function uploadCheckCardClassName({

--- a/packages/scms-core/src/modules/extensions/checks.spec.ts
+++ b/packages/scms-core/src/modules/extensions/checks.spec.ts
@@ -9,6 +9,7 @@ import {
   isCheckWorkListSummaryVisible,
   resolveExtensionDesignLoaderData,
   resolveUploadCheckLogoUrls,
+  sortExtensionCheckServicesByExtensionName,
 } from './checks.js';
 import type { ClientExtension, ServerExtension } from './types.js';
 import type { Context } from '../../backend/types.js';
@@ -84,6 +85,65 @@ describe('extension checks config gates', () => {
       mockCheckExtension as ServerExtension,
     ]);
     expect(services).toEqual([]);
+  });
+});
+
+describe('sortExtensionCheckServicesByExtensionName', () => {
+  const zebraExtension = {
+    id: 'zebra-checks',
+    name: 'Zebra Checks',
+    description: 'Test',
+    registerNavigation: () => [],
+    getChecks: () => [
+      {
+        id: 'zebra-service',
+        name: 'Zebra Service',
+        description: 'Runs zebra checks',
+        sectionHeaderComponent: noopCheckComponent,
+        sectionActivityComponent: noopCheckComponent,
+      },
+    ],
+  } satisfies ClientExtension;
+
+  const alphaExtension = {
+    id: 'alpha-checks',
+    name: 'Alpha Checks',
+    description: 'Test',
+    registerNavigation: () => [],
+    getChecks: () => [
+      {
+        id: 'alpha-service',
+        name: 'Alpha Service',
+        description: 'Runs alpha checks',
+        sectionHeaderComponent: noopCheckComponent,
+        sectionActivityComponent: noopCheckComponent,
+      },
+    ],
+  } satisfies ClientExtension;
+
+  it('orders check services alphabetically by extension name', () => {
+    const services = [
+      {
+        id: 'zebra-service',
+        name: 'Zebra Service',
+        description: 'Runs zebra checks',
+        sectionHeaderComponent: noopCheckComponent,
+        sectionActivityComponent: noopCheckComponent,
+      },
+      {
+        id: 'alpha-service',
+        name: 'Alpha Service',
+        description: 'Runs alpha checks',
+        sectionHeaderComponent: noopCheckComponent,
+        sectionActivityComponent: noopCheckComponent,
+      },
+    ];
+
+    expect(
+      sortExtensionCheckServicesByExtensionName(services, [zebraExtension, alphaExtension]).map(
+        (service) => service.id,
+      ),
+    ).toEqual(['alpha-service', 'zebra-service']);
   });
 });
 

--- a/packages/scms-core/src/modules/extensions/checks.ts
+++ b/packages/scms-core/src/modules/extensions/checks.ts
@@ -78,6 +78,35 @@ export function getExtensionCheckServicesFromServerConfig(
   return services;
 }
 
+type ExtensionWithCheckServices = Pick<ClientExtension, 'id' | 'name' | 'getChecks'>;
+
+/**
+ * Stable display order for check sections — alphabetical by owning extension name,
+ * then by check service display name when one extension registers multiple services.
+ */
+export function sortExtensionCheckServicesByExtensionName(
+  services: ExtensionCheckService[],
+  extensions: ExtensionWithCheckServices[],
+): ExtensionCheckService[] {
+  const extensionNameByServiceId = new Map<string, string>();
+  for (const ext of extensions) {
+    if (!ext.getChecks) continue;
+    for (const service of ext.getChecks()) {
+      extensionNameByServiceId.set(service.id, ext.name);
+    }
+  }
+
+  return [...services].sort((a, b) => {
+    const extensionNameA = extensionNameByServiceId.get(a.id) ?? a.name;
+    const extensionNameB = extensionNameByServiceId.get(b.id) ?? b.name;
+    const byExtension = extensionNameA.localeCompare(extensionNameB, undefined, {
+      sensitivity: 'base',
+    });
+    if (byExtension !== 0) return byExtension;
+    return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+  });
+}
+
 /**
  * Get a specific check service by ID from enabled extensions.
  */

--- a/platform/scms/app/routes/app/works.$workId.checks/RunCheckOnLatestVersionButton.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/RunCheckOnLatestVersionButton.tsx
@@ -1,5 +1,5 @@
 import { useFetcher } from 'react-router';
-import { ShieldCheck } from 'lucide-react';
+import { GitBranch } from 'lucide-react';
 import { ui, useCheckMaintenanceBlocked } from '@curvenote/scms-core';
 
 type RunCheckOnLatestVersionButtonProps = {
@@ -8,6 +8,8 @@ type RunCheckOnLatestVersionButtonProps = {
   /** Latest non-draft work version id to run the check against. */
   workVersionId: string;
   checkServiceId: string;
+  /** 1-based version number for the target work version (shown in the button). */
+  versionNumber: number;
 };
 
 /**
@@ -19,6 +21,7 @@ export function RunCheckOnLatestVersionButton({
   actionPath,
   workVersionId,
   checkServiceId,
+  versionNumber,
 }: RunCheckOnLatestVersionButtonProps) {
   const fetcher = useFetcher();
   const isSubmitting = fetcher.state === 'submitting';
@@ -38,8 +41,13 @@ export function RunCheckOnLatestVersionButton({
           busy={isSubmitting}
           disabled={blocked}
         >
-          <span className="flex gap-1 items-center">
-            <ShieldCheck className="w-3 h-3" aria-hidden />
+          <span className="flex gap-1.5 items-center">
+            <ui.VersionTagBadge
+              tag={`v${versionNumber}`}
+              titlePrefix="Version"
+              icon={GitBranch}
+              compact
+            />
             Check Latest Version
           </span>
         </ui.StatefulButton>

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -18,6 +18,7 @@ import {
   httpError,
   scopes,
   getExtensionCheckServicesFromServerConfig,
+  sortExtensionCheckServicesByExtensionName,
   formatDateWithRecentTime,
   formatDatetime,
   buildWorkVersionNumberByIdMap,
@@ -174,28 +175,10 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
     { app: { extensions: extensionsConfig } } as unknown as AppConfig,
     extensions,
   );
-
-  // Order services: those with any run first (desc by latest run date_created),
-  // then services with no runs in original config order.
-  const sortedCheckServices = checkServices
-    .map((service, index) => ({
-      service,
-      index,
-      latestRunDateCreated: latestRunByServiceKind[service.id]?.run.date_created ?? null,
-    }))
-    .sort((a, b) => {
-      if (a.latestRunDateCreated != null && b.latestRunDateCreated != null) {
-        return a.latestRunDateCreated > b.latestRunDateCreated
-          ? -1
-          : a.latestRunDateCreated < b.latestRunDateCreated
-            ? 1
-            : 0;
-      }
-      if (a.latestRunDateCreated != null) return -1;
-      if (b.latestRunDateCreated != null) return 1;
-      return a.index - b.index;
-    })
-    .map(({ service }) => service);
+  const sortedCheckServices = sortExtensionCheckServicesByExtensionName(
+    checkServices,
+    extensions,
+  );
 
   const basePath = `/app/works/${work.id}`;
   const nonDraftVersions = (work.versions ?? []).filter((version) => !version.draft);

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -76,6 +76,8 @@ export async function loader(args: Route.LoaderArgs) {
     nonDraftVersions,
     runsByVersionId,
   );
+  const latestVersionNumber =
+    buildWorkVersionNumberByIdMap(nonDraftVersions)[latestNonDraftWorkVersion.id] ?? 0;
 
   // -------------------------------------------------------------------------
   // TEMPORARY (stepping-stone): service-manifest fallback for kinds with no run.
@@ -133,6 +135,7 @@ export async function loader(args: Route.LoaderArgs) {
     latestRunByServiceKind,
     previousRunsByServiceKind,
     manifestByServiceKind,
+    latestVersionNumber,
   };
 }
 
@@ -156,6 +159,7 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
     latestRunByServiceKind,
     previousRunsByServiceKind,
     manifestByServiceKind,
+    latestVersionNumber,
   } = loaderData;
   const location = useLocation();
   const revalidator = useRevalidator();
@@ -175,15 +179,9 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
     { app: { extensions: extensionsConfig } } as unknown as AppConfig,
     extensions,
   );
-  const sortedCheckServices = sortExtensionCheckServicesByExtensionName(
-    checkServices,
-    extensions,
-  );
+  const sortedCheckServices = sortExtensionCheckServicesByExtensionName(checkServices, extensions);
 
   const basePath = `/app/works/${work.id}`;
-  const nonDraftVersions = (work.versions ?? []).filter((version) => !version.draft);
-  const latestVersionNumber =
-    buildWorkVersionNumberByIdMap(nonDraftVersions)[latestNonDraftWorkVersion.id] ?? 0;
   const enabledCheckKinds = metadata.checks?.enabled ?? [];
   const enabledCheckKindSet = new Set<string>(enabledCheckKinds);
   const hasPendingLatestRun = enabledCheckKinds.some(

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -355,7 +355,7 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
               <HeaderComponent tag={null} action={headerAction} metadata={serviceMetadata} />
               <div className="space-y-0">
                 <ui.Card>
-                  <ui.CardContent className="pt-6">
+                  <ui.CardContent className="py-4">
                     <ActivityComponent
                       metadata={
                         serviceMetadata as WorkVersionMetadata &

--- a/platform/scms/app/routes/app/works.$workId.checks/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.checks/route.tsx
@@ -20,6 +20,7 @@ import {
   getExtensionCheckServicesFromServerConfig,
   formatDateWithRecentTime,
   formatDatetime,
+  buildWorkVersionNumberByIdMap,
   Timeline,
   TimelineSection,
   CheckServiceRunTimelineItem,
@@ -197,6 +198,9 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
     .map(({ service }) => service);
 
   const basePath = `/app/works/${work.id}`;
+  const nonDraftVersions = (work.versions ?? []).filter((version) => !version.draft);
+  const latestVersionNumber =
+    buildWorkVersionNumberByIdMap(nonDraftVersions)[latestNonDraftWorkVersion.id] ?? 0;
   const enabledCheckKinds = metadata.checks?.enabled ?? [];
   const enabledCheckKindSet = new Set<string>(enabledCheckKinds);
   const hasPendingLatestRun = enabledCheckKinds.some(
@@ -227,10 +231,20 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
     return () => window.clearInterval(interval);
   }, [showDispatchingState, revalidator]);
 
-  const renderWorkVersionDate = (
+  const renderVersionBadge = (
     entry: ServiceRunEntry,
-    { showBranchIcon = false }: { showBranchIcon?: boolean } = {},
-  ) => {
+    { compact = false }: { compact?: boolean } = {},
+  ) => (
+    <ui.VersionTagBadge
+      tag={`v${entry.versionNumber}`}
+      title={`Created at: ${formatDatetime(entry.versionDateCreated)}`}
+      titlePrefix="Version"
+      icon={GitBranch}
+      compact={compact}
+    />
+  );
+
+  const renderWorkVersionDate = (entry: ServiceRunEntry) => {
     const versionDate = formatDateWithRecentTime(entry.versionDateCreated);
     return (
       <ui.SimpleTooltip
@@ -240,7 +254,6 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
         delayDuration={1000}
       >
         <span className="inline-flex gap-1.5 items-center text-xs cursor-default text-muted-foreground">
-          {showBranchIcon ? <GitBranch className="size-3.5 shrink-0" aria-hidden /> : null}
           {versionDate}
         </span>
       </ui.SimpleTooltip>
@@ -249,6 +262,7 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
 
   const renderTimelineVersionLabel = (entry: ServiceRunEntry) => (
     <span className="inline-flex flex-wrap gap-y-1 gap-x-2 items-center">
+      {renderVersionBadge(entry)}
       {renderWorkVersionDate(entry)}
       <DateWithPopover
         date={entry.run.date_modified}
@@ -332,6 +346,7 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
                 actionPath={service.checksActionPath ?? `${basePath}/checks`}
                 workVersionId={latestNonDraftWorkVersion.id}
                 checkServiceId={service.id}
+                versionNumber={latestVersionNumber}
               />
             ) : null;
 
@@ -359,8 +374,9 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
                     />
                   </ui.CardContent>
                   {latest ? (
-                    <div className="flex justify-start py-1.5 pr-6 pl-3 border-t border-border">
-                      {renderWorkVersionDate(latest, { showBranchIcon: true })}
+                    <div className="flex gap-2 justify-start items-center py-1.5 pr-6 pl-3 border-t border-border">
+                      {renderVersionBadge(latest, { compact: true })}
+                      {renderWorkVersionDate(latest)}
                     </div>
                   ) : null}
                 </ui.Card>
@@ -370,6 +386,7 @@ export default function CheckMyWorkPage({ loaderData }: Route.ComponentProps) {
                       <TimelineSection
                         key={entry.workVersionId}
                         label={renderTimelineVersionLabel(entry)}
+                        icon={<span className="block size-5 shrink-0" aria-hidden />}
                         stacked
                       >
                         <CheckServiceRunTimelineItem

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Columns4, Image as ImageIcon, Check, LayoutGrid } from 'lucide-react';
 import { SectionWithHeading, cn, ui } from '@curvenote/scms-core';
 import { collectAllFigures } from './DocumentPreviewer';
@@ -32,6 +32,52 @@ const rowTileWidthClassName =
 
 const galleryLayoutToggleItemClassName =
   'px-1 bg-transparent text-muted-foreground/35 hover:bg-transparent hover:text-muted-foreground/50 data-[state=on]:bg-transparent data-[state=on]:text-foreground/70';
+
+/** Visible tile columns in row layout at each breakpoint (matches rowTileWidthClassName). */
+function rowGalleryColumnCount(containerWidth: number): number {
+  if (containerWidth >= 1024) return 5;
+  if (containerWidth >= 768) return 4;
+  if (containerWidth >= 640) return 3;
+  return 2;
+}
+
+function useRowGalleryOverflow({
+  tileCount,
+  layout,
+}: {
+  tileCount: number;
+  layout: ThumbnailGalleryLayout;
+}) {
+  const galleryRef = useRef<HTMLDivElement>(null);
+  const [overflows, setOverflows] = useState(false);
+
+  const measureOverflow = useCallback(() => {
+    const el = galleryRef.current;
+    if (!el || tileCount === 0) {
+      setOverflows(false);
+      return;
+    }
+
+    if (layout === 'row') {
+      setOverflows(el.scrollWidth > el.clientWidth + 1);
+      return;
+    }
+
+    setOverflows(tileCount > rowGalleryColumnCount(el.clientWidth));
+  }, [layout, tileCount]);
+
+  useLayoutEffect(() => {
+    measureOverflow();
+    const el = galleryRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(measureOverflow);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [measureOverflow]);
+
+  return { galleryRef, overflows };
+}
 
 function GalleryLayoutToggle({
   value,
@@ -197,6 +243,17 @@ export function ChooseThumbnailSection({
       : 'No figures were found in the current document previews.';
 
   const hasTiles = Boolean(pinnedThumbnail) || figures.length > 0;
+  const tileCount = (pinnedThumbnail ? 1 : 0) + figures.length;
+  const { galleryRef, overflows: rowGalleryOverflows } = useRowGalleryOverflow({
+    tileCount,
+    layout,
+  });
+
+  useLayoutEffect(() => {
+    if (!rowGalleryOverflows && layout === 'grid') {
+      setLayout('row');
+    }
+  }, [rowGalleryOverflows, layout]);
 
   return (
     <SectionWithHeading
@@ -214,14 +271,20 @@ export function ChooseThumbnailSection({
       ) : null}
       {hasTiles ? (
         <div className="relative">
-          <div className="absolute top-0 right-1 z-10">
-            <GalleryLayoutToggle value={layout} onChange={setLayout} />
-          </div>
+          {rowGalleryOverflows ? (
+            <div className="absolute top-0 right-1 z-10">
+              <GalleryLayoutToggle value={layout} onChange={setLayout} />
+            </div>
+          ) : null}
           <div
+            ref={galleryRef}
             className={cn(
               'items-center py-1 pt-2',
               layout === 'row'
-                ? 'flex overflow-x-auto overflow-y-hidden overscroll-x-contain gap-4 px-1 pr-14 [scrollbar-gutter:stable]'
+                ? cn(
+                    'flex overflow-x-auto overflow-y-hidden overscroll-x-contain gap-4 px-1 [scrollbar-gutter:stable]',
+                    rowGalleryOverflows && 'pr-14',
+                  )
                 : 'grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5',
             )}
           >


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly UI timing, layout, and read-path filtering for draft versions; checks ordering and version labels are presentation-only with a small, tested API contract change for timelines.
> 
> **Overview**
> This PR bundles several **works-area UX fixes** across listings, hover behavior, the checks page, and upload flows.
> 
> **Submission version timelines** no longer include **DRAFT** versions in the site submission versions API (`where: { status: { not: 'DRAFT' } }`), aligning My Works and site listing hover popovers with the rule of not surfacing draft submission state. Tests cover the filter and query shape.
> 
> **Tooltips and hover cards** default to an **800ms** open delay (`DEFAULT_TOOLTIP_DELAY_MS` / `DEFAULT_HOVER_CARD_OPEN_DELAY_MS`). The version timeline hover card drops its previous 400ms override so it follows the shared default.
> 
> **Work checks page**: sections sort **alphabetically by extension name** via new `sortExtensionCheckServicesByExtensionName` (replacing sort-by-latest-run-date). **`v{n}` version badges** appear on timeline headers, latest-run footers, and **Check Latest Version**; the loader computes **`latestVersionNumber`** so the CTA no longer shows **`v0`**. Activity card padding is tightened.
> 
> **Upload polish**: upload check option cards use **one column below `sm`**, two from `sm` up. The thumbnail gallery **row/grid toggle** only appears when the row layout **overflows** (measured with `ResizeObserver`), and extra right padding for the toggle is applied only in that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc902a6941f9c0e91a04faca860c8be1199c81c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->