### PR TITLE
🔀 narrow allowed uploads & UI fixes

### DIFF
--- a/.changeset/create-work-sort-last-option.md
+++ b/.changeset/create-work-sort-last-option.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-core': patch
+---
+
+Add `sortLast` to work create options so entries like Article can be listed after extension flows in the My Works create dropdown; extension options still sort by `order` (default 100).

--- a/.changeset/limit-manuscript-upload-single-file.md
+++ b/.changeset/limit-manuscript-upload-single-file.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-core': patch
+'@curvenote/scms': patch
+---
+
+Limit work upload manuscript slot to a single file until multi-file handling improves: set `multiple: false` and `maxFiles: 1`, update upload page copy, and use singular dropzone helper text when multi-upload is disabled.

--- a/packages/scms-core/src/components/upload/WorkFileUpload.tsx
+++ b/packages/scms-core/src/components/upload/WorkFileUpload.tsx
@@ -544,7 +544,9 @@ export function WorkFileUpload({
                   <span className="text-blue-500 underline cursor-pointer">
                     Browse your computer
                   </span>
-                  <span className="text-stone-400">{' or drag and drop your file(s) here'}</span>
+                  <span className="text-stone-400">
+                    {multiple ? ' or drag and drop your files here' : ' or drag and drop your file here'}
+                  </span>
                 </>
               )}
             </p>

--- a/packages/scms-core/src/components/upload/WorkFileUpload.tsx
+++ b/packages/scms-core/src/components/upload/WorkFileUpload.tsx
@@ -545,7 +545,9 @@ export function WorkFileUpload({
                     Browse your computer
                   </span>
                   <span className="text-stone-400">
-                    {multiple ? ' or drag and drop your files here' : ' or drag and drop your file here'}
+                    {multiple
+                      ? ' or drag and drop your files here'
+                      : ' or drag and drop your file here'}
                   </span>
                 </>
               )}

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -41,7 +41,10 @@ export interface WorkCreateOption {
   scopes?: string[];
   /** Present when the option is supplied by an extension. */
   extensionId?: string;
+  /** Lower values appear earlier among non-`sortLast` options (default 100). */
   order?: number;
+  /** When true, this option is listed after all other options (then by label). */
+  sortLast?: boolean;
 }
 
 /** @deprecated Use WorkCreateOption */

--- a/packages/scms-core/src/modules/workCreate/builtinArticleOption.ts
+++ b/packages/scms-core/src/modules/workCreate/builtinArticleOption.ts
@@ -12,5 +12,5 @@ export const BUILTIN_ARTICLE_WORK_CREATE_OPTION: WorkCreateOption = {
   metadataKey: 'frontmatter.myst',
   startPath: '/app/works/new',
   mode: 'composite',
-  order: 0,
+  sortLast: true,
 };

--- a/packages/scms-core/src/modules/workCreate/workCreateOptions.test.ts
+++ b/packages/scms-core/src/modules/workCreate/workCreateOptions.test.ts
@@ -76,17 +76,24 @@ describe('getAvailableWorkCreateOptions', () => {
 
   it('merges Article with enabled extension options', () => {
     const options = getAvailableWorkCreateOptions({ pmc: { routes: true } }, mockExtensions, []);
-    expect(options.map((o) => o.id)).toEqual(['article', 'pmc-deposit']);
+    expect(options.map((o) => o.id)).toEqual(['pmc-deposit', 'article']);
   });
 
   it('includes Check My Work when checks feature scope is present', () => {
     const options = getAvailableWorkCreateOptions({}, [], ['app:works:checks:feature']);
-    expect(options.map((o) => o.id)).toEqual(['article', 'check']);
+    expect(options.map((o) => o.id)).toEqual(['check', 'article']);
   });
 
   it('omits Check My Work without checks feature scope', () => {
     const options = getAvailableWorkCreateOptions({}, [], ['app:works:upload']);
     expect(options.map((o) => o.id)).toEqual(['article']);
+  });
+
+  it('sorts sortLast options after extension and other built-in options', () => {
+    const options = getAvailableWorkCreateOptions({ pmc: { routes: true } }, mockExtensions, [
+      'app:works:checks:feature',
+    ]);
+    expect(options.map((o) => o.id)).toEqual(['check', 'pmc-deposit', 'article']);
   });
 });
 

--- a/packages/scms-core/src/modules/workCreate/workCreateOptions.ts
+++ b/packages/scms-core/src/modules/workCreate/workCreateOptions.ts
@@ -62,9 +62,12 @@ export function hydrateWorkCreateOptions(
 }
 
 function sortWorkCreateOptions(options: WorkCreateOption[]): WorkCreateOption[] {
-  return options.sort(
-    (a, b) => (a.order ?? 100) - (b.order ?? 100) || a.label.localeCompare(b.label),
-  );
+  return [...options].sort((a, b) => {
+    const aLast = a.sortLast === true ? 1 : 0;
+    const bLast = b.sortLast === true ? 1 : 0;
+    if (aLast !== bLast) return aLast - bLast;
+    return (a.order ?? 100) - (b.order ?? 100) || a.label.localeCompare(b.label);
+  });
 }
 
 function userHasAllScopes(userScopes: string[], requiredScopes: string[]): boolean {

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
@@ -1162,8 +1162,8 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
             className="space-y-4 max-w-3xl"
           >
             <p className="text-md text-muted-foreground">
-              Upload one or more manuscript files (DOCX or PDF), up to 100 MB total. Individual
-              check services may have stricter limits.
+              Upload a single manuscript file (DOCX or PDF), up to 100 MB. Individual check services
+              may have stricter limits.
             </p>
             <WorkFileUpload
               cdnKey={cdnKey}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/uploadConfig.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/uploadConfig.server.ts
@@ -6,9 +6,10 @@ export const WORK_UPLOAD_CONFIGURATION: Record<string, FileUploadConfig> = {
     slot: 'manuscript',
     label: 'Manuscript',
     icon: 'file',
-    description: 'Upload one or more manuscript files (.docx or .pdf), up to 100 MB total',
+    description: 'Upload a manuscript file (.docx or .pdf), up to 100 MB',
     optional: false,
-    multiple: true,
+    multiple: false,
+    maxFiles: 1,
     accept: MANUSCRIPT_UPLOAD_ACCEPT,
     mimeTypes: [...MANUSCRIPT_UPLOAD_MIME_TYPES],
     maxTotalSize: 100 * 1024 * 1024, // 100 MB total across slot


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Product/UX limits on upload and menu ordering; no auth or persistence schema changes. Existing drafts with multiple manuscript files are not migrated by this diff.
> 
> **Overview**
> **Manuscript upload** is capped at one file for now: server config sets `multiple: false` and `maxFiles: 1`, the upload route copy describes a single DOCX/PDF (100 MB), and `WorkFileUpload` uses singular dropzone helper text when multi-upload is off.
> 
> **My Works create menu** ordering changes via a new `sortLast` flag on `WorkCreateOption`. Sorting lists non-`sortLast` entries first by `order` (default 100), then `sortLast` entries by label. Built-in **Article** uses `sortLast: true` instead of `order: 0`, so extension flows (e.g. Check, PMC) appear above Article in the dropdown. Tests cover the new order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc7a9ac5c9c3b1c6e6d87660bb613d15352b574d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->