### PR TITLE
🏈 SubmitTo #2

### DIFF
--- a/.changeset/extension-submit-to-site-pmc.md
+++ b/.changeset/extension-submit-to-site-pmc.md
@@ -1,7 +1,6 @@
 ---
 '@curvenote/scms-core': minor
 '@curvenote/scms': minor
-'@hhmi/pmc': minor
 ---
 
-Add extension-owned submit-to-site delegation. Extensions may declare operated sites and an optional `submitToSite` handler; core routes by declaration (delegate or fail, no fallback). PMC uses the hook to create a submission version on the current finalized work version and redirect to deposit intake without cloning a work version.
+Add extension-owned submit-to-site delegation. Extensions may declare operated sites and an optional `submitToSite` handler; core routes by declaration (delegate or fail, no fallback).

--- a/.changeset/extension-submit-to-site-pmc.md
+++ b/.changeset/extension-submit-to-site-pmc.md
@@ -1,0 +1,7 @@
+---
+'@curvenote/scms-core': minor
+'@curvenote/scms': minor
+'@hhmi/pmc': minor
+---
+
+Add extension-owned submit-to-site delegation. Extensions may declare operated sites and an optional `submitToSite` handler; core routes by declaration (delegate or fail, no fallback). PMC uses the hook to create a submission version on the current finalized work version and redirect to deposit intake without cloning a work version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -43296,6 +43296,16 @@
         "typescript": "^5.7.0"
       }
     },
+    "platform/relay/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "platform/relay/node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -43307,6 +43317,13 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "platform/relay/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "platform/scms": {
       "name": "@curvenote/scms",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43296,16 +43296,6 @@
         "typescript": "^5.7.0"
       }
     },
-    "platform/relay/node_modules/@types/node": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "platform/relay/node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -43317,13 +43307,6 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
-    },
-    "platform/relay/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "platform/scms": {
       "name": "@curvenote/scms",

--- a/packages/scms-core/src/modules/extensions/index.ts
+++ b/packages/scms-core/src/modules/extensions/index.ts
@@ -9,6 +9,7 @@ export * from './email-templates.js';
 export * from './icons.js';
 export * from './navigation.js';
 export * from './sanitize-admin-config.js';
+export * from './submitToSite.js';
 export * from './tasks.js';
 export * from './types.js';
 export * from './utils.js';

--- a/packages/scms-core/src/modules/extensions/submitToSite.test.ts
+++ b/packages/scms-core/src/modules/extensions/submitToSite.test.ts
@@ -48,6 +48,56 @@ describe('resolveSubmitToSiteExtension', () => {
     expect(resolveSubmitToSiteExtension(extensions, 'pmc')).toBe(pmc);
   });
 
+  it('returns undefined when submitToSite is declared without getOperatedSites', () => {
+    const extensions = [
+      extension({
+        id: 'pmc',
+        submitToSite: async () => ({ success: true }),
+      }),
+    ];
+
+    expect(resolveSubmitToSiteExtension(extensions, 'pmc')).toBeUndefined();
+  });
+
+  it('returns undefined when getOperatedSites returns null or undefined', () => {
+    const extensions = [
+      extension({
+        id: 'null-sites',
+        getOperatedSites: () => null as unknown as string[],
+        submitToSite: async () => ({ success: true }),
+      }),
+      extension({
+        id: 'undefined-sites',
+        getOperatedSites: () => undefined as unknown as string[],
+        submitToSite: async () => ({ success: true }),
+      }),
+    ];
+
+    expect(resolveSubmitToSiteExtension(extensions, 'pmc')).toBeUndefined();
+  });
+
+  it('does not throw when scanning extensions with missing or empty operated sites', () => {
+    const extensions = [
+      extension({
+        id: 'no-operated-sites',
+        submitToSite: async () => ({ success: true }),
+      }),
+      extension({
+        id: 'empty-operated-sites',
+        getOperatedSites: () => [],
+        submitToSite: async () => ({ success: true }),
+      }),
+      extension({
+        id: 'pmc',
+        getOperatedSites: () => ['pmc'],
+        submitToSite: async () => ({ success: true, submissionVersionId: 'sv-1' }),
+      }),
+    ];
+
+    expect(() => resolveSubmitToSiteExtension(extensions, 'pmc')).not.toThrow();
+    expect(resolveSubmitToSiteExtension(extensions, 'pmc')?.id).toBe('pmc');
+  });
+
   it('returns the first matching extension when multiple declare the same site', () => {
     const first = extension({
       id: 'first',

--- a/packages/scms-core/src/modules/extensions/submitToSite.test.ts
+++ b/packages/scms-core/src/modules/extensions/submitToSite.test.ts
@@ -1,0 +1,65 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import { resolveSubmitToSiteExtension } from './submitToSite.js';
+import type { ServerExtension } from './types.js';
+
+function extension(partial: Partial<ServerExtension>): ServerExtension {
+  return {
+    id: partial.id ?? 'ext',
+    name: partial.name ?? 'Extension',
+    description: partial.description ?? 'Test extension',
+    registerNavigation: partial.registerNavigation ?? (() => []),
+    ...partial,
+  };
+}
+
+describe('resolveSubmitToSiteExtension', () => {
+  it('returns undefined when no extension operates the site', () => {
+    const extensions = [
+      extension({
+        id: 'other',
+        getOperatedSites: () => ['other-site'],
+        submitToSite: async () => ({ success: true }),
+      }),
+    ];
+
+    expect(resolveSubmitToSiteExtension(extensions, 'pmc')).toBeUndefined();
+  });
+
+  it('returns undefined when an extension operates the site but declares no submit handler', () => {
+    const extensions = [
+      extension({
+        id: 'pmc',
+        getOperatedSites: () => ['pmc'],
+      }),
+    ];
+
+    expect(resolveSubmitToSiteExtension(extensions, 'pmc')).toBeUndefined();
+  });
+
+  it('returns the extension when it operates the site and declares submitToSite', () => {
+    const pmc = extension({
+      id: 'pmc',
+      getOperatedSites: () => ['pmc'],
+      submitToSite: async () => ({ success: true, submissionVersionId: 'sv-1' }),
+    });
+    const extensions = [pmc];
+
+    expect(resolveSubmitToSiteExtension(extensions, 'pmc')).toBe(pmc);
+  });
+
+  it('returns the first matching extension when multiple declare the same site', () => {
+    const first = extension({
+      id: 'first',
+      getOperatedSites: () => ['pmc'],
+      submitToSite: async () => ({ success: true }),
+    });
+    const second = extension({
+      id: 'second',
+      getOperatedSites: () => ['pmc'],
+      submitToSite: async () => ({ success: true }),
+    });
+
+    expect(resolveSubmitToSiteExtension([first, second], 'pmc')).toBe(first);
+  });
+});

--- a/packages/scms-core/src/modules/extensions/submitToSite.ts
+++ b/packages/scms-core/src/modules/extensions/submitToSite.ts
@@ -1,0 +1,15 @@
+import type { ServerExtension } from './types.js';
+
+/**
+ * Resolves the extension that owns submit-to-site for a site.
+ * Requires both `getOperatedSites` (site match) and a declared `submitToSite` handler.
+ * Extensions that operate a site but omit `submitToSite` use the central route instead.
+ */
+export function resolveSubmitToSiteExtension(
+  extensions: ServerExtension[],
+  siteName: string,
+): ServerExtension | undefined {
+  return extensions.find(
+    (extension) => !!extension.submitToSite && !!extension.getOperatedSites?.().includes(siteName),
+  );
+}

--- a/packages/scms-core/src/modules/extensions/submitToSite.ts
+++ b/packages/scms-core/src/modules/extensions/submitToSite.ts
@@ -10,6 +10,6 @@ export function resolveSubmitToSiteExtension(
   siteName: string,
 ): ServerExtension | undefined {
   return extensions.find(
-    (extension) => !!extension.submitToSite && !!extension.getOperatedSites?.().includes(siteName),
+    (extension) => !!extension.submitToSite && !!extension.getOperatedSites?.()?.includes(siteName),
   );
 }

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -68,6 +68,22 @@ export interface ExtensionCreateWorkVersionResult {
   error?: string;
 }
 
+export interface ExtensionSubmitToSiteArgs {
+  ctx: Context;
+  workId: string;
+  /** Current finalized work version being submitted — never cloned. */
+  workVersionId: string;
+  siteName: string;
+}
+
+export interface ExtensionSubmitToSiteResult {
+  success: boolean;
+  submissionVersionId?: string;
+  /** Where to send the user for extension-specific intake/confirm. */
+  redirectPath?: string;
+  error?: string;
+}
+
 export interface ExtensionIcon {
   id: string;
   component: IconComponent;
@@ -409,6 +425,16 @@ export interface ServerExtension extends ClientExtension {
   createWorkVersion?: (
     args: ExtensionCreateWorkVersionArgs,
   ) => Promise<ExtensionCreateWorkVersionResult | null>;
+  /**
+   * Site names this extension operates (routes, config, UI). Operating a site does not imply a
+   * custom submission flow — omit `submitToSite` to use the central submit-to-site route.
+   */
+  getOperatedSites?: () => string[];
+  /**
+   * Optional opt-in: when present together with `getOperatedSites`, this extension owns submit-to-site
+   * for those sites. Must resolve success/failure; never returns null to fall back to core.
+   */
+  submitToSite?: (args: ExtensionSubmitToSiteArgs) => Promise<ExtensionSubmitToSiteResult>;
   getJobs?: () => JobRegistration[];
   /**
    * Returns the effective configuration for this extension.

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -433,6 +433,10 @@ export interface ServerExtension extends ClientExtension {
   /**
    * Optional opt-in: when present together with `getOperatedSites`, this extension owns submit-to-site
    * for those sites. Must resolve success/failure; never returns null to fall back to core.
+   *
+   * Core serializes concurrent invocations for the same work+site with an advisory lock, so a
+   * double submit will not run two handlers at once. Implementations should still be idempotent
+   * (re-check for an existing submission/version and reuse it) rather than unconditionally creating.
    */
   submitToSite?: (args: ExtensionSubmitToSiteArgs) => Promise<ExtensionSubmitToSiteResult>;
   getJobs?: () => JobRegistration[];

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -322,10 +322,11 @@ export function SubmittedToBar({
   );
 
   useEffect(() => {
-    if (fetcher.state !== 'idle' || !fetcher.data) return;
-    // Settled: release the click guard on any response (even one without an intent,
-    // e.g. an invalid-form-data error) so a failed submit can be retried.
+    if (fetcher.state !== 'idle') return;
+    // Settled: release the click guard even when there is no response body (e.g. network
+    // error on first attempt) so a failed submit can be retried.
     submitLockRef.current = false;
+    if (!fetcher.data) return;
     // The fetcher only posts submit-to-site, so an error response belongs to this
     // submit even when it carries no intent (e.g. invalid form data).
     const errorMessage = getErrorMessage(fetcher.data);

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -257,6 +257,8 @@ export function SubmittedToBar({
 }) {
   const navigate = useNavigate();
   const fetcher = useFetcher<SubmitToSiteFetcherData>();
+  // Synchronous guard closing the double-click window before `disabled` re-renders.
+  const submitLockRef = useRef(false);
   const [versionDropdownOpen, setVersionDropdownOpen] = useState(false);
   const versionNumberByVersionId = useMemo(
     () => buildWorkVersionNumberByIdMap(versions),
@@ -320,6 +322,8 @@ export function SubmittedToBar({
 
   useEffect(() => {
     if (fetcher.state !== 'idle' || fetcher.data?.intent !== 'submit-to-site') return;
+    // Settled: release the click guard so a failed submit can be retried.
+    submitLockRef.current = false;
     const errorMessage = getErrorMessage(fetcher.data);
     if (errorMessage) {
       ui.toastError(errorMessage);
@@ -630,10 +634,10 @@ export function SubmittedToBar({
                           site.name,
                         );
                         const isBusy = isCurrentSiteSubmitting;
+                        // Disable every site button (including the one just clicked) while any
+                        // submit is in flight so a double-click cannot trigger a second submission.
                         const isDisabled =
-                          !hasCompletedVersions ||
-                          alreadySubmitted ||
-                          (isSubmitting && !isCurrentSiteSubmitting);
+                          !hasCompletedVersions || alreadySubmitted || isSubmitting;
                         return (
                           <button
                             key={site.id}
@@ -642,6 +646,13 @@ export function SubmittedToBar({
                             value={site.name}
                             disabled={isDisabled}
                             aria-busy={isBusy || undefined}
+                            onClick={(event) => {
+                              if (submitLockRef.current) {
+                                event.preventDefault();
+                                return;
+                              }
+                              submitLockRef.current = true;
+                            }}
                             className={cn(
                               'flex gap-3 items-start p-2 w-full text-left rounded-md transition-colors',
                               'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -325,11 +325,18 @@ export function SubmittedToBar({
       ui.toastError(errorMessage);
       return;
     }
-    if (fetcher.data.success && fetcher.data.siteName && fetcher.data.submissionVersionId) {
-      const redirectPath =
-        fetcher.data.redirectPath ??
-        `${basePath}/site/${fetcher.data.siteName}/submission/${fetcher.data.submissionVersionId}`;
-      navigate(redirectPath);
+    if (fetcher.data.success) {
+      const { redirectPath, siteName, submissionVersionId } = fetcher.data;
+      const target =
+        redirectPath ??
+        (siteName && submissionVersionId
+          ? `${basePath}/site/${siteName}/submission/${submissionVersionId}`
+          : undefined);
+      if (target) {
+        navigate(target);
+      } else {
+        ui.toastError('Submission succeeded but no destination was provided');
+      }
     }
   }, [basePath, fetcher.data, fetcher.state, navigate]);
 

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -633,7 +633,6 @@ export function SubmittedToBar({
                         const alreadySubmitted = submittedSiteNamesForSelectedVersion.has(
                           site.name,
                         );
-                        const isBusy = isCurrentSiteSubmitting;
                         // Disable every site button (including the one just clicked) while any
                         // submit is in flight so a double-click cannot trigger a second submission.
                         const isDisabled =
@@ -645,7 +644,7 @@ export function SubmittedToBar({
                             name="siteName"
                             value={site.name}
                             disabled={isDisabled}
-                            aria-busy={isBusy || undefined}
+                            aria-busy={isCurrentSiteSubmitting || undefined}
                             onClick={(event) => {
                               if (submitLockRef.current) {
                                 event.preventDefault();
@@ -657,8 +656,9 @@ export function SubmittedToBar({
                               'flex gap-3 items-start p-2 w-full text-left rounded-md transition-colors',
                               'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
                               'disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:bg-transparent',
-                              isBusy && 'cursor-wait opacity-70 pointer-events-none',
-                              !isDisabled && !isBusy && 'hover:bg-accent',
+                              isCurrentSiteSubmitting &&
+                                'cursor-wait opacity-70 pointer-events-none',
+                              !isDisabled && !isCurrentSiteSubmitting && 'hover:bg-accent',
                             )}
                           >
                             <span className="flex overflow-hidden justify-center items-center w-9 h-9 rounded border bg-muted shrink-0 border-border">

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -18,8 +18,12 @@ import type {
 import type { CheckServiceRunRow } from '../works.$workId/checkServiceRun.shared';
 import { getCheckRunSummaryByKind } from '../works.$workId/checkServiceRunSummaries';
 import { resolveSubmitRedirectTarget } from './submitToSiteRedirect';
-import { Check, ChevronDown, GitBranch, Loader2, Send } from 'lucide-react';
+import { GitBranch, Loader2, Send } from 'lucide-react';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+
+// TEMPORARY(submit-to-site): Remove when per-version submit is supported end-to-end.
+const SUBMIT_LATEST_VERSION_ONLY_TOOLTIP =
+  'At this time, only the latest completed version can be submitted to a site. If you would like to submit an earlier version, please contact support.';
 
 type SubmissionTargetSite = {
   id: string;
@@ -260,7 +264,6 @@ export function SubmittedToBar({
   const fetcher = useFetcher<SubmitToSiteFetcherData>();
   // Synchronous guard closing the double-click window before `disabled` re-renders.
   const submitLockRef = useRef(false);
-  const [versionDropdownOpen, setVersionDropdownOpen] = useState(false);
   const versionNumberByVersionId = useMemo(
     () => buildWorkVersionNumberByIdMap(versions),
     [versions],
@@ -275,12 +278,9 @@ export function SubmittedToBar({
       label: `v${versionNumberByVersionId[version.id] ?? 0}`,
     }));
   }, [versions, versionNumberByVersionId]);
-  const [selectedVersionId, setSelectedVersionId] = useState(versionOptions[0]?.version.id ?? '');
-  const selectedVersion =
-    versionOptions.find((option) => option.version.id === selectedVersionId)?.version ??
-    versionOptions[0]?.version;
-  const selectedVersionLabel =
-    versionOptions.find((option) => option.version.id === selectedVersion?.id)?.label ?? 'version';
+  // TEMPORARY(submit-to-site): Lock to the latest completed version until per-version submit ships.
+  const selectedVersion = versionOptions[0]?.version;
+  const selectedVersionLabel = versionOptions[0]?.label ?? 'version';
   const selectedFiles = selectedVersion ? getVersionFiles(selectedVersion) : {};
   const fileLabels = Object.entries(selectedFiles).map(([key, value]) => getFileLabel(key, value));
   // Checks surface the most recent run of each kind on the selected version and
@@ -344,11 +344,6 @@ export function SubmittedToBar({
       }
     }
   }, [basePath, fetcher.data, fetcher.state, navigate]);
-
-  useEffect(() => {
-    if (selectedVersionId || !versionOptions[0]) return;
-    setSelectedVersionId(versionOptions[0].version.id);
-  }, [selectedVersionId, versionOptions]);
 
   return (
     <primitives.Card
@@ -434,78 +429,40 @@ export function SubmittedToBar({
                 <input type="hidden" name="workVersionId" value={selectedVersion?.id ?? ''} />
                 <div className="p-4 space-y-4 border-r border-border bg-muted/20">
                   <div>
-                    <p className="text-sm font-medium">Choose the version to submit</p>
+                    <p className="text-sm font-medium">Version to submit</p>
                     <p className="text-xs text-muted-foreground">
                       Review available files, metadata, and checks before choosing a venue.
                     </p>
                   </div>
 
                   {hasCompletedVersions ? (
-                    <ui.Popover open={versionDropdownOpen} onOpenChange={setVersionDropdownOpen}>
-                      <ui.PopoverTrigger asChild>
-                        <button
-                          id="submit-version-select"
-                          type="button"
-                          className={cn(
-                            'flex gap-3 justify-between items-center px-3 py-2 w-full h-16 text-left bg-white rounded-md border transition-colors border-input shadow-xs',
-                            'hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
-                          )}
-                        >
-                          {selectedVersion ? (
-                            <span className="flex flex-col gap-1 items-start min-w-0">
-                              <SubmitVersionLabel label={selectedVersionLabel} />
-                              <span className="text-xs text-muted-foreground">
-                                {new Date(
-                                  selectedVersion.date_modified ?? selectedVersion.date_created,
-                                ).toLocaleDateString()}
-                              </span>
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground">Select a version</span>
-                          )}
-                          <ChevronDown className="w-4 h-4 text-muted-foreground shrink-0" />
-                        </button>
-                      </ui.PopoverTrigger>
-                      <ui.PopoverContent
-                        align="start"
-                        side="bottom"
-                        sideOffset={6}
-                        className="p-1 w-[268px]"
+                    <ui.SimpleTooltip
+                      title={SUBMIT_LATEST_VERSION_ONLY_TOOLTIP}
+                      side="top"
+                      sideOffset={6}
+                    >
+                      <div
+                        id="submit-version-select"
+                        aria-disabled="true"
+                        className={cn(
+                          'flex gap-3 justify-between items-center px-3 py-2 w-full h-16 text-left bg-white rounded-md border border-input shadow-xs',
+                          'cursor-not-allowed opacity-80',
+                        )}
                       >
-                        <div className="space-y-1">
-                          {versionOptions.map(({ version, label }) => {
-                            const selected = version.id === selectedVersionId;
-                            return (
-                              <button
-                                key={version.id}
-                                type="button"
-                                className={cn(
-                                  'flex w-full items-center justify-between gap-3 rounded-sm px-3 py-2 text-left transition-colors',
-                                  'hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-                                  selected && 'bg-accent',
-                                )}
-                                onClick={() => {
-                                  setSelectedVersionId(version.id);
-                                  setVersionDropdownOpen(false);
-                                }}
-                              >
-                                <span className="flex flex-col gap-1 items-start min-w-0">
-                                  <SubmitVersionLabel label={label} />
-                                  <span className="text-xs text-muted-foreground">
-                                    {new Date(
-                                      version.date_modified ?? version.date_created,
-                                    ).toLocaleDateString()}
-                                  </span>
-                                </span>
-                                {selected ? (
-                                  <Check className="w-4 h-4 text-primary shrink-0" />
-                                ) : null}
-                              </button>
-                            );
-                          })}
-                        </div>
-                      </ui.PopoverContent>
-                    </ui.Popover>
+                        {selectedVersion ? (
+                          <span className="flex flex-col gap-1 items-start min-w-0">
+                            <SubmitVersionLabel label={selectedVersionLabel} />
+                            <span className="text-xs text-muted-foreground">
+                              {new Date(
+                                selectedVersion.date_modified ?? selectedVersion.date_created,
+                              ).toLocaleDateString()}
+                            </span>
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">Select a version</span>
+                        )}
+                      </div>
+                    </ui.SimpleTooltip>
                   ) : (
                     <p className="px-3 py-4 text-xs leading-relaxed rounded-md border border-dashed border-muted-foreground/40 bg-background text-muted-foreground">
                       No completed version is available to submit. Finish creating a version before

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -40,6 +40,7 @@ type SubmitToSiteFetcherData = {
   intent?: string;
   siteName?: string;
   submissionVersionId?: string;
+  redirectPath?: string;
   alreadySubmitted?: boolean;
   error?: string | { message?: string };
 };
@@ -325,9 +326,10 @@ export function SubmittedToBar({
       return;
     }
     if (fetcher.data.success && fetcher.data.siteName && fetcher.data.submissionVersionId) {
-      navigate(
-        `${basePath}/site/${fetcher.data.siteName}/submission/${fetcher.data.submissionVersionId}`,
-      );
+      const redirectPath =
+        fetcher.data.redirectPath ??
+        `${basePath}/site/${fetcher.data.siteName}/submission/${fetcher.data.submissionVersionId}`;
+      navigate(redirectPath);
     }
   }, [basePath, fetcher.data, fetcher.state, navigate]);
 

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -622,8 +622,11 @@ export function SubmittedToBar({
                         const alreadySubmitted = submittedSiteNamesForSelectedVersion.has(
                           site.name,
                         );
+                        const isBusy = isCurrentSiteSubmitting;
                         const isDisabled =
-                          !hasCompletedVersions || isSubmitting || alreadySubmitted;
+                          !hasCompletedVersions ||
+                          alreadySubmitted ||
+                          (isSubmitting && !isCurrentSiteSubmitting);
                         return (
                           <button
                             key={site.id}
@@ -631,12 +634,13 @@ export function SubmittedToBar({
                             name="siteName"
                             value={site.name}
                             disabled={isDisabled}
+                            aria-busy={isBusy || undefined}
                             className={cn(
                               'flex gap-3 items-start p-2 w-full text-left rounded-md transition-colors',
                               'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
                               'disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:bg-transparent',
-                              !isDisabled && 'hover:bg-accent',
-                              isSubmitting && 'opacity-70',
+                              isBusy && 'cursor-wait opacity-70 pointer-events-none',
+                              !isDisabled && !isBusy && 'hover:bg-accent',
                             )}
                           >
                             <span className="flex overflow-hidden justify-center items-center w-9 h-9 rounded border bg-muted shrink-0 border-border">

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -326,12 +326,14 @@ export function SubmittedToBar({
     // Settled: release the click guard on any response (even one without an intent,
     // e.g. an invalid-form-data error) so a failed submit can be retried.
     submitLockRef.current = false;
-    if (fetcher.data.intent !== 'submit-to-site') return;
+    // The fetcher only posts submit-to-site, so an error response belongs to this
+    // submit even when it carries no intent (e.g. invalid form data).
     const errorMessage = getErrorMessage(fetcher.data);
     if (errorMessage) {
       ui.toastError(errorMessage);
       return;
     }
+    if (fetcher.data.intent !== 'submit-to-site') return;
     if (fetcher.data.success) {
       const target = resolveSubmitRedirectTarget(fetcher.data, basePath);
       if (target) {

--- a/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
+++ b/platform/scms/app/routes/app/works.$workId.details/SubmittedToBar.tsx
@@ -17,6 +17,7 @@ import type {
 } from '../works.$workId/types';
 import type { CheckServiceRunRow } from '../works.$workId/checkServiceRun.shared';
 import { getCheckRunSummaryByKind } from '../works.$workId/checkServiceRunSummaries';
+import { resolveSubmitRedirectTarget } from './submitToSiteRedirect';
 import { Check, ChevronDown, GitBranch, Loader2, Send } from 'lucide-react';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 
@@ -321,25 +322,23 @@ export function SubmittedToBar({
   );
 
   useEffect(() => {
-    if (fetcher.state !== 'idle' || fetcher.data?.intent !== 'submit-to-site') return;
-    // Settled: release the click guard so a failed submit can be retried.
+    if (fetcher.state !== 'idle' || !fetcher.data) return;
+    // Settled: release the click guard on any response (even one without an intent,
+    // e.g. an invalid-form-data error) so a failed submit can be retried.
     submitLockRef.current = false;
+    if (fetcher.data.intent !== 'submit-to-site') return;
     const errorMessage = getErrorMessage(fetcher.data);
     if (errorMessage) {
       ui.toastError(errorMessage);
       return;
     }
     if (fetcher.data.success) {
-      const { redirectPath, siteName, submissionVersionId } = fetcher.data;
-      const target =
-        redirectPath ??
-        (siteName && submissionVersionId
-          ? `${basePath}/site/${siteName}/submission/${submissionVersionId}`
-          : undefined);
+      const target = resolveSubmitRedirectTarget(fetcher.data, basePath);
       if (target) {
         navigate(target);
       } else {
-        ui.toastError('Submission succeeded but no destination was provided');
+        // The submission succeeded server-side; some extensions return no destination.
+        ui.toastSuccess('Submitted successfully');
       }
     }
   }, [basePath, fetcher.data, fetcher.state, navigate]);
@@ -656,8 +655,8 @@ export function SubmittedToBar({
                               'flex gap-3 items-start p-2 w-full text-left rounded-md transition-colors',
                               'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
                               'disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:bg-transparent',
-                              isCurrentSiteSubmitting &&
-                                'cursor-wait opacity-70 pointer-events-none',
+                              // twMerge lets this displace disabled:cursor-not-allowed above.
+                              isCurrentSiteSubmitting && 'disabled:cursor-wait',
                               !isDisabled && !isCurrentSiteSubmitting && 'hover:bg-accent',
                             )}
                           >

--- a/platform/scms/app/routes/app/works.$workId.details/submitToSiteRedirect.test.ts
+++ b/platform/scms/app/routes/app/works.$workId.details/submitToSiteRedirect.test.ts
@@ -1,0 +1,30 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { describe, expect, it } from 'vitest';
+import { resolveSubmitRedirectTarget } from './submitToSiteRedirect';
+
+describe('resolveSubmitRedirectTarget', () => {
+  it('prefers redirectPath when provided', () => {
+    expect(
+      resolveSubmitRedirectTarget(
+        {
+          redirectPath: '/app/custom/destination',
+          siteName: 'pmc',
+          submissionVersionId: 'sv-1',
+        },
+        '/app',
+      ),
+    ).toBe('/app/custom/destination');
+  });
+
+  it('falls back to the constructed submission URL from siteName and submissionVersionId', () => {
+    expect(
+      resolveSubmitRedirectTarget({ siteName: 'pmc', submissionVersionId: 'sv-1' }, '/app'),
+    ).toBe('/app/site/pmc/submission/sv-1');
+  });
+
+  it('returns undefined when no destination is provided', () => {
+    expect(resolveSubmitRedirectTarget({}, '/app')).toBeUndefined();
+    expect(resolveSubmitRedirectTarget({ siteName: 'pmc' }, '/app')).toBeUndefined();
+    expect(resolveSubmitRedirectTarget({ submissionVersionId: 'sv-1' }, '/app')).toBeUndefined();
+  });
+});

--- a/platform/scms/app/routes/app/works.$workId.details/submitToSiteRedirect.ts
+++ b/platform/scms/app/routes/app/works.$workId.details/submitToSiteRedirect.ts
@@ -1,0 +1,24 @@
+type SubmitToSiteRedirectData = {
+  siteName?: string;
+  submissionVersionId?: string;
+  redirectPath?: string;
+};
+
+/**
+ * Resolve where to navigate after a successful submit-to-site. Prefers an explicit
+ * redirectPath from the action (e.g. supplied by an extension), falls back to the
+ * constructed submission URL, and returns undefined when the response carries no
+ * destination.
+ */
+export function resolveSubmitRedirectTarget(
+  data: SubmitToSiteRedirectData,
+  basePath: string,
+): string | undefined {
+  const { redirectPath, siteName, submissionVersionId } = data;
+  return (
+    redirectPath ??
+    (siteName && submissionVersionId
+      ? `${basePath}/site/${siteName}/submission/${submissionVersionId}`
+      : undefined)
+  );
+}

--- a/platform/scms/app/routes/app/works.$workId/route.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/route.test.ts
@@ -24,6 +24,7 @@ const {
   withSecureWorkContext,
   cloneDraftWorkVersionFromSource,
   getUserScopesSet,
+  executeRaw,
   mockServerExtensions,
 } = vi.hoisted(() => ({
   createReturningVersion: vi.fn(),
@@ -47,6 +48,7 @@ const {
   withSecureWorkContext: vi.fn(),
   cloneDraftWorkVersionFromSource: vi.fn(),
   getUserScopesSet: vi.fn(() => new Set(['app:works:upload'])),
+  executeRaw: vi.fn(),
   mockServerExtensions: [] as Array<{
     id: string;
     getOperatedSites?: () => string[];
@@ -65,7 +67,7 @@ vi.mock('@curvenote/scms-server', () => ({
   getPrismaClient: vi.fn(async () => ({
     $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
       fn({
-        $executeRaw: vi.fn(),
+        $executeRaw: executeRaw,
         submission: {
           findFirst: findFirstSubmission,
         },
@@ -736,6 +738,59 @@ describe('work submit-to-site route', () => {
         siteName: 'pmc',
       }),
     );
+    // The advisory lock is acquired inside the transaction before the extension
+    // handler runs, so concurrent delegated submits serialize.
+    const lockSql = executeRaw.mock.calls[0][0] as { values: unknown[] };
+    expect(lockSql.values).toContain('work-site-submit:work-1:site-pmc');
+    expect(executeRaw.mock.invocationCallOrder[0]).toBeLessThan(
+      submitToSite.mock.invocationCallOrder[0],
+    );
+    expect(createReturningVersion).not.toHaveBeenCalled();
+    expect(createSubmissionVersion).not.toHaveBeenCalled();
+  });
+
+  it('fails when an extension submit handler rejects without falling back to the central route', async () => {
+    mockServerExtensions.push({
+      id: 'pmc',
+      getOperatedSites: () => ['pmc'],
+      submitToSite: vi.fn().mockRejectedValue(new Error('PMC deposit service unavailable')),
+    });
+    findUniqueSite.mockResolvedValue({
+      id: 'site-pmc',
+      name: 'pmc',
+      title: 'PMC',
+      private: true,
+      restricted: false,
+      external: true,
+      domains: [],
+      submissionKinds: [{ id: 'kind-1', default: true }],
+      collections: [
+        {
+          id: 'collection-1',
+          default: true,
+          open: true,
+          kindsInCollection: [{ kind: { id: 'kind-1', default: true } }],
+        },
+      ],
+    });
+    userHasScope.mockImplementation((_user, scope, siteName) => {
+      if (scope === 'app:works:submit-to-site') return true;
+      return scope === 'site:submissions:create' && siteName === 'pmc';
+    });
+
+    const response = await action({
+      request: createSubmitToSiteRequest('pmc', 'wv-1'),
+      params: { workId: 'work-1' },
+    } as never);
+    const status = 'init' in response ? response.init?.status : 200;
+    const body = 'data' in response ? response.data : response;
+
+    expect(status).toBe(500);
+    expect(body).toMatchObject({
+      success: false,
+      intent: 'submit-to-site',
+      error: 'PMC deposit service unavailable',
+    });
     expect(createReturningVersion).not.toHaveBeenCalled();
     expect(createSubmissionVersion).not.toHaveBeenCalled();
   });

--- a/platform/scms/app/routes/app/works.$workId/route.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/route.test.ts
@@ -536,7 +536,7 @@ describe('work submit-to-site route', () => {
     expect(createReturningVersion).not.toHaveBeenCalled();
   });
 
-  it('returns the existing submission version when resubmitting an older work version after a newer one', async () => {
+  it('rejects submit-to-site when an older completed work version is requested', async () => {
     findUniqueSite.mockResolvedValue({
       id: 'site-public',
       name: 'public-site',
@@ -555,32 +555,22 @@ describe('work submit-to-site route', () => {
         },
       ],
     });
-    findFirstSubmission.mockResolvedValue({
-      id: 'submission-1',
-      versions: [{ id: 'sv-1', work_version_id: 'wv-1', status: 'PENDING' }],
-    });
+    findFirstWorkVersion.mockResolvedValue({ id: 'wv-2' });
 
     const response = await action({
       request: createSubmitToSiteRequest('public-site', 'wv-1'),
       params: { workId: 'work-1' },
     } as never);
 
-    expect(response).toMatchObject({
-      success: true,
+    const status = 'init' in response ? response.init?.status : 200;
+    const body = 'data' in response ? response.data : response;
+
+    expect(status).toBe(400);
+    expect(body).toMatchObject({
+      success: false,
       intent: 'submit-to-site',
-      siteName: 'public-site',
-      submissionVersionId: 'sv-1',
-      alreadySubmitted: true,
+      error: expect.stringContaining('Only the latest completed version'),
     });
-    expect(findFirstSubmission).toHaveBeenCalledWith(
-      expect.objectContaining({
-        include: {
-          versions: expect.objectContaining({
-            where: { work_version_id: 'wv-1' },
-          }),
-        },
-      }),
-    );
     expect(createSubmissionVersion).not.toHaveBeenCalled();
     expect(createReturningVersion).not.toHaveBeenCalled();
   });

--- a/platform/scms/app/routes/app/works.$workId/route.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/route.test.ts
@@ -23,6 +23,7 @@ const {
   withSecureWorkContext,
   cloneDraftWorkVersionFromSource,
   getUserScopesSet,
+  mockServerExtensions,
 } = vi.hoisted(() => ({
   createReturningVersion: vi.fn(),
   createSubmissionVersion: vi.fn(),
@@ -45,6 +46,11 @@ const {
   withSecureWorkContext: vi.fn(),
   cloneDraftWorkVersionFromSource: vi.fn(),
   getUserScopesSet: vi.fn(() => new Set(['app:works:upload'])),
+  mockServerExtensions: [] as Array<{
+    id: string;
+    getOperatedSites?: () => string[];
+    submitToSite?: (...args: unknown[]) => Promise<unknown>;
+  }>,
 }));
 
 vi.mock('@curvenote/scms-server', () => ({
@@ -143,6 +149,17 @@ vi.mock('@curvenote/scms-core', () => ({
     option: { id: 'article', extensionId: undefined },
   })),
   invokeExtensionCreateWorkVersion: vi.fn(),
+  resolveSubmitToSiteExtension: (
+    extensions: Array<{
+      getOperatedSites?: () => string[];
+      submitToSite?: (...args: unknown[]) => Promise<unknown>;
+    }>,
+    siteName: string,
+  ) =>
+    extensions.find(
+      (extension) =>
+        !!extension.submitToSite && !!extension.getOperatedSites?.().includes(siteName),
+    ),
 }));
 
 vi.mock('./menu', () => ({
@@ -200,7 +217,9 @@ vi.mock('../../../extensions/client', () => ({
 }));
 
 vi.mock('../../../extensions/server', () => ({
-  extensions: [],
+  get extensions() {
+    return mockServerExtensions;
+  },
 }));
 
 vi.mock('./actionHelpers.server', () => ({
@@ -245,6 +264,7 @@ function createSubmitToSiteRequest(siteName = 'private-site', workVersionId = 'w
 describe('work submit-to-site route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockServerExtensions.length = 0;
     withSecureWorkContext.mockResolvedValue({
       user: {
         id: 'user-1',
@@ -663,6 +683,154 @@ describe('work submit-to-site route', () => {
       expect.objectContaining({ submission: expect.any(Object) }),
     );
     expect(createReturningVersion).not.toHaveBeenCalled();
+  });
+
+  it('delegates to an extension that operates the site and declares submitToSite', async () => {
+    const submitToSite = vi.fn().mockResolvedValue({
+      success: true,
+      submissionVersionId: 'sv-ext',
+      redirectPath: '/app/works/work-1/site/pmc/deposit/sv-ext',
+    });
+    mockServerExtensions.push({
+      id: 'pmc',
+      getOperatedSites: () => ['pmc'],
+      submitToSite,
+    });
+    findUniqueSite.mockResolvedValue({
+      id: 'site-pmc',
+      name: 'pmc',
+      title: 'PMC',
+      private: true,
+      restricted: false,
+      external: true,
+      domains: [],
+      submissionKinds: [{ id: 'kind-1', default: true }],
+      collections: [
+        {
+          id: 'collection-1',
+          default: true,
+          open: true,
+          kindsInCollection: [{ kind: { id: 'kind-1', default: true } }],
+        },
+      ],
+    });
+    userHasScope.mockImplementation((_user, scope, siteName) => {
+      if (scope === 'app:works:submit-to-site') return true;
+      return scope === 'site:submissions:create' && siteName === 'pmc';
+    });
+
+    const response = await action({
+      request: createSubmitToSiteRequest('pmc', 'wv-1'),
+      params: { workId: 'work-1' },
+    } as never);
+
+    expect(response).toMatchObject({
+      success: true,
+      intent: 'submit-to-site',
+      siteName: 'pmc',
+      submissionVersionId: 'sv-ext',
+      redirectPath: '/app/works/work-1/site/pmc/deposit/sv-ext',
+    });
+    expect(submitToSite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workId: 'work-1',
+        workVersionId: 'wv-1',
+        siteName: 'pmc',
+      }),
+    );
+    expect(createReturningVersion).not.toHaveBeenCalled();
+    expect(createSubmissionVersion).not.toHaveBeenCalled();
+  });
+
+  it('fails when an extension submit handler returns an error without falling back to the central route', async () => {
+    mockServerExtensions.push({
+      id: 'pmc',
+      getOperatedSites: () => ['pmc'],
+      submitToSite: vi.fn().mockResolvedValue({
+        success: false,
+        error: 'Extension submission failed',
+      }),
+    });
+    findUniqueSite.mockResolvedValue({
+      id: 'site-pmc',
+      name: 'pmc',
+      title: 'PMC',
+      private: true,
+      restricted: false,
+      external: true,
+      domains: [],
+      submissionKinds: [{ id: 'kind-1', default: true }],
+      collections: [
+        {
+          id: 'collection-1',
+          default: true,
+          open: true,
+          kindsInCollection: [{ kind: { id: 'kind-1', default: true } }],
+        },
+      ],
+    });
+    userHasScope.mockImplementation((_user, scope, siteName) => {
+      if (scope === 'app:works:submit-to-site') return true;
+      return scope === 'site:submissions:create' && siteName === 'pmc';
+    });
+
+    const response = await action({
+      request: createSubmitToSiteRequest('pmc', 'wv-1'),
+      params: { workId: 'work-1' },
+    } as never);
+    const status = 'init' in response ? response.init?.status : 200;
+    const body = 'data' in response ? response.data : response;
+
+    expect(status).toBe(500);
+    expect(body).toMatchObject({
+      success: false,
+      intent: 'submit-to-site',
+      error: 'Extension submission failed',
+    });
+    expect(createReturningVersion).not.toHaveBeenCalled();
+    expect(createSubmissionVersion).not.toHaveBeenCalled();
+  });
+
+  it('uses the central route when an extension operates the site but declares no submit handler', async () => {
+    mockServerExtensions.push({
+      id: 'pmc',
+      getOperatedSites: () => ['pmc'],
+    });
+    findUniqueSite.mockResolvedValue({
+      id: 'site-pmc',
+      name: 'pmc',
+      title: 'PMC',
+      private: true,
+      restricted: false,
+      external: true,
+      domains: [],
+      submissionKinds: [{ id: 'kind-1', default: true }],
+      collections: [
+        {
+          id: 'collection-1',
+          default: true,
+          open: true,
+          kindsInCollection: [{ kind: { id: 'kind-1', default: true } }],
+        },
+      ],
+    });
+    userHasScope.mockImplementation((_user, scope, siteName) => {
+      if (scope === 'app:works:submit-to-site') return true;
+      return scope === 'site:submissions:create' && siteName === 'pmc';
+    });
+
+    const response = await action({
+      request: createSubmitToSiteRequest('pmc', 'wv-1'),
+      params: { workId: 'work-1' },
+    } as never);
+
+    expect(response).toMatchObject({
+      success: true,
+      intent: 'submit-to-site',
+      siteName: 'pmc',
+      submissionVersionId: 'sv-1',
+    });
+    expect(createReturningVersion).toHaveBeenCalled();
   });
 });
 

--- a/platform/scms/app/routes/app/works.$workId/route.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/route.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as ScmsCore from '@curvenote/scms-core';
 
 const {
   createReturningVersion,
@@ -106,61 +107,58 @@ vi.mock('@curvenote/scms-server', () => ({
   },
 }));
 
-vi.mock('@curvenote/scms-core', () => ({
-  MainWrapper: vi.fn(),
-  SecondaryNav: vi.fn(),
-  getBrandingFromMetaMatches: vi.fn(() => ({ title: 'SCMS' })),
-  joinPageTitle: vi.fn((title: string | undefined, suffix: string) => `${title ?? ''} ${suffix}`),
-  TrackEvent: {
-    WORK_VIEWED: 'WORK_VIEWED',
-  },
-  getWorkflows: vi.fn(() => ({ SIMPLE: {} })),
-  registerExtensionWorkflows: vi.fn(() => ({})),
-  getExtensionCheckServicesFromServerConfig: vi.fn(() => []),
-  loadCheckMaintenanceByServiceIds,
-  CheckMaintenanceProvider: vi.fn(({ children }) => children),
-  scopes: {
-    app: {
-      works: {
-        upload: 'app:works:upload',
-        submitToSite: 'app:works:submit-to-site',
-      },
+vi.mock('@curvenote/scms-core', async () => {
+  // Pull the real resolver through instead of hand-copying its body, so these route
+  // tests exercise the actual routing logic and catch regressions if it changes. The
+  // function is pure, so only it is un-mocked while the rest of the module stays stubbed.
+  const { resolveSubmitToSiteExtension } =
+    await vi.importActual<typeof ScmsCore>('@curvenote/scms-core');
+  return {
+    MainWrapper: vi.fn(),
+    SecondaryNav: vi.fn(),
+    getBrandingFromMetaMatches: vi.fn(() => ({ title: 'SCMS' })),
+    joinPageTitle: vi.fn((title: string | undefined, suffix: string) => `${title ?? ''} ${suffix}`),
+    TrackEvent: {
+      WORK_VIEWED: 'WORK_VIEWED',
     },
-    site: {
-      submissions: {
-        create: 'site:submissions:create',
-      },
-    },
-    work: {
-      id: {
-        read: 'work:id:read',
-        users: {
-          read: 'work:users:read',
-        },
-        checks: {
-          dispatch: 'work:id:checks:dispatch',
+    getWorkflows: vi.fn(() => ({ SIMPLE: {} })),
+    registerExtensionWorkflows: vi.fn(() => ({})),
+    getExtensionCheckServicesFromServerConfig: vi.fn(() => []),
+    loadCheckMaintenanceByServiceIds,
+    CheckMaintenanceProvider: vi.fn(({ children }) => children),
+    scopes: {
+      app: {
+        works: {
+          upload: 'app:works:upload',
+          submitToSite: 'app:works:submit-to-site',
         },
       },
+      site: {
+        submissions: {
+          create: 'site:submissions:create',
+        },
+      },
+      work: {
+        id: {
+          read: 'work:id:read',
+          users: {
+            read: 'work:users:read',
+          },
+          checks: {
+            dispatch: 'work:id:checks:dispatch',
+          },
+        },
+      },
     },
-  },
-  BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID: 'article',
-  resolveCreateNewVersionOption: vi.fn(() => ({
-    ok: true,
-    option: { id: 'article', extensionId: undefined },
-  })),
-  invokeExtensionCreateWorkVersion: vi.fn(),
-  resolveSubmitToSiteExtension: (
-    extensions: Array<{
-      getOperatedSites?: () => string[];
-      submitToSite?: (...args: unknown[]) => Promise<unknown>;
-    }>,
-    siteName: string,
-  ) =>
-    extensions.find(
-      (extension) =>
-        !!extension.submitToSite && !!extension.getOperatedSites?.().includes(siteName),
-    ),
-}));
+    BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID: 'article',
+    resolveCreateNewVersionOption: vi.fn(() => ({
+      ok: true,
+      option: { id: 'article', extensionId: undefined },
+    })),
+    invokeExtensionCreateWorkVersion: vi.fn(),
+    resolveSubmitToSiteExtension,
+  };
+});
 
 vi.mock('./menu', () => ({
   buildMenu: vi.fn(() => []),

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -332,7 +332,8 @@ export async function action(args: ActionFunctionArgs) {
         // central path uses, so a double submit can't race the extension's own
         // existing-submission dedup (e.g. two DRAFT submissions for one work+site).
         // The lock is held for the extension call and released when the wrapping
-        // transaction settles.
+        // transaction settles. The timeout is generous because a timeout releases
+        // the lock while the un-cancellable extension call keeps running.
         const extLockKey = workSiteSubmitLockKey(ctx.work.id, site.id);
         const extResult = await prisma.$transaction(
           async (tx) => {
@@ -344,7 +345,7 @@ export async function action(args: ActionFunctionArgs) {
               siteName,
             });
           },
-          { timeout: 20_000 },
+          { timeout: 60_000 },
         );
         if (!extResult?.success) {
           return data(
@@ -455,6 +456,21 @@ export async function action(args: ActionFunctionArgs) {
     } catch (error) {
       if (error instanceof SubmitToSiteConfigError) {
         return data({ success: false, intent, error: error.message }, { status: 400 });
+      }
+      // P2028: the wrapping transaction timed out. The advisory lock is released but
+      // the underlying submit (e.g. an extension call) may still complete, so warn
+      // the user against blindly retrying instead of returning a generic failure.
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2028') {
+        console.error('Submit work to site transaction timed out:', error);
+        return data(
+          {
+            success: false,
+            intent,
+            error:
+              'The submission timed out but may still be processing. Check the site for a new submission before retrying.',
+          },
+          { status: 500 },
+        );
       }
       console.error('Failed to submit work to site:', error);
       return data(

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -328,12 +328,24 @@ export async function action(args: ActionFunctionArgs) {
 
       const submitExt = resolveSubmitToSiteExtension(serverExtensions, siteName);
       if (submitExt) {
-        const extResult = await submitExt.submitToSite!({
-          ctx,
-          workId: ctx.work.id,
-          workVersionId: selectedVersion.id,
-          siteName,
-        });
+        // Serialize concurrent delegated submits with the same advisory lock the
+        // central path uses, so a double submit can't race the extension's own
+        // existing-submission dedup (e.g. two DRAFT submissions for one work+site).
+        // The lock is held for the extension call and released when the wrapping
+        // transaction settles.
+        const extLockKey = workSiteSubmitLockKey(ctx.work.id, site.id);
+        const extResult = await prisma.$transaction(
+          async (tx) => {
+            await tx.$executeRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtext(${extLockKey}))`);
+            return submitExt.submitToSite!({
+              ctx,
+              workId: ctx.work.id,
+              workVersionId: selectedVersion.id,
+              siteName,
+            });
+          },
+          { timeout: 20_000 },
+        );
         if (!extResult?.success) {
           return data(
             {

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -35,6 +35,7 @@ import {
   scopes,
   resolveCreateNewVersionOption,
   invokeExtensionCreateWorkVersion,
+  resolveSubmitToSiteExtension,
   BUILTIN_ARTICLE_WORK_CREATE_OPTION_ID,
   buildWorkVersionNumberByIdMap,
 } from '@curvenote/scms-core';
@@ -323,6 +324,33 @@ export async function action(args: ActionFunctionArgs) {
           { success: false, intent, error: 'No completed work version is available to submit' },
           { status: 400 },
         );
+      }
+
+      const submitExt = resolveSubmitToSiteExtension(serverExtensions, siteName);
+      if (submitExt) {
+        const extResult = await submitExt.submitToSite!({
+          ctx,
+          workId: ctx.work.id,
+          workVersionId: selectedVersion.id,
+          siteName,
+        });
+        if (!extResult?.success) {
+          return data(
+            {
+              success: false,
+              intent,
+              error: extResult?.error ?? 'Extension failed to create submission',
+            },
+            { status: 500 },
+          );
+        }
+        return {
+          success: true,
+          intent: 'submit-to-site',
+          siteName,
+          submissionVersionId: extResult.submissionVersionId,
+          redirectPath: extResult.redirectPath,
+        };
       }
 
       const siteCtx = new SiteContextWithUser(ctx, site);

--- a/platform/scms/app/routes/app/works.$workId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId/route.tsx
@@ -67,6 +67,7 @@ import { WORK_ROUTE_CONTENT_CLASS } from './workRouteLayout';
 import { exportToPdfAction } from './actionHelpers.server';
 import {
   canUserSubmitToSite,
+  getSubmitToSiteLatestVersionPolicyError,
   isSiteAvailableForWorkSubmit,
   resolveOpenCollection,
   resolveSubmissionKind,
@@ -309,22 +310,26 @@ export async function action(args: ActionFunctionArgs) {
         );
       }
 
-      const selectedVersion = workVersionId
-        ? await prisma.workVersion.findFirst({
-            where: { id: workVersionId, work_id: ctx.work.id, draft: false },
-            select: { id: true },
-          })
-        : await prisma.workVersion.findFirst({
-            where: { work_id: ctx.work.id, draft: false },
-            orderBy: { date_created: 'desc' },
-            select: { id: true },
-          });
-      if (!selectedVersion) {
+      // TEMPORARY(submit-to-site): Only the latest non-draft version may be submitted.
+      const latestNonDraftVersion = await prisma.workVersion.findFirst({
+        where: { work_id: ctx.work.id, draft: false },
+        orderBy: { date_created: 'desc' },
+        select: { id: true },
+      });
+      if (!latestNonDraftVersion) {
         return data(
           { success: false, intent, error: 'No completed work version is available to submit' },
           { status: 400 },
         );
       }
+      const latestVersionPolicyError = getSubmitToSiteLatestVersionPolicyError(
+        workVersionId,
+        latestNonDraftVersion.id,
+      );
+      if (latestVersionPolicyError) {
+        return data({ success: false, intent, error: latestVersionPolicyError }, { status: 400 });
+      }
+      const selectedVersion = latestNonDraftVersion;
 
       const submitExt = resolveSubmitToSiteExtension(serverExtensions, siteName);
       if (submitExt) {

--- a/platform/scms/app/routes/app/works.$workId/submitToSite.server.test.ts
+++ b/platform/scms/app/routes/app/works.$workId/submitToSite.server.test.ts
@@ -2,10 +2,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   canSiteAcceptNewSubmission,
+  getSubmitToSiteLatestVersionPolicyError,
   isAlreadySubmittedVersion,
   isSiteAvailableForWorkSubmit,
   resolveOpenCollection,
   resolveSubmissionKind,
+  SUBMIT_TO_SITE_LATEST_VERSION_ONLY_ERROR,
   submitWorkVersionToSite,
   workSiteSubmitLockKey,
 } from './submitToSite.server';
@@ -29,6 +31,20 @@ const userWithoutSubmitScopes = {
 describe('submitToSite.server', () => {
   it('builds a stable work/site advisory lock key', () => {
     expect(workSiteSubmitLockKey('work-1', 'site-1')).toBe('work-site-submit:work-1:site-1');
+  });
+
+  it('allows submit when no work version is requested explicitly', () => {
+    expect(getSubmitToSiteLatestVersionPolicyError(undefined, 'wv-latest')).toBeNull();
+  });
+
+  it('allows submit when the requested work version is the latest non-draft', () => {
+    expect(getSubmitToSiteLatestVersionPolicyError('wv-latest', 'wv-latest')).toBeNull();
+  });
+
+  it('rejects submit when an older non-draft work version is requested', () => {
+    expect(getSubmitToSiteLatestVersionPolicyError('wv-old', 'wv-latest')).toBe(
+      SUBMIT_TO_SITE_LATEST_VERSION_ONLY_ERROR,
+    );
   });
 
   it('resolves default open collection first', () => {

--- a/platform/scms/app/routes/app/works.$workId/submitToSite.server.ts
+++ b/platform/scms/app/routes/app/works.$workId/submitToSite.server.ts
@@ -58,6 +58,21 @@ export class SubmitToSiteConfigError extends Error {
   }
 }
 
+// TEMPORARY(submit-to-site): Remove when per-version submit is supported end-to-end.
+export const SUBMIT_TO_SITE_LATEST_VERSION_ONLY_ERROR =
+  'Only the latest completed version can be submitted right now. Please contact support if you need to submit an earlier version.';
+
+/** Rejects explicit requests to submit a non-latest completed work version. */
+export function getSubmitToSiteLatestVersionPolicyError(
+  requestedWorkVersionId: string | undefined,
+  latestNonDraftWorkVersionId: string,
+): string | null {
+  if (!requestedWorkVersionId || requestedWorkVersionId === latestNonDraftWorkVersionId) {
+    return null;
+  }
+  return SUBMIT_TO_SITE_LATEST_VERSION_ONLY_ERROR;
+}
+
 /** Stable advisory-lock key for one work submitting to one site. */
 export function workSiteSubmitLockKey(workId: string, siteId: string): string {
   return `work-site-submit:${workId}:${siteId}`;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes submission routing and concurrency for work-to-site flows; extension failures block core fallback, and transaction timeouts may leave ambiguous in-flight state.
> 
> **Overview**
> Adds **extension-owned submit-to-site**: extensions can declare `getOperatedSites` and an optional `submitToSite` handler; core picks the first match via `resolveSubmitToSiteExtension` and either runs that handler or the existing central flow—**no fallback** if a handler is registered and fails.
> 
> The work `submit-to-site` action calls the extension inside a transaction with the same **pg advisory lock** as the central path, returns optional **`redirectPath`**, and handles **Prisma P2028** timeouts with a “may still be processing” message. **Only the latest completed work version** may be submitted (server policy + UI locks the version picker with a tooltip).
> 
> **SubmittedToBar** uses `resolveSubmitRedirectTarget` after success (custom path vs default submission URL vs toast), and adds **double-submit** protection (ref lock + disable all site buttons while in flight).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a76ae4a5c9d0504760297d71af9e224001907b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->