### PR TITLE
⚡️ faster previews

### DIFF
--- a/.changeset/cool-horses-build.md
+++ b/.changeset/cool-horses-build.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms': patch
+---
+
+Decoupling first page preview from thumbnail extraction

--- a/package-lock.json
+++ b/package-lock.json
@@ -43296,16 +43296,6 @@
         "typescript": "^5.7.0"
       }
     },
-    "platform/relay/node_modules/@types/node": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "platform/relay/node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -43317,13 +43307,6 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
-    },
-    "platform/relay/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "platform/scms": {
       "name": "@curvenote/scms",
@@ -43378,6 +43361,7 @@
         "nprogress": "^0.2.0",
         "officeparser": "^6.0.4",
         "p-limit": "^3.1.0",
+        "pdfjs-dist": "^5.6.205",
         "react": "^18.3.1",
         "react-router": "7.9.5",
         "sharp": "^0.35.1",
@@ -43451,6 +43435,16 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "platform/scms/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "platform/scms/node_modules/@types/react": {
@@ -43654,6 +43648,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "platform/scms/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { Columns4, Image as ImageIcon, Check, LayoutGrid } from 'lucide-react';
+import { Columns4, Image as ImageIcon, Check, LayoutGrid, RefreshCw } from 'lucide-react';
 import { LoadingSpinner, SectionWithHeading, cn, ui } from '@curvenote/scms-core';
 import { collectAllFigures } from './DocumentPreviewer';
 import {
@@ -31,6 +31,9 @@ export interface ChooseThumbnailSectionProps {
   pinnedThumbnail?: PinnedThumbnail | null;
   /** True while phase-B figure extraction is in progress. */
   isFiguresLoading?: boolean;
+  /** Show a manual re-try control after the latest figures fetch has finished. */
+  showFiguresRetry?: boolean;
+  onRetryFigures?: () => void;
   /**
    * When provided, a long-running figures busy state (>15s) reveals an escape hatch
    * that calls this to abandon thumbnail generation and continue without candidates.
@@ -129,6 +132,23 @@ function GalleryLayoutToggle({
         <LayoutGrid className="w-5 h-5" />
       </ui.ToggleGroupItem>
     </ui.ToggleGroup>
+  );
+}
+
+function FiguresRetryButton({ onRetry, disabled }: { onRetry: () => void; disabled?: boolean }) {
+  return (
+    <ui.Button
+      type="button"
+      variant="link"
+      size="sm"
+      className="p-0 h-auto text-xs"
+      onClick={onRetry}
+      disabled={disabled}
+      title="Re-try thumbnail extraction"
+    >
+      <RefreshCw className="mr-px w-3.5 h-3.5" />
+      re-try
+    </ui.Button>
   );
 }
 
@@ -325,6 +345,8 @@ export function ChooseThumbnailSection({
   onChange,
   pinnedThumbnail = null,
   isFiguresLoading = false,
+  showFiguresRetry = false,
+  onRetryFigures,
   onSkipFigures,
 }: ChooseThumbnailSectionProps) {
   const [layout, setLayout] = useState<ThumbnailGalleryLayout>('row');
@@ -404,6 +426,9 @@ export function ChooseThumbnailSection({
     }
   }, [rowGalleryOverflows, layout]);
 
+  const showFiguresRetryControl = showFiguresRetry && onRetryFigures != null;
+  const showGalleryToolbar = showFiguresRetryControl || rowGalleryOverflows;
+
   return (
     <SectionWithHeading
       heading="Choose a Thumbnail"
@@ -414,18 +439,30 @@ export function ChooseThumbnailSection({
         Select an image from your document to use as the thumbnail.
       </p>
       {showStandaloneEmpty ? (
-        <StandaloneEmptyGallery
-          showBusy={showStandaloneFiguresBusy}
-          emptyMessage={emptyMessage}
-          busyMessage={figuresBusyMessage}
-          onSkipFigures={onSkipFigures}
-        />
+        <div className="space-y-2">
+          {showFiguresRetryControl ? (
+            <div className="flex justify-end">
+              <FiguresRetryButton onRetry={onRetryFigures} disabled={isFiguresLoading} />
+            </div>
+          ) : null}
+          <StandaloneEmptyGallery
+            showBusy={showStandaloneFiguresBusy}
+            emptyMessage={emptyMessage}
+            busyMessage={figuresBusyMessage}
+            onSkipFigures={onSkipFigures}
+          />
+        </div>
       ) : null}
       {showGalleryRow ? (
         <div className="relative">
-          {rowGalleryOverflows ? (
-            <div className="absolute top-0 right-1 z-10">
-              <GalleryLayoutToggle value={layout} onChange={setLayout} />
+          {showGalleryToolbar ? (
+            <div className="absolute top-0 right-1 z-10 flex gap-2 items-center">
+              {showFiguresRetryControl ? (
+                <FiguresRetryButton onRetry={onRetryFigures} disabled={isFiguresLoading} />
+              ) : null}
+              {rowGalleryOverflows ? (
+                <GalleryLayoutToggle value={layout} onChange={setLayout} />
+              ) : null}
             </div>
           ) : null}
           <div
@@ -435,7 +472,7 @@ export function ChooseThumbnailSection({
               layout === 'row'
                 ? cn(
                     'flex items-stretch overflow-x-auto overflow-y-hidden overscroll-x-contain gap-4 px-1 [scrollbar-gutter:stable]',
-                    rowGalleryOverflows && 'pr-14',
+                    showGalleryToolbar && 'pr-14',
                   )
                 : 'grid grid-cols-2 items-stretch gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5',
             )}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
@@ -388,10 +388,8 @@ export function ChooseThumbnailSection({
   const hasExtractedFigures = figures.length > 0;
   const hasGalleryTiles = hasPinnedThumbnail || hasExtractedFigures;
   const showStandaloneEmpty = !hasGalleryTiles;
-  const showGalleryRow = hasGalleryTiles || (hasPinnedThumbnail && isFiguresLoading);
   const showPinnedLoadingPlaceholder =
     hasPinnedThumbnail && isFiguresLoading && !hasExtractedFigures;
-  const showStandaloneFiguresBusy = isFiguresLoading && showStandaloneEmpty;
   const tileCount =
     (hasPinnedThumbnail ? 1 : 0) + figures.length + (showPinnedLoadingPlaceholder ? 1 : 0);
   const { galleryRef, overflows: rowGalleryOverflows } = useRowGalleryOverflow({
@@ -446,14 +444,14 @@ export function ChooseThumbnailSection({
             </div>
           ) : null}
           <StandaloneEmptyGallery
-            showBusy={showStandaloneFiguresBusy}
+            showBusy={isFiguresLoading}
             emptyMessage={emptyMessage}
             busyMessage={figuresBusyMessage}
             onSkipFigures={onSkipFigures}
           />
         </div>
       ) : null}
-      {showGalleryRow ? (
+      {hasGalleryTiles ? (
         <div className="relative">
           {showGalleryToolbar ? (
             <div className="absolute top-0 right-1 z-10 flex gap-2 items-center">

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Columns4, Image as ImageIcon, Check, LayoutGrid } from 'lucide-react';
-import { SectionWithHeading, cn, ui } from '@curvenote/scms-core';
+import { LoadingSpinner, SectionWithHeading, cn, ui } from '@curvenote/scms-core';
 import { collectAllFigures } from './DocumentPreviewer';
 import {
   buildThumbnailCandidateLocators,
@@ -22,6 +22,8 @@ export interface ChooseThumbnailSectionProps {
   onChange: (locator: string | null) => void;
   /** Inherited thumbnail from a prior version — always rendered first when present. */
   pinnedThumbnail?: PinnedThumbnail | null;
+  /** True while phase-B figure extraction is in progress. */
+  isFiguresLoading?: boolean;
 }
 
 type ThumbnailGalleryLayout = 'row' | 'grid';
@@ -207,6 +209,7 @@ export function ChooseThumbnailSection({
   value,
   onChange,
   pinnedThumbnail = null,
+  isFiguresLoading = false,
 }: ChooseThumbnailSectionProps) {
   const [layout, setLayout] = useState<ThumbnailGalleryLayout>('row');
   const allFigures = useMemo(() => collectAllFigures(previewList), [previewList]);
@@ -240,9 +243,12 @@ export function ChooseThumbnailSection({
   const emptyMessage =
     previewList.length === 0 && !pinnedThumbnail
       ? 'No images yet'
-      : 'No figures were found in the current document previews.';
+      : isFiguresLoading
+        ? 'Generating thumbnail candidates…'
+        : 'No figures were found in the current document previews.';
 
   const hasTiles = Boolean(pinnedThumbnail) || figures.length > 0;
+  const showFiguresLoading = isFiguresLoading && !hasTiles;
   const tileCount = (pinnedThumbnail ? 1 : 0) + figures.length;
   const { galleryRef, overflows: rowGalleryOverflows } = useRowGalleryOverflow({
     tileCount,
@@ -266,7 +272,14 @@ export function ChooseThumbnailSection({
       </p>
       {!hasTiles ? (
         <div className="flex justify-center items-center px-6 py-8 text-center bg-white rounded-md border border-dashed min-h-36 border-stone-300 dark:border-stone-600 dark:bg-stone-900">
-          <p className="max-w-sm text-sm text-muted-foreground">{emptyMessage}</p>
+          {showFiguresLoading ? (
+            <div className="flex flex-col gap-3 items-center">
+              <LoadingSpinner size="sm" />
+              <p className="max-w-sm text-sm text-muted-foreground">{emptyMessage}</p>
+            </div>
+          ) : (
+            <p className="max-w-sm text-sm text-muted-foreground">{emptyMessage}</p>
+          )}
         </div>
       ) : null}
       {hasTiles ? (

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
@@ -226,7 +226,7 @@ function FiguresLoadingPlaceholder({
         <p className="pr-6 text-xs invisible truncate min-h-[1rem]" aria-hidden>
           &nbsp;
         </p>
-        <div className="relative flex-1 min-h-0 rounded aspect-square bg-stone-50 dark:bg-stone-800/50">
+        <div className="relative min-h-0 flex-1 w-full overflow-hidden rounded bg-stone-50 dark:bg-stone-800/50">
           <FiguresBusyOverlay message={message} onSkipFigures={onSkipFigures} compact />
         </div>
       </div>
@@ -403,13 +403,13 @@ export function ChooseThumbnailSection({
           <div
             ref={galleryRef}
             className={cn(
-              'items-center py-1 pt-2',
+              'py-1 pt-2',
               layout === 'row'
                 ? cn(
-                    'flex overflow-x-auto overflow-y-hidden overscroll-x-contain gap-4 px-1 [scrollbar-gutter:stable]',
+                    'flex items-stretch overflow-x-auto overflow-y-hidden overscroll-x-contain gap-4 px-1 [scrollbar-gutter:stable]',
                     rowGalleryOverflows && 'pr-14',
                   )
-                : 'grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5',
+                : 'grid grid-cols-2 items-stretch gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5',
             )}
           >
             {pinnedThumbnail && pinnedLocator ? (

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
@@ -141,20 +141,23 @@ function figureLabelFromKey(key: string): string {
 function FiguresBusyOverlay({
   message,
   onSkipFigures,
+  compact = false,
 }: {
   message: string;
   onSkipFigures?: () => void;
+  /** Smaller spinner when the overlay sits inside a gallery tile slot. */
+  compact?: boolean;
 }) {
   const showSkipHatch = useDelayedFlag(true, FIGURES_SKIP_HATCH_DELAY_MS);
 
   return (
     <div
-      className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 rounded-md bg-background/80 px-6 text-center backdrop-blur-[1px]"
+      className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 rounded-md bg-background/80 px-4 text-center backdrop-blur-[1px]"
       aria-busy="true"
       aria-live="polite"
     >
-      <LoadingSpinner size={32} />
-      <p className="text-sm text-stone-500">{message}</p>
+      <LoadingSpinner size={compact ? 24 : 32} />
+      <p className={cn('text-stone-500', compact ? 'text-xs' : 'text-sm')}>{message}</p>
       {showSkipHatch && onSkipFigures ? (
         <p className="max-w-sm text-xs text-stone-500">
           This is taking longer than usual. You can{' '}
@@ -168,6 +171,65 @@ function FiguresBusyOverlay({
           and continue without a document image.
         </p>
       ) : null}
+    </div>
+  );
+}
+
+function StandaloneEmptyGallery({
+  showBusy,
+  emptyMessage,
+  busyMessage,
+  onSkipFigures,
+}: {
+  showBusy: boolean;
+  emptyMessage: string;
+  busyMessage: string;
+  onSkipFigures?: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        'relative rounded-md border border-dashed border-stone-300 bg-white dark:border-stone-600 dark:bg-stone-900',
+        EMPTY_GALLERY_HEIGHT_CLASS,
+      )}
+    >
+      {showBusy ? (
+        <FiguresBusyOverlay message={busyMessage} onSkipFigures={onSkipFigures} />
+      ) : (
+        <div className="flex h-full items-center justify-center px-6 text-center">
+          <p className="max-w-sm text-sm text-muted-foreground">{emptyMessage}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Occupies remaining gallery width beside a pinned tile while figure extraction runs. */
+function FiguresLoadingPlaceholder({
+  layout,
+  message,
+  onSkipFigures,
+}: {
+  layout: ThumbnailGalleryLayout;
+  message: string;
+  onSkipFigures?: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-[1px] justify-center items-stretch h-full min-w-0',
+        layout === 'row' ? 'flex-1 shrink' : 'w-full',
+      )}
+    >
+      <CurrentLabel visible={false} />
+      <div className="relative flex flex-col flex-1 gap-1 min-h-0 rounded-md border border-dashed border-stone-300 bg-white px-2 py-1 dark:border-stone-600 dark:bg-stone-900">
+        <p className="pr-6 text-xs invisible truncate min-h-[1rem]" aria-hidden>
+          &nbsp;
+        </p>
+        <div className="relative flex-1 min-h-0 rounded aspect-square bg-stone-50 dark:bg-stone-800/50">
+          <FiguresBusyOverlay message={message} onSkipFigures={onSkipFigures} compact />
+        </div>
+      </div>
     </div>
   );
 }
@@ -293,9 +355,16 @@ export function ChooseThumbnailSection({
       : 'No figures were found in the current document previews.';
 
   const figuresBusyMessage = 'Generating thumbnail options…';
-  const hasTiles = Boolean(pinnedThumbnail) || figures.length > 0;
-  const showFiguresBusy = isFiguresLoading && !hasTiles;
-  const tileCount = (pinnedThumbnail ? 1 : 0) + figures.length;
+  const hasPinnedThumbnail = Boolean(pinnedThumbnail);
+  const hasExtractedFigures = figures.length > 0;
+  const hasGalleryTiles = hasPinnedThumbnail || hasExtractedFigures;
+  const showStandaloneEmpty = !hasGalleryTiles;
+  const showGalleryRow = hasGalleryTiles || (hasPinnedThumbnail && isFiguresLoading);
+  const showPinnedLoadingPlaceholder =
+    hasPinnedThumbnail && isFiguresLoading && !hasExtractedFigures;
+  const showStandaloneFiguresBusy = isFiguresLoading && showStandaloneEmpty;
+  const tileCount =
+    (hasPinnedThumbnail ? 1 : 0) + figures.length + (showPinnedLoadingPlaceholder ? 1 : 0);
   const { galleryRef, overflows: rowGalleryOverflows } = useRowGalleryOverflow({
     tileCount,
     layout,
@@ -311,28 +380,20 @@ export function ChooseThumbnailSection({
     <SectionWithHeading
       heading="Choose a Thumbnail"
       icon={<ImageIcon className="w-5 h-5" />}
-      className={cn('space-y-4', !hasTiles ? 'max-w-3xl' : 'max-w-none')}
+      className={cn('space-y-4', showStandaloneEmpty ? 'max-w-3xl' : 'max-w-none')}
     >
       <p className="text-muted-foreground">
         Select an image from your document to use as the thumbnail.
       </p>
-      {!hasTiles ? (
-        <div
-          className={cn(
-            'relative rounded-md border border-dashed border-stone-300 bg-white dark:border-stone-600 dark:bg-stone-900',
-            EMPTY_GALLERY_HEIGHT_CLASS,
-          )}
-        >
-          {showFiguresBusy ? (
-            <FiguresBusyOverlay message={figuresBusyMessage} onSkipFigures={onSkipFigures} />
-          ) : (
-            <div className="flex h-full items-center justify-center px-6 text-center">
-              <p className="max-w-sm text-sm text-muted-foreground">{emptyMessage}</p>
-            </div>
-          )}
-        </div>
+      {showStandaloneEmpty ? (
+        <StandaloneEmptyGallery
+          showBusy={showStandaloneFiguresBusy}
+          emptyMessage={emptyMessage}
+          busyMessage={figuresBusyMessage}
+          onSkipFigures={onSkipFigures}
+        />
       ) : null}
-      {hasTiles ? (
+      {showGalleryRow ? (
         <div className="relative">
           {rowGalleryOverflows ? (
             <div className="absolute top-0 right-1 z-10">
@@ -378,6 +439,13 @@ export function ChooseThumbnailSection({
                 />
               );
             })}
+            {showPinnedLoadingPlaceholder ? (
+              <FiguresLoadingPlaceholder
+                layout={layout}
+                message={figuresBusyMessage}
+                onSkipFigures={onSkipFigures}
+              />
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
@@ -24,6 +24,8 @@ const FIGURES_SKIP_HATCH_DELAY_MS = 15000;
 /** Fixed height for the empty gallery placeholder — busy overlay must not expand it. */
 const EMPTY_GALLERY_HEIGHT_CLASS = 'h-36';
 
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
 export type PinnedThumbnail = {
   key: string;
   signedUrl: string;
@@ -401,7 +403,7 @@ export function ChooseThumbnailSection({
   const pinnedTileRef = useRef<HTMLDivElement>(null);
   const [pinnedTileHeight, setPinnedTileHeight] = useState<number | undefined>(undefined);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!showPinnedLoadingPlaceholder) {
       setPinnedTileHeight(undefined);
       return;

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
@@ -8,6 +8,13 @@ import {
   resolveThumbnailSelection,
 } from './thumbnailSelection';
 import type { DocumentPreviewItem } from './fetchPreviews.server';
+import { useDelayedFlag } from './useDelayedFlag';
+
+/** Reveal the skip escape hatch after this long in the figures busy state. */
+const FIGURES_SKIP_HATCH_DELAY_MS = 15000;
+
+/** Fixed height for the empty gallery placeholder — busy overlay must not expand it. */
+const EMPTY_GALLERY_HEIGHT_CLASS = 'h-36';
 
 export type PinnedThumbnail = {
   key: string;
@@ -24,6 +31,11 @@ export interface ChooseThumbnailSectionProps {
   pinnedThumbnail?: PinnedThumbnail | null;
   /** True while phase-B figure extraction is in progress. */
   isFiguresLoading?: boolean;
+  /**
+   * When provided, a long-running figures busy state (>15s) reveals an escape hatch
+   * that calls this to abandon thumbnail generation and continue without candidates.
+   */
+  onSkipFigures?: () => void;
 }
 
 type ThumbnailGalleryLayout = 'row' | 'grid';
@@ -126,6 +138,40 @@ function figureLabelFromKey(key: string): string {
   return withoutExt || 'Figure';
 }
 
+function FiguresBusyOverlay({
+  message,
+  onSkipFigures,
+}: {
+  message: string;
+  onSkipFigures?: () => void;
+}) {
+  const showSkipHatch = useDelayedFlag(true, FIGURES_SKIP_HATCH_DELAY_MS);
+
+  return (
+    <div
+      className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 rounded-md bg-background/80 px-6 text-center backdrop-blur-[1px]"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <LoadingSpinner size={32} />
+      <p className="text-sm text-stone-500">{message}</p>
+      {showSkipHatch && onSkipFigures ? (
+        <p className="max-w-sm text-xs text-stone-500">
+          This is taking longer than usual. You can{' '}
+          <button
+            type="button"
+            onClick={onSkipFigures}
+            className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+          >
+            skip generating thumbnails
+          </button>{' '}
+          and continue without a document image.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 function CurrentLabel({ visible }: { visible: boolean }) {
   return (
     <p
@@ -210,6 +256,7 @@ export function ChooseThumbnailSection({
   onChange,
   pinnedThumbnail = null,
   isFiguresLoading = false,
+  onSkipFigures,
 }: ChooseThumbnailSectionProps) {
   const [layout, setLayout] = useState<ThumbnailGalleryLayout>('row');
   const allFigures = useMemo(() => collectAllFigures(previewList), [previewList]);
@@ -243,12 +290,11 @@ export function ChooseThumbnailSection({
   const emptyMessage =
     previewList.length === 0 && !pinnedThumbnail
       ? 'No images yet'
-      : isFiguresLoading
-        ? 'Generating thumbnail candidates…'
-        : 'No figures were found in the current document previews.';
+      : 'No figures were found in the current document previews.';
 
+  const figuresBusyMessage = 'Generating thumbnail options…';
   const hasTiles = Boolean(pinnedThumbnail) || figures.length > 0;
-  const showFiguresLoading = isFiguresLoading && !hasTiles;
+  const showFiguresBusy = isFiguresLoading && !hasTiles;
   const tileCount = (pinnedThumbnail ? 1 : 0) + figures.length;
   const { galleryRef, overflows: rowGalleryOverflows } = useRowGalleryOverflow({
     tileCount,
@@ -271,14 +317,18 @@ export function ChooseThumbnailSection({
         Select an image from your document to use as the thumbnail.
       </p>
       {!hasTiles ? (
-        <div className="flex justify-center items-center px-6 py-8 text-center bg-white rounded-md border border-dashed min-h-36 border-stone-300 dark:border-stone-600 dark:bg-stone-900">
-          {showFiguresLoading ? (
-            <div className="flex flex-col gap-3 items-center">
-              <LoadingSpinner size="sm" />
+        <div
+          className={cn(
+            'relative rounded-md border border-dashed border-stone-300 bg-white dark:border-stone-600 dark:bg-stone-900',
+            EMPTY_GALLERY_HEIGHT_CLASS,
+          )}
+        >
+          {showFiguresBusy ? (
+            <FiguresBusyOverlay message={figuresBusyMessage} onSkipFigures={onSkipFigures} />
+          ) : (
+            <div className="flex h-full items-center justify-center px-6 text-center">
               <p className="max-w-sm text-sm text-muted-foreground">{emptyMessage}</p>
             </div>
-          ) : (
-            <p className="max-w-sm text-sm text-muted-foreground">{emptyMessage}</p>
           )}
         </div>
       ) : null}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
@@ -143,7 +143,7 @@ function GalleryLayoutToggle({
   );
 }
 
-function FiguresRetryButton({ onRetry, disabled }: { onRetry: () => void; disabled?: boolean }) {
+function FiguresRetryButton({ onRetry }: { onRetry: () => void }) {
   return (
     <ui.Button
       type="button"
@@ -151,7 +151,6 @@ function FiguresRetryButton({ onRetry, disabled }: { onRetry: () => void; disabl
       size="sm"
       className="p-0 h-auto text-xs"
       onClick={onRetry}
-      disabled={disabled}
       title="Re-try thumbnail extraction"
     >
       <RefreshCw className="mr-px w-3.5 h-3.5" />
@@ -443,7 +442,7 @@ export function ChooseThumbnailSection({
         <div className="space-y-2">
           {showFiguresRetryControl ? (
             <div className="flex justify-end">
-              <FiguresRetryButton onRetry={onRetryFigures} disabled={isFiguresLoading} />
+              <FiguresRetryButton onRetry={onRetryFigures} />
             </div>
           ) : null}
           <StandaloneEmptyGallery
@@ -458,9 +457,7 @@ export function ChooseThumbnailSection({
         <div className="relative">
           {showGalleryToolbar ? (
             <div className="absolute top-0 right-1 z-10 flex gap-2 items-center">
-              {showFiguresRetryControl ? (
-                <FiguresRetryButton onRetry={onRetryFigures} disabled={isFiguresLoading} />
-              ) : null}
+              {showFiguresRetryControl ? <FiguresRetryButton onRetry={onRetryFigures} /> : null}
               {rowGalleryOverflows ? (
                 <GalleryLayoutToggle value={layout} onChange={setLayout} />
               ) : null}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Columns4, Image as ImageIcon, Check, LayoutGrid, RefreshCw } from 'lucide-react';
 import { LoadingSpinner, SectionWithHeading, cn, ui } from '@curvenote/scms-core';
 import { collectAllFigures } from './DocumentPreviewer';
@@ -272,16 +280,7 @@ function CurrentLabel({ visible }: { visible: boolean }) {
   );
 }
 
-function ThumbnailTile({
-  label,
-  imageSrc,
-  imageAlt,
-  isSelected,
-  isCurrent,
-  onSelect,
-  layout,
-  ref,
-}: {
+type ThumbnailTileProps = {
   label: string;
   imageSrc: string | undefined;
   imageAlt: string;
@@ -289,8 +288,12 @@ function ThumbnailTile({
   isCurrent?: boolean;
   onSelect: () => void;
   layout: ThumbnailGalleryLayout;
-  ref?: React.Ref<HTMLDivElement>;
-}) {
+};
+
+const ThumbnailTile = forwardRef<HTMLDivElement, ThumbnailTileProps>(function ThumbnailTile(
+  { label, imageSrc, imageAlt, isSelected, isCurrent, onSelect, layout },
+  ref,
+) {
   return (
     <div
       ref={ref}
@@ -337,7 +340,7 @@ function ThumbnailTile({
       </button>
     </div>
   );
-}
+});
 
 export function ChooseThumbnailSection({
   previewList,

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Columns4, Image as ImageIcon, Check, LayoutGrid } from 'lucide-react';
 import { LoadingSpinner, SectionWithHeading, cn, ui } from '@curvenote/scms-core';
 import { collectAllFigures } from './DocumentPreviewer';
@@ -209,20 +209,24 @@ function FiguresLoadingPlaceholder({
   layout,
   message,
   onSkipFigures,
+  tileHeight,
 }: {
   layout: ThumbnailGalleryLayout;
   message: string;
   onSkipFigures?: () => void;
+  /** Matched to the pinned thumbnail column so the row stays one height. */
+  tileHeight?: number;
 }) {
   return (
     <div
+      style={tileHeight != null ? { height: tileHeight } : undefined}
       className={cn(
-        'flex flex-col gap-[1px] justify-center items-stretch h-full min-w-0',
-        layout === 'row' ? 'flex-1 shrink' : 'w-full',
+        'flex min-h-0 flex-col gap-[1px] items-stretch self-stretch',
+        layout === 'row' ? 'min-w-0 flex-1 shrink' : 'w-full',
       )}
     >
       <CurrentLabel visible={false} />
-      <div className="relative flex flex-col flex-1 gap-1 min-h-0 rounded-md border border-dashed border-stone-300 bg-white px-2 py-1 dark:border-stone-600 dark:bg-stone-900">
+      <div className="relative flex min-h-0 flex-1 flex-col gap-1 rounded-md border border-dashed border-stone-300 bg-white px-2 py-1 dark:border-stone-600 dark:bg-stone-900">
         <p className="pr-6 text-xs invisible truncate min-h-[1rem]" aria-hidden>
           &nbsp;
         </p>
@@ -256,6 +260,7 @@ function ThumbnailTile({
   isCurrent,
   onSelect,
   layout,
+  ref,
 }: {
   label: string;
   imageSrc: string | undefined;
@@ -264,11 +269,13 @@ function ThumbnailTile({
   isCurrent?: boolean;
   onSelect: () => void;
   layout: ThumbnailGalleryLayout;
+  ref?: React.Ref<HTMLDivElement>;
 }) {
   return (
     <div
+      ref={ref}
       className={cn(
-        'flex flex-col gap-[1px] justify-center items-stretch h-full',
+        'flex flex-col gap-[1px] items-stretch self-stretch',
         layout === 'row' ? rowTileWidthClassName : 'w-full min-w-0',
       )}
     >
@@ -369,6 +376,27 @@ export function ChooseThumbnailSection({
     tileCount,
     layout,
   });
+  const pinnedTileRef = useRef<HTMLDivElement>(null);
+  const [pinnedTileHeight, setPinnedTileHeight] = useState<number | undefined>(undefined);
+
+  useLayoutEffect(() => {
+    if (!showPinnedLoadingPlaceholder) {
+      setPinnedTileHeight(undefined);
+      return;
+    }
+
+    const el = pinnedTileRef.current;
+    if (!el) return;
+
+    const syncHeight = () => {
+      setPinnedTileHeight(el.getBoundingClientRect().height);
+    };
+
+    syncHeight();
+    const observer = new ResizeObserver(syncHeight);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [showPinnedLoadingPlaceholder, pinnedLabel, pinnedThumbnail?.signedUrl, layout]);
 
   useEffect(() => {
     if (!rowGalleryOverflows && layout === 'grid') {
@@ -415,6 +443,7 @@ export function ChooseThumbnailSection({
             {pinnedThumbnail && pinnedLocator ? (
               <ThumbnailTile
                 key={pinnedLocator}
+                ref={showPinnedLoadingPlaceholder ? pinnedTileRef : undefined}
                 layout={layout}
                 label={pinnedLabel}
                 imageSrc={pinnedThumbnail.signedUrl}
@@ -444,6 +473,7 @@ export function ChooseThumbnailSection({
                 layout={layout}
                 message={figuresBusyMessage}
                 onSkipFigures={onSkipFigures}
+                tileHeight={pinnedTileHeight}
               />
             ) : null}
           </div>

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Columns4, Image as ImageIcon, Check, LayoutGrid } from 'lucide-react';
 import { LoadingSpinner, SectionWithHeading, cn, ui } from '@curvenote/scms-core';
 import { collectAllFigures } from './DocumentPreviewer';
@@ -80,7 +80,7 @@ function useRowGalleryOverflow({
     setOverflows(tileCount > rowGalleryColumnCount(el.clientWidth));
   }, [layout, tileCount]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     measureOverflow();
     const el = galleryRef.current;
     if (!el) return;
@@ -301,7 +301,7 @@ export function ChooseThumbnailSection({
     layout,
   });
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!rowGalleryOverflows && layout === 'grid') {
       setLayout('row');
     }

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.spec.ts
@@ -141,6 +141,15 @@ describe('resolvePreviewImagePresence', () => {
     ).toBe('unknown');
   });
 
+  it('returns unknown while figure extraction is still pending', () => {
+    expect(
+      resolvePreviewImagePresence(
+        ['a.pdf'],
+        [{ path: 'a.pdf', figures: [], figuresPending: true, figuresExtractionSkipped: false }],
+      ),
+    ).toBe('unknown');
+  });
+
   it('returns unknown for legacy cached previews with empty figures and no extraction flag', () => {
     expect(resolvePreviewImagePresence(['a.pdf'], [{ path: 'a.pdf', figures: [] }])).toBe(
       'unknown',

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
@@ -1,22 +1,12 @@
 /**
  * Server-side document preview fetching for a work version.
  *
- * For the given work version: finds preview-candidate files in metadata.files
- * (the intersection of officeparser-supported formats and the manuscript dropzone
- * MIME types — see isPreviewCandidate; today {docx, pdf}), downloads each via
- * signed URL, parses with officeparser, and returns the first "page" of content
- * (truncated AST) per file.
+ * Two-phase pipeline:
+ * - Phase A (fetch-previews): fast first-page text AST cached without figures.
+ * - Phase B (fetch-preview-figures): deferred attachment extraction + thumbnail storage.
  *
- * Extracted figures are NOT kept as base64. Each candidate figure is downscaled to a
- * compact webp at parse time and written to object storage under the work version's
- * `thumbnails/` subpath; the cached preview stores only the storage keys. The picker
- * references signed URLs (see signPreviewFigures), so base64 image bytes never hit the
- * Object table, the loader payload, or client memory.
- *
- * Parsed previews are cached in the Object table keyed per work version AND source-file
- * md5 (see documentPreviewCacheId in ./previewCache) so repeated loads skip re-parsing
- * while each version's cache stays isolated. The prefix is versioned: bumping it
- * invalidates older cache shapes.
+ * PDF phase A uses a pdfjs first-page fast path; DOCX uses officeparser without attachments.
+ * Phase B re-parses with officeparser + extractAttachments (v1 tradeoff).
  */
 
 import {
@@ -38,7 +28,8 @@ import {
 import type { Context } from '@curvenote/scms-server';
 import type { Prisma } from '@curvenote/scms-db';
 import { formatDate } from '@curvenote/common';
-import type { OfficeParserAST, OfficeContentNode, OfficeAttachment } from 'officeparser';
+import type { OfficeAttachment } from 'officeparser';
+import pLimit from 'p-limit';
 import { isPreviewCandidate } from './previewGuards';
 import { downscaleToWebp, isRenderableFigureMime } from './imagePipeline.server';
 import {
@@ -46,26 +37,11 @@ import {
   legacyPreviewCacheIds,
   previewCacheObjectIds,
 } from './previewCache';
-
-/** A first page with this much text is enough for metadata extraction on its own. */
-const FIRST_PAGE_MIN_TEXT_LENGTH = 500;
-
-/** Page two must be this much larger than a sparse first page before we include it. */
-const SECOND_PAGE_SIGNIFICANTLY_LARGER_RATIO = 1.5;
-
-/**
- * Target amount of extractable text (chars) to collect for non-paged ASTs (e.g. DOCX),
- * where there are no page nodes to bound "the first page". Roughly one dense page of
- * front matter — enough to reach the title/author block without pulling the whole body.
- */
-const FIRST_PAGE_TARGET_TEXT_LENGTH = 4000;
-
-/**
- * Hard ceiling on the number of top-level nodes collected for non-paged ASTs. Guards
- * pathological documents made of many tiny/empty nodes from being walked unbounded when
- * the character budget is never reached.
- */
-const FIRST_PAGE_MAX_CONTENT_NODES = 40;
+import {
+  emptyPreviewAst,
+  truncateAstToFirstPage,
+  type PreviewAstData,
+} from './previewAstUtils.server';
 
 /** Longest edge (px) of a downscaled candidate figure thumbnail. */
 const PREVIEW_FIGURE_MAX_EDGE = 384;
@@ -75,6 +51,9 @@ const PREVIEW_FIGURE_WEBP_QUALITY = 70;
 
 /** Maximum number of candidate figures to extract/store per document. */
 const MAX_PREVIEW_FIGURES = 24;
+
+/** Parallel figure downscale + storage writes during phase B. */
+const FIGURE_EXTRACTION_CONCURRENCY = 4;
 
 /** Skip preview generation for source files larger than this (protects against OOM). */
 const MAX_PREVIEW_SOURCE_BYTES = 100 * 1024 * 1024;
@@ -89,83 +68,70 @@ function thumbnailKeyForFigure(sourcePath: string, md5: string, index: number): 
 
 /** A candidate thumbnail figure, referenced by storage key (never base64). */
 export interface PreviewFigure {
-  /** Storage key (path) of the downscaled webp candidate thumbnail. */
   key: string;
-  /** Original attachment name, used to resolve inline image nodes in the text preview. */
   name?: string;
   altText?: string;
-  /** Signed read URL — populated at loader time (see signPreviewFigures), never persisted. */
   signedUrl?: string;
 }
 
-/** Top-level WorkVersion.metadata key holding the durable thumbnail listing. */
 export const METADATA_THUMBNAILS_KEY = 'thumbnails';
 
-/**
- * A thumbnail generated during preview extraction and retained in storage for the work
- * version's lifetime. Persisted under metadata.thumbnails on confirm-work so the full
- * set of generated thumbnails can be discovered later (the cached preview rows that also
- * hold these keys are cleaned up on confirm; this listing is the durable record).
- */
 export interface StoredThumbnail {
-  /** Storage key (path) of the downscaled webp thumbnail. */
   key: string;
-  /** Source file path (key in metadata.files) the thumbnail was extracted from. */
   sourcePath: string;
-  /** md5 of the source file, correlating the thumbnail with its source in metadata.files. */
   md5: string;
-  /** Original attachment name, if available. */
   name?: string;
-  /** Original attachment alt text, if available. */
   altText?: string;
 }
 
-/** First-page AST (text/content only — no base64 attachments). */
-export interface PreviewAstData {
-  type: OfficeParserAST['type'];
-  metadata: OfficeParserAST['metadata'];
-  content: OfficeContentNode[];
-  wasTruncated: boolean;
-}
+export type { PreviewAstData };
 
 export interface DocumentPreviewItem {
-  /** File path (key in metadata.files) */
   path: string;
-  /** File metadata (name, size, type, path, etc.) */
   data: FileMetadataSectionItem;
-  /** First-page AST (type, metadata, content only) */
   ast: PreviewAstData;
-  /** Candidate thumbnail figures (storage keys; signedUrl added at loader time). */
   figures: PreviewFigure[];
-  /** True when preview generation was skipped (e.g. source too large). */
   previewUnavailable?: boolean;
-  /** True when figure extraction did not run (e.g. no thumbnail bucket or cache id). */
   figuresExtractionSkipped?: boolean;
+  /** True when phase-B figure extraction is still pending for this preview. */
+  figuresPending?: boolean;
 }
 
 export interface FetchPreviewsResult {
   previews: DocumentPreviewItem[];
 }
 
-/** Shape persisted in Object.data for a cached preview. */
 interface CachedPreview {
   ast: PreviewAstData;
   figures: PreviewFigure[];
   previewUnavailable?: boolean;
   figuresExtractionSkipped?: boolean;
+  figuresPending?: boolean;
+}
+
+interface PreviewWorkContext {
+  workVersionId: string;
+  rawMetadata: Record<string, unknown>;
+  previewEntries: [string, FileMetadataSectionItem & { signedUrl?: string }][];
+  backend: StorageBackend;
+  figureBucket: KnownBuckets | null;
+  prisma: Awaited<ReturnType<typeof getPrismaClient>>;
 }
 
 export function resolvePreviewImagePresence(
   previewCandidatePaths: string[],
   previews: Pick<
     DocumentPreviewItem,
-    'path' | 'figures' | 'previewUnavailable' | 'figuresExtractionSkipped'
+    'path' | 'figures' | 'previewUnavailable' | 'figuresExtractionSkipped' | 'figuresPending'
   >[],
 ): UploadFactPresence {
   if (previewCandidatePaths.length === 0) return 'unknown';
   const previewPaths = new Set(previews.map((preview) => preview.path));
   const hasMissingPreview = previewCandidatePaths.some((path) => !previewPaths.has(path));
   if (hasMissingPreview || previews.some((preview) => preview.previewUnavailable === true)) {
+    return 'unknown';
+  }
+  if (previews.some((preview) => preview.figuresPending === true)) {
     return 'unknown';
   }
   if (previews.some((preview) => preview.figures.length > 0)) {
@@ -231,185 +197,6 @@ function isCachedPreview(data: unknown): data is CachedPreview {
   );
 }
 
-/**
- * Recursively extract plain text from AST content nodes for sending to LLM.
- * Skips image/attachment content (no binary); uses placeholder for images.
- */
-function nodeToPlainText(node: OfficeContentNode): string {
-  if (node.type === 'text') {
-    return (node as { text?: string }).text ?? '';
-  }
-  if (node.type === 'image' || node.type === 'chart' || node.type === 'drawing') {
-    return '';
-  }
-  const children = (node as { children?: OfficeContentNode[] }).children;
-  if (!children?.length) {
-    const direct = (node as { text?: string }).text;
-    return direct != null ? String(direct) : '';
-  }
-  return children.map(nodeToPlainText).join('');
-}
-
-function extractableTextLength(nodes: OfficeContentNode[]): number {
-  return astContentToPlainText(nodes).length;
-}
-
-function isPageNode(node: OfficeContentNode): boolean {
-  return node.type === 'page';
-}
-
-function shouldIncludeSecondPage(
-  firstPage: OfficeContentNode,
-  secondPage?: OfficeContentNode,
-): boolean {
-  if (!secondPage) return false;
-  const firstPageLength = extractableTextLength([firstPage]);
-  if (firstPageLength >= FIRST_PAGE_MIN_TEXT_LENGTH) return false;
-  const secondPageLength = extractableTextLength([secondPage]);
-  if (secondPageLength === 0) return false;
-  return (
-    secondPageLength >=
-    Math.max(FIRST_PAGE_MIN_TEXT_LENGTH, firstPageLength * SECOND_PAGE_SIGNIFICANTLY_LARGER_RATIO)
-  );
-}
-
-/**
- * Select "first page" content for non-paged ASTs (e.g. DOCX) using a hybrid budget:
- * walk top-level nodes in order and accumulate until we have roughly a page of
- * extractable text ({@link FIRST_PAGE_TARGET_TEXT_LENGTH}). Empty nodes (blank
- * paragraphs, image-only blocks) are included for preview fidelity but contribute no
- * text, so they never consume the budget. A node ceiling
- * ({@link FIRST_PAGE_MAX_CONTENT_NODES}) bounds documents made of many tiny nodes where
- * the character budget would otherwise never be reached.
- */
-function selectFirstPageContentByBudget(fullContent: OfficeContentNode[]): OfficeContentNode[] {
-  let textLength = 0;
-  let count = 0;
-  for (; count < fullContent.length; count += 1) {
-    if (count >= FIRST_PAGE_MAX_CONTENT_NODES) break;
-    textLength += extractableTextLength([fullContent[count]]);
-    if (textLength >= FIRST_PAGE_TARGET_TEXT_LENGTH) {
-      count += 1; // include the node that crossed the budget
-      break;
-    }
-  }
-  return fullContent.slice(0, count);
-}
-
-/**
- * Truncate AST content to the first page of content — no base64 attachments.
- *
- * Two strategies, chosen by AST shape:
- * - Paged (notably PDF): officeparser emits `page` nodes, so we keep page one (and
- *   page two when page one is sparse; see {@link shouldIncludeSecondPage}).
- * - Non-paged (notably DOCX): no page nodes exist, so we use a character budget over
- *   top-level nodes (see {@link selectFirstPageContentByBudget}) to gather roughly a
- *   page of text without stopping early on empty paragraphs or image blocks.
- */
-export function truncateAstToFirstPage(ast: OfficeParserAST): PreviewAstData {
-  const fullContent = ast.content ?? [];
-  const pageNodes = fullContent.filter(isPageNode);
-  const usePages = pageNodes.length > 0;
-  const content = usePages
-    ? pageNodes.slice(0, shouldIncludeSecondPage(pageNodes[0], pageNodes[1]) ? 2 : 1)
-    : selectFirstPageContentByBudget(fullContent);
-  const wasTruncated = usePages
-    ? content.length < pageNodes.length
-    : content.length < fullContent.length;
-  return {
-    type: ast.type,
-    metadata: ast.metadata,
-    content,
-    wasTruncated,
-  };
-}
-
-/**
- * Downscale each image attachment to a compact webp and write it to storage under the
- * source file's thumbnails/ subpath. Returns the candidate figures (storage keys only).
- * Best-effort per image: a single failure is skipped rather than aborting the document.
- */
-async function extractAndStoreFigures(
-  attachments: OfficeAttachment[],
-  opts: { sourcePath: string; md5: string; backend: StorageBackend; bucket: KnownBuckets },
-): Promise<PreviewFigure[]> {
-  const images = attachments
-    .filter(
-      (att) =>
-        att.type === 'image' &&
-        typeof att.data === 'string' &&
-        att.data.length > 0 &&
-        // Skip EMF/WMF/PICT metafiles up front: sharp can't decode them, so attempting
-        // would throw and also waste a slot against MAX_PREVIEW_FIGURES.
-        isRenderableFigureMime(att.mimeType),
-    )
-    .slice(0, MAX_PREVIEW_FIGURES);
-
-  const figures: PreviewFigure[] = [];
-  let index = 0;
-  for (const att of images) {
-    try {
-      const source = Buffer.from(att.data, 'base64');
-      const webp = await downscaleToWebp(source, att.mimeType, {
-        maxEdge: PREVIEW_FIGURE_MAX_EDGE,
-        quality: PREVIEW_FIGURE_WEBP_QUALITY,
-      });
-      const key = thumbnailKeyForFigure(opts.sourcePath, opts.md5, index);
-      const file = new File(opts.backend, key, opts.bucket);
-      await file.writeArrayBuffer(
-        webp.buffer.slice(webp.byteOffset, webp.byteOffset + webp.byteLength) as ArrayBuffer,
-        'image/webp',
-      );
-      figures.push({ key, name: att.name, altText: att.altText });
-      index += 1;
-    } catch (err) {
-      // Best-effort: a single undecodable figure shouldn't abort the document. Log the
-      // message (not the full stack) plus the mime type so noisy formats are diagnosable.
-      const message = err instanceof Error ? err.message : String(err);
-      console.warn(
-        'extractAndStoreFigures: skipped figure (decode failed)',
-        opts.sourcePath,
-        att.mimeType,
-        message,
-      );
-    }
-  }
-  return figures;
-}
-
-/**
- * Convert first-page AST content to a single plain text string (no attachments).
- * Used as the document body for the Anthropic fast-find-metadata call.
- */
-export function astContentToPlainText(content: OfficeContentNode[]): string {
-  const parts = content.map((node) => {
-    const text = nodeToPlainText(node);
-    if (node.type === 'paragraph' || node.type === 'heading' || node.type === 'list') {
-      return text ? `${text}\n` : '\n';
-    }
-    if (node.type === 'table') {
-      const children = (node as { children?: OfficeContentNode[] }).children ?? [];
-      const rowTexts = children
-        .filter((c) => (c as { type?: string }).type === 'row')
-        .map((row) => {
-          const cells = (row as { children?: OfficeContentNode[] }).children ?? [];
-          return cells
-            .map((c) => nodeToPlainText(c as OfficeContentNode))
-            .filter(Boolean)
-            .join('\t');
-        });
-      return rowTexts.join('\n') + '\n';
-    }
-    return text;
-  });
-  return parts.join('').trim();
-}
-
-function emptyPreviewAst(sourcePath: string): PreviewAstData {
-  const type: OfficeParserAST['type'] = sourcePath.toLowerCase().endsWith('.pdf') ? 'pdf' : 'docx';
-  return { type, metadata: {} as OfficeParserAST['metadata'], content: [], wasTruncated: false };
-}
-
 function stripSignedUrl(file: FileMetadataSectionItem & { signedUrl?: string }) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { signedUrl: _drop, ...fileMeta } = file;
@@ -424,26 +211,138 @@ function sortPreviewsByOrder(previews: DocumentPreviewItem[]): DocumentPreviewIt
   });
 }
 
-/**
- * Fetch previews for all preview-candidate files in the work version's metadata
- * (see isPreviewCandidate). Downloads each file via signed URL, parses with
- * officeparser, downscales+stores candidate figures, and returns file metadata plus
- * truncated AST (first page of content) and figure storage keys.
- */
-export async function fetchDocumentPreviews(
+function cachedToDocumentPreviewItem(
+  path: string,
+  file: FileMetadataSectionItem & { signedUrl?: string },
+  cached: CachedPreview,
+): DocumentPreviewItem {
+  return {
+    path,
+    data: stripSignedUrl(file),
+    ast: cached.ast,
+    figures: cached.figures,
+    previewUnavailable: cached.previewUnavailable,
+    figuresExtractionSkipped: cached.figuresExtractionSkipped,
+    figuresPending: cached.figuresPending,
+  };
+}
+
+function isPdfFile(path: string, file: FileMetadataSectionItem): boolean {
+  if (path.toLowerCase().endsWith('.pdf')) return true;
+  return file.type?.toLowerCase() === 'application/pdf';
+}
+
+function isDocxFile(path: string, file: FileMetadataSectionItem): boolean {
+  const lower = path.toLowerCase();
+  if (lower.endsWith('.docx') || lower.endsWith('.docm')) return true;
+  const type = file.type?.toLowerCase() ?? '';
+  return (
+    type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+    type === 'application/vnd.ms-word.document.macroenabled.12'
+  );
+}
+
+async function downloadPreviewSource(signedUrl: string): Promise<ArrayBuffer | null> {
+  const response = await fetch(signedUrl);
+  if (!response.ok) return null;
+  return response.arrayBuffer();
+}
+
+async function parseOfficeTextOnly(
+  arrayBuffer: ArrayBuffer,
+  fileType: 'pdf' | 'docx',
+): Promise<PreviewAstData> {
+  const { parseOffice } = await import('officeparser');
+  const fullAst = await parseOffice(arrayBuffer, {
+    extractAttachments: false,
+    fileType,
+    newlineDelimiter: '\n',
+  });
+  return truncateAstToFirstPage(fullAst);
+}
+
+async function generatePhaseATextAst(
+  path: string,
+  file: FileMetadataSectionItem,
+  arrayBuffer: ArrayBuffer,
+): Promise<PreviewAstData> {
+  if (isPdfFile(path, file)) {
+    const { parsePdfFirstPagePreview, isPdfFastPathTextSufficient } =
+      await import('./pdfFirstPagePreview.server');
+    const fastAst = await parsePdfFirstPagePreview(arrayBuffer);
+    if (isPdfFastPathTextSufficient(fastAst)) {
+      return fastAst;
+    }
+    return parseOfficeTextOnly(arrayBuffer, 'pdf');
+  }
+  if (isDocxFile(path, file)) {
+    return parseOfficeTextOnly(arrayBuffer, 'docx');
+  }
+  const { parseOffice } = await import('officeparser');
+  const fullAst = await parseOffice(arrayBuffer, {
+    extractAttachments: false,
+    newlineDelimiter: '\n',
+  });
+  return truncateAstToFirstPage(fullAst);
+}
+
+async function extractAndStoreFigures(
+  attachments: OfficeAttachment[],
+  opts: { sourcePath: string; md5: string; backend: StorageBackend; bucket: KnownBuckets },
+): Promise<PreviewFigure[]> {
+  const images = attachments
+    .filter(
+      (att) =>
+        att.type === 'image' &&
+        typeof att.data === 'string' &&
+        att.data.length > 0 &&
+        isRenderableFigureMime(att.mimeType),
+    )
+    .slice(0, MAX_PREVIEW_FIGURES);
+
+  const limit = pLimit(FIGURE_EXTRACTION_CONCURRENCY);
+  const results = await Promise.all(
+    images.map((att, index) =>
+      limit(async (): Promise<PreviewFigure | null> => {
+        try {
+          const source = Buffer.from(att.data, 'base64');
+          const webp = await downscaleToWebp(source, att.mimeType, {
+            maxEdge: PREVIEW_FIGURE_MAX_EDGE,
+            quality: PREVIEW_FIGURE_WEBP_QUALITY,
+          });
+          const key = thumbnailKeyForFigure(opts.sourcePath, opts.md5, index);
+          const file = new File(opts.backend, key, opts.bucket);
+          await file.writeArrayBuffer(
+            webp.buffer.slice(webp.byteOffset, webp.byteOffset + webp.byteLength) as ArrayBuffer,
+            'image/webp',
+          );
+          return { key, name: att.name, altText: att.altText };
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          console.warn(
+            'extractAndStoreFigures: skipped figure (decode failed)',
+            opts.sourcePath,
+            att.mimeType,
+            message,
+          );
+          return null;
+        }
+      }),
+    ),
+  );
+  return results.filter((fig): fig is PreviewFigure => fig != null);
+}
+
+async function loadPreviewWorkContext(
   workVersionId: string,
   ctx: Context,
-): Promise<FetchPreviewsResult> {
+): Promise<PreviewWorkContext | null> {
   const work = await findWorkByVersion(workVersionId);
-  if (!work?.metadata) {
-    return { previews: [] };
-  }
+  if (!work?.metadata) return null;
 
   const rawMetadata = work.metadata as Record<string, unknown>;
   const files = rawMetadata?.files as Record<string, FileMetadataSectionItem> | undefined;
-  if (!files || typeof files !== 'object') {
-    return { previews: [] };
-  }
+  if (!files || typeof files !== 'object') return null;
 
   const cdn = work.cdn ?? '';
   const signedMetadata = await signFilesInMetadata(
@@ -452,111 +351,149 @@ export async function fetchDocumentPreviews(
     ctx,
   );
   const signedFiles = signedMetadata.files ?? {};
-  const previewEntries = Object.entries(signedFiles).filter(([, file]) => isPreviewCandidate(file));
+  const previewEntries = Object.entries(signedFiles).filter(([, file]) =>
+    isPreviewCandidate(file),
+  ) as [string, FileMetadataSectionItem & { signedUrl?: string }][];
 
   const backend = new StorageBackend(ctx, [KnownBuckets.prv, KnownBuckets.pub]);
   const figureBucket = cdn ? resolveThumbnailBucket(ctx, backend, cdn) : null;
-
-  const previews: DocumentPreviewItem[] = [];
   const prisma = await getPrismaClient();
+
+  return {
+    workVersionId,
+    rawMetadata,
+    previewEntries,
+    backend,
+    figureBucket,
+    prisma,
+  };
+}
+
+async function readCachedPreview(
+  prisma: Awaited<ReturnType<typeof getPrismaClient>>,
+  cacheId: string | null,
+): Promise<CachedPreview | null> {
+  if (!cacheId) return null;
+  const row = await prisma.object.findUnique({
+    where: { id: cacheId },
+    select: { data: true },
+  });
+  if (row?.data != null && isCachedPreview(row.data)) {
+    return row.data;
+  }
+  return null;
+}
+
+async function writePhaseACache(
+  ctx: Context,
+  prisma: Awaited<ReturnType<typeof getPrismaClient>>,
+  cacheId: string,
+  cached: CachedPreview,
+): Promise<void> {
+  const now = formatDate();
+  try {
+    await prisma.object.createMany({
+      data: [
+        {
+          id: cacheId,
+          type: cacheId,
+          date_created: now,
+          date_modified: now,
+          data: cached as object,
+          occ: 0,
+          ...(ctx.user?.id ? { created_by_id: ctx.user.id } : {}),
+        },
+      ],
+      skipDuplicates: true,
+    });
+  } catch (createErr: unknown) {
+    console.warn('fetchDocumentPreviewText: failed to cache preview', cacheId, createErr);
+  }
+}
+
+async function updatePhaseBCache(
+  prisma: Awaited<ReturnType<typeof getPrismaClient>>,
+  cacheId: string,
+  cached: CachedPreview,
+): Promise<void> {
+  const now = formatDate();
+  try {
+    await prisma.object.update({
+      where: { id: cacheId },
+      data: {
+        date_modified: now,
+        data: cached as object,
+      },
+    });
+  } catch (updateErr: unknown) {
+    console.warn('fetchDocumentPreviewFigures: failed to update preview cache', cacheId, updateErr);
+  }
+}
+
+/**
+ * Phase A: cache first-page text AST without figure extraction.
+ */
+export async function fetchDocumentPreviewText(
+  workVersionId: string,
+  ctx: Context,
+): Promise<FetchPreviewsResult> {
+  const previewCtx = await loadPreviewWorkContext(workVersionId, ctx);
+  if (!previewCtx) return { previews: [] };
+
+  const { rawMetadata, previewEntries, figureBucket, prisma } = previewCtx;
+  const previews: DocumentPreviewItem[] = [];
 
   for (const [path, file] of previewEntries) {
     const md5 = file.md5;
     const cacheId =
       typeof md5 === 'string' && md5 ? documentPreviewCacheId(workVersionId, md5) : null;
 
-    let cached: CachedPreview | null = null;
-
-    if (cacheId) {
-      const row = await prisma.object.findUnique({
-        where: { id: cacheId },
-        select: { data: true },
-      });
-      if (row?.data != null && isCachedPreview(row.data)) {
-        cached = row.data;
-      }
-    }
+    let cached = await readCachedPreview(prisma, cacheId);
 
     if (!cached) {
-      // Guard oversized sources to avoid loading/parsing huge documents into memory.
       const size = typeof file.size === 'number' ? file.size : 0;
       if (size > MAX_PREVIEW_SOURCE_BYTES) {
-        console.warn('fetchDocumentPreviews: source too large, skipping preview', path, size);
-        cached = { ast: emptyPreviewAst(path), figures: [], previewUnavailable: true };
+        console.warn('fetchDocumentPreviewText: source too large, skipping preview', path, size);
+        cached = {
+          ast: emptyPreviewAst(path),
+          figures: [],
+          previewUnavailable: true,
+          figuresExtractionSkipped: true,
+          figuresPending: false,
+        };
       } else {
         const signedUrl = file.signedUrl;
         if (!signedUrl || typeof signedUrl !== 'string') {
-          console.warn('fetchDocumentPreviews: no signedUrl for preview candidate', path);
+          console.warn('fetchDocumentPreviewText: no signedUrl for preview candidate', path);
           continue;
         }
         try {
-          const response = await fetch(signedUrl);
-          if (!response.ok) {
-            console.warn('fetchDocumentPreviews: download failed', path, response.status);
+          const arrayBuffer = await downloadPreviewSource(signedUrl);
+          if (!arrayBuffer) {
+            console.warn('fetchDocumentPreviewText: download failed', path);
             continue;
           }
-          const arrayBuffer = await response.arrayBuffer();
-          // Defer loading officeparser (and its heavy transitive deps: tesseract.js,
-          // pdfjs-dist) until a document actually needs parsing, keeping the route's
-          // server module light on cold start.
-          const { parseOffice } = await import('officeparser');
-          const fullAst = await parseOffice(arrayBuffer, {
-            extractAttachments: true,
-            newlineDelimiter: '\n',
-          });
-          const ast = truncateAstToFirstPage(fullAst);
-          const figuresExtractionSkipped = !(figureBucket && cacheId);
-          const figures = figuresExtractionSkipped
-            ? []
-            : await extractAndStoreFigures(fullAst.attachments ?? [], {
-                sourcePath: path,
-                md5: md5 as string,
-                backend,
-                bucket: figureBucket,
-              });
-          cached = { ast, figures, previewUnavailable: false, figuresExtractionSkipped };
+          const ast = await generatePhaseATextAst(path, file, arrayBuffer);
+          const canExtractFigures = Boolean(figureBucket && cacheId);
+          cached = {
+            ast,
+            figures: [],
+            previewUnavailable: false,
+            figuresExtractionSkipped: !canExtractFigures,
+            figuresPending: canExtractFigures,
+          };
         } catch (err) {
-          console.warn('fetchDocumentPreviews: parse failed', path, err);
+          console.warn('fetchDocumentPreviewText: parse failed', path, err);
           continue;
         }
       }
 
       if (cacheId) {
-        const now = formatDate();
-        try {
-          // Concurrent fetch-previews requests can race to cache the same
-          // (workVersionId, md5) preview. createMany with skipDuplicates compiles to
-          // INSERT ... ON CONFLICT DO NOTHING, so the loser of the race silently
-          // no-ops instead of throwing a unique-constraint violation that Prisma
-          // logs as `prisma:error` even when the exception is caught.
-          await prisma.object.createMany({
-            data: [
-              {
-                id: cacheId,
-                type: cacheId,
-                date_created: now,
-                date_modified: now,
-                data: cached as object,
-                occ: 0,
-                ...(ctx.user?.id ? { created_by_id: ctx.user.id } : {}),
-              },
-            ],
-            skipDuplicates: true,
-          });
-        } catch (createErr: unknown) {
-          console.warn('fetchDocumentPreviews: failed to cache preview', path, createErr);
-        }
+        await writePhaseACache(ctx, prisma, cacheId, cached);
       }
     }
 
-    previews.push({
-      path,
-      data: stripSignedUrl(file),
-      ast: cached.ast,
-      figures: cached.figures,
-      previewUnavailable: cached.previewUnavailable,
-      figuresExtractionSkipped: cached.figuresExtractionSkipped,
-    });
+    previews.push(cachedToDocumentPreviewItem(path, file, cached));
   }
 
   const sortedPreviews = sortPreviewsByOrder(previews);
@@ -568,17 +505,125 @@ export async function fetchDocumentPreviews(
       previews: sortedPreviews,
     });
   } catch (err) {
-    console.warn('fetchDocumentPreviews: failed to persist upload analysis', workVersionId, err);
+    console.warn('fetchDocumentPreviewText: failed to persist upload analysis', workVersionId, err);
   }
 
   return { previews: sortedPreviews };
 }
 
 /**
- * Single entry point for the fetch-previews intent (action).
- * Generates previews (and writes to Object table), returns previews.
- * Throws if workVersionId is missing (caller can map to 400).
+ * Phase B: extract and store candidate figures for previews marked figuresPending.
  */
+export async function fetchDocumentPreviewFigures(
+  workVersionId: string,
+  ctx: Context,
+): Promise<FetchPreviewsResult> {
+  const previewCtx = await loadPreviewWorkContext(workVersionId, ctx);
+  if (!previewCtx) return { previews: [] };
+
+  const { rawMetadata, previewEntries, backend, figureBucket, prisma } = previewCtx;
+  const previews: DocumentPreviewItem[] = [];
+  let anyFiguresUpdated = false;
+
+  for (const [path, file] of previewEntries) {
+    const md5 = file.md5;
+    const cacheId =
+      typeof md5 === 'string' && md5 ? documentPreviewCacheId(workVersionId, md5) : null;
+
+    const cached = await readCachedPreview(prisma, cacheId);
+    if (!cached) continue;
+
+    if (cached.figuresPending !== true) {
+      previews.push(cachedToDocumentPreviewItem(path, file, cached));
+      continue;
+    }
+
+    if (!figureBucket || !cacheId) {
+      cached.figuresPending = false;
+      cached.figuresExtractionSkipped = true;
+      if (cacheId) {
+        await updatePhaseBCache(prisma, cacheId, cached);
+      }
+      previews.push(cachedToDocumentPreviewItem(path, file, cached));
+      continue;
+    }
+
+    const signedUrl = file.signedUrl;
+    if (!signedUrl || typeof signedUrl !== 'string') {
+      console.warn('fetchDocumentPreviewFigures: no signedUrl', path);
+      previews.push(cachedToDocumentPreviewItem(path, file, cached));
+      continue;
+    }
+
+    try {
+      const arrayBuffer = await downloadPreviewSource(signedUrl);
+      if (!arrayBuffer) {
+        console.warn('fetchDocumentPreviewFigures: download failed', path);
+        previews.push(cachedToDocumentPreviewItem(path, file, cached));
+        continue;
+      }
+
+      const fileType = isPdfFile(path, file) ? 'pdf' : isDocxFile(path, file) ? 'docx' : undefined;
+      const { parseOffice } = await import('officeparser');
+      const fullAst = await parseOffice(arrayBuffer, {
+        extractAttachments: true,
+        ...(fileType ? { fileType } : {}),
+        newlineDelimiter: '\n',
+      });
+      const figures = await extractAndStoreFigures(fullAst.attachments ?? [], {
+        sourcePath: path,
+        md5: md5 as string,
+        backend,
+        bucket: figureBucket,
+      });
+
+      const updated: CachedPreview = {
+        ...cached,
+        figures,
+        figuresPending: false,
+        figuresExtractionSkipped: false,
+      };
+      await updatePhaseBCache(prisma, cacheId, updated);
+      anyFiguresUpdated = true;
+      previews.push(cachedToDocumentPreviewItem(path, file, updated));
+    } catch (err) {
+      console.warn('fetchDocumentPreviewFigures: figure extraction failed', path, err);
+      previews.push(cachedToDocumentPreviewItem(path, file, cached));
+    }
+  }
+
+  if (anyFiguresUpdated) {
+    const allPreviews = await readDocumentPreviewsFromObjectTable(workVersionId, {
+      files: Object.fromEntries(previewEntries.map(([path, f]) => [path, stripSignedUrl(f)])),
+    });
+    try {
+      await persistPreviewUploadAnalysis({
+        workVersionId,
+        rawMetadata,
+        previewCandidatePaths: previewEntries.map(([path]) => path),
+        previews: allPreviews,
+      });
+    } catch (err) {
+      console.warn(
+        'fetchDocumentPreviewFigures: failed to persist upload analysis',
+        workVersionId,
+        err,
+      );
+    }
+    return { previews: allPreviews };
+  }
+
+  return { previews: sortPreviewsByOrder(previews) };
+}
+
+/** @deprecated Use fetchDocumentPreviewText. Kept for internal callers/tests. */
+export async function fetchDocumentPreviews(
+  workVersionId: string,
+  ctx: Context,
+): Promise<FetchPreviewsResult> {
+  return fetchDocumentPreviewText(workVersionId, ctx);
+}
+
 export async function handleFetchPreviewsIntent(
   workVersionId: string | undefined,
   ctx: Context,
@@ -586,18 +631,21 @@ export async function handleFetchPreviewsIntent(
   if (!workVersionId) {
     throw new Error('Work version ID is required');
   }
-  const result = await fetchDocumentPreviews(workVersionId, ctx);
+  const result = await fetchDocumentPreviewText(workVersionId, ctx);
   return { previews: result.previews };
 }
 
-/**
- * Read document previews from the Object table only (no download/parse).
- * Used by the loader to return whatever previews are already cached.
- * Caller must pass the work version id (cache rows are version-scoped) and metadata that
- * includes .files (e.g. signed metadata).
- *
- * Figures are returned without signedUrl; call signPreviewFigures to add them.
- */
+export async function handleFetchPreviewFiguresIntent(
+  workVersionId: string | undefined,
+  ctx: Context,
+): Promise<{ previews: DocumentPreviewItem[] }> {
+  if (!workVersionId) {
+    throw new Error('Work version ID is required');
+  }
+  const result = await fetchDocumentPreviewFigures(workVersionId, ctx);
+  return { previews: result.previews };
+}
+
 export async function readDocumentPreviewsFromObjectTable(
   workVersionId: string,
   metadata: {
@@ -621,23 +669,11 @@ export async function readDocumentPreviewsFromObjectTable(
       select: { data: true },
     });
     if (row?.data == null || !isCachedPreview(row.data)) continue;
-    previews.push({
-      path,
-      data: stripSignedUrl(file),
-      ast: row.data.ast,
-      figures: row.data.figures,
-      previewUnavailable: row.data.previewUnavailable,
-      figuresExtractionSkipped: row.data.figuresExtractionSkipped,
-    });
+    previews.push(cachedToDocumentPreviewItem(path, file, row.data));
   }
   return sortPreviewsByOrder(previews);
 }
 
-/**
- * Attach a signed read URL to each candidate figure so the client can render the
- * thumbnail without the bytes ever entering the loader payload. Best-effort per
- * figure: a signing failure leaves that figure without a URL.
- */
 export async function signPreviewFigures(
   previews: DocumentPreviewItem[],
   cdn: string,
@@ -665,10 +701,6 @@ export async function signPreviewFigures(
   );
 }
 
-/**
- * Read the set of valid candidate figure storage keys for a work version (from cache).
- * Used to validate a submitted thumbnail locator before persisting it.
- */
 export async function readPreviewFigureKeysForVersion(workVersionId: string): Promise<Set<string>> {
   const keys = new Set<string>();
   const work = await findWorkByVersion(workVersionId);
@@ -696,11 +728,6 @@ export async function readPreviewFigureKeysForVersion(workVersionId: string): Pr
   return keys;
 }
 
-/**
- * Collect the full set of generated thumbnails for a work version from the cached
- * preview rows, as rich {@link StoredThumbnail} entries (storage key + source
- * correlation + names). De-duplicated by storage key.
- */
 export async function collectStoredThumbnailsForVersion(
   workVersionId: string,
 ): Promise<StoredThumbnail[]> {
@@ -709,8 +736,6 @@ export async function collectStoredThumbnailsForVersion(
   const files = rawMetadata?.files as Record<string, FileMetadataSectionItem> | undefined;
   if (!files || typeof files !== 'object') return [];
 
-  // Map each candidate file's cache id back to its md5 + source path so every cached
-  // figure can record where it came from.
   const metaByCacheId = new Map<string, { md5: string; sourcePath: string }>();
   for (const [sourcePath, file] of Object.entries(files)) {
     if (!isPreviewCandidate(file)) continue;
@@ -748,14 +773,6 @@ export async function collectStoredThumbnailsForVersion(
   return thumbnails;
 }
 
-/**
- * Persist the full thumbnail listing to metadata.thumbnails (union by storage key with
- * any existing entries). Called on confirm-work so generated thumbnails remain
- * discoverable after the preview cache rows are cleaned up.
- *
- * Throws on collection or metadata-write failure so callers can preserve the preview
- * cache rows rather than deleting the only remaining thumbnail listing source.
- */
 export async function persistThumbnailListingForVersion(
   workVersionId: string,
 ): Promise<StoredThumbnail[]> {
@@ -776,19 +793,6 @@ export async function persistThumbnailListingForVersion(
   return thumbnails;
 }
 
-/**
- * Remove the cached preview rows for a work version from the Object table after a
- * successful `confirm-work`. Deletes this version's scoped rows plus any legacy md5-only
- * rows for the same files (the latter predate version scoping and may be shared across
- * works — that's the documented, accepted trade-off here; they regenerate on demand).
- *
- * The generated thumbnail webp files are intentionally retained in storage — they are
- * recorded under metadata.thumbnails (see {@link persistThumbnailListingForVersion}) so
- * they stay discoverable for the work version's lifetime. Only the regenerable parse
- * cache rows are dropped here.
- *
- * Best-effort: never throws.
- */
 export async function deletePreviewArtifactsForVersion(
   workVersionId: string,
 ): Promise<{ rows: number }> {
@@ -811,3 +815,10 @@ export async function deletePreviewArtifactsForVersion(
     return { rows: 0 };
   }
 }
+
+// Re-export AST helpers used by anthropic.server and tests.
+export {
+  astContentToPlainText,
+  truncateAstToFirstPage,
+  shouldIncludeSecondPage,
+} from './previewAstUtils.server';

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
@@ -543,6 +543,7 @@ export async function fetchDocumentPreviewFigures(
       if (cacheId) {
         await updatePhaseBCache(prisma, cacheId, cached);
       }
+      anyFiguresUpdated = true;
       previews.push(cachedToDocumentPreviewItem(path, file, cached));
       continue;
     }

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
@@ -250,12 +250,11 @@ async function downloadPreviewSource(signedUrl: string): Promise<ArrayBuffer | n
 
 async function parseOfficeTextOnly(
   arrayBuffer: ArrayBuffer,
-  fileType: 'pdf' | 'docx',
+  sourcePath: string,
 ): Promise<PreviewAstData> {
-  const { parseOffice } = await import('officeparser');
-  const fullAst = await parseOffice(arrayBuffer, {
+  const { parseOfficeFromBuffer } = await import('./parseOfficeFromBuffer.server');
+  const fullAst = await parseOfficeFromBuffer(arrayBuffer, sourcePath, {
     extractAttachments: false,
-    fileType,
     newlineDelimiter: '\n',
   });
   return truncateAstToFirstPage(fullAst);
@@ -273,13 +272,13 @@ async function generatePhaseATextAst(
     if (isPdfFastPathTextSufficient(fastAst)) {
       return fastAst;
     }
-    return parseOfficeTextOnly(arrayBuffer, 'pdf');
+    return parseOfficeTextOnly(arrayBuffer, path);
   }
   if (isDocxFile(path, file)) {
-    return parseOfficeTextOnly(arrayBuffer, 'docx');
+    return parseOfficeTextOnly(arrayBuffer, path);
   }
-  const { parseOffice } = await import('officeparser');
-  const fullAst = await parseOffice(arrayBuffer, {
+  const { parseOfficeFromBuffer } = await import('./parseOfficeFromBuffer.server');
+  const fullAst = await parseOfficeFromBuffer(arrayBuffer, path, {
     extractAttachments: false,
     newlineDelimiter: '\n',
   });
@@ -563,11 +562,9 @@ export async function fetchDocumentPreviewFigures(
         continue;
       }
 
-      const fileType = isPdfFile(path, file) ? 'pdf' : isDocxFile(path, file) ? 'docx' : undefined;
-      const { parseOffice } = await import('officeparser');
-      const fullAst = await parseOffice(arrayBuffer, {
+      const { parseOfficeFromBuffer } = await import('./parseOfficeFromBuffer.server');
+      const fullAst = await parseOfficeFromBuffer(arrayBuffer, path, {
         extractAttachments: true,
-        ...(fileType ? { fileType } : {}),
         newlineDelimiter: '\n',
       });
       const figures = await extractAndStoreFigures(fullAst.attachments ?? [], {

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/figuresAutoRetry.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/figuresAutoRetry.spec.ts
@@ -1,0 +1,149 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_FIGURES_AUTO_ATTEMPTS,
+  applyFiguresFetcherStateTransition,
+  nextAutoFiguresAttempts,
+  pendingFigurePathsKey,
+  shouldAutoSubmitFiguresFetch,
+  shouldManualRetryFigures,
+  shouldResetFiguresAutoAttemptsForPendingKey,
+  shouldShowFiguresRetry,
+} from './figuresAutoRetry';
+
+describe('pendingFigurePathsKey', () => {
+  it('sorts pending paths into a stable signature', () => {
+    const key = pendingFigurePathsKey([
+      { path: 'b.docx', figuresPending: true },
+      { path: 'a.docx', figuresPending: true },
+      { path: 'c.docx', figuresPending: false },
+    ]);
+    expect(key).toBe('a.docx\0b.docx');
+  });
+
+  it('returns empty string when nothing is pending', () => {
+    expect(pendingFigurePathsKey([{ path: 'a.docx', figuresPending: false }])).toBe('');
+  });
+});
+
+describe('shouldResetFiguresAutoAttemptsForPendingKey', () => {
+  it('resets when the pending path set changes', () => {
+    expect(
+      shouldResetFiguresAutoAttemptsForPendingKey({ previousKey: 'a.docx', nextKey: 'b.docx' }),
+    ).toBe(true);
+  });
+
+  it('does not reset when the pending path set is unchanged', () => {
+    expect(
+      shouldResetFiguresAutoAttemptsForPendingKey({ previousKey: 'a.docx', nextKey: 'a.docx' }),
+    ).toBe(false);
+  });
+});
+
+describe('shouldAutoSubmitFiguresFetch', () => {
+  it('submits while under the auto-attempt cap and fetcher is idle', () => {
+    expect(
+      shouldAutoSubmitFiguresFetch({
+        shouldFetchPreviewFigures: true,
+        fetcherState: 'idle',
+        autoAttempts: 0,
+      }),
+    ).toBe(true);
+    expect(
+      shouldAutoSubmitFiguresFetch({
+        shouldFetchPreviewFigures: true,
+        fetcherState: 'idle',
+        autoAttempts: MAX_FIGURES_AUTO_ATTEMPTS - 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('stops auto-submit after the cap is reached', () => {
+    expect(
+      shouldAutoSubmitFiguresFetch({
+        shouldFetchPreviewFigures: true,
+        fetcherState: 'idle',
+        autoAttempts: MAX_FIGURES_AUTO_ATTEMPTS,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not submit while fetcher is in flight', () => {
+    expect(
+      shouldAutoSubmitFiguresFetch({
+        shouldFetchPreviewFigures: true,
+        fetcherState: 'loading',
+        autoAttempts: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not submit when figures fetch is disabled', () => {
+    expect(
+      shouldAutoSubmitFiguresFetch({
+        shouldFetchPreviewFigures: false,
+        fetcherState: 'idle',
+        autoAttempts: 0,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('nextAutoFiguresAttempts', () => {
+  it('increments the auto-attempt counter', () => {
+    expect(nextAutoFiguresAttempts(0)).toBe(1);
+    expect(nextAutoFiguresAttempts(1)).toBe(2);
+  });
+});
+
+describe('applyFiguresFetcherStateTransition', () => {
+  it('marks in-flight when fetcher leaves idle', () => {
+    expect(
+      applyFiguresFetcherStateTransition({ fetcherState: 'submitting', wasInFlight: false }),
+    ).toEqual({ wasInFlight: true, fetchFinished: false });
+  });
+
+  it('marks finished only after an in-flight fetch returns to idle', () => {
+    expect(applyFiguresFetcherStateTransition({ fetcherState: 'idle', wasInFlight: true })).toEqual(
+      { wasInFlight: false, fetchFinished: true },
+    );
+  });
+
+  it('does not mark finished on initial idle', () => {
+    expect(
+      applyFiguresFetcherStateTransition({ fetcherState: 'idle', wasInFlight: false }),
+    ).toEqual({ wasInFlight: false, fetchFinished: false });
+  });
+});
+
+describe('shouldManualRetryFigures', () => {
+  it('allows manual retry only when fetcher is idle', () => {
+    expect(shouldManualRetryFigures('idle')).toBe(true);
+    expect(shouldManualRetryFigures('loading')).toBe(false);
+  });
+
+  it('bypasses the auto-attempt cap by design', () => {
+    expect(
+      shouldAutoSubmitFiguresFetch({
+        shouldFetchPreviewFigures: true,
+        fetcherState: 'idle',
+        autoAttempts: MAX_FIGURES_AUTO_ATTEMPTS,
+      }),
+    ).toBe(false);
+    expect(shouldManualRetryFigures('idle')).toBe(true);
+  });
+});
+
+describe('shouldShowFiguresRetry', () => {
+  it('shows retry after a fetch finishes and generation is idle', () => {
+    expect(shouldShowFiguresRetry({ figuresFetchFinished: true, isGeneratingFigures: false })).toBe(
+      true,
+    );
+  });
+
+  it('hides retry while generation is in progress', () => {
+    expect(shouldShowFiguresRetry({ figuresFetchFinished: true, isGeneratingFigures: true })).toBe(
+      false,
+    );
+  });
+});

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/figuresAutoRetry.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/figuresAutoRetry.ts
@@ -1,0 +1,63 @@
+/** Max automatic phase-B figure fetches per pending path set; manual retry bypasses this. */
+export const MAX_FIGURES_AUTO_ATTEMPTS = 2;
+
+export type FiguresFetcherState = 'idle' | 'loading' | 'submitting';
+
+export interface PendingFigurePreview {
+  path: string;
+  figuresPending?: boolean;
+}
+
+/** Stable signature for the set of previews still awaiting figure extraction. */
+export function pendingFigurePathsKey(previewList: ReadonlyArray<PendingFigurePreview>): string {
+  return previewList
+    .filter((preview) => preview.figuresPending === true)
+    .map((preview) => preview.path)
+    .sort()
+    .join('\0');
+}
+
+export function shouldResetFiguresAutoAttemptsForPendingKey(args: {
+  previousKey: string;
+  nextKey: string;
+}): boolean {
+  return args.previousKey !== args.nextKey;
+}
+
+export function shouldAutoSubmitFiguresFetch(args: {
+  shouldFetchPreviewFigures: boolean;
+  fetcherState: FiguresFetcherState;
+  autoAttempts: number;
+}): boolean {
+  if (!args.shouldFetchPreviewFigures) return false;
+  if (args.fetcherState !== 'idle') return false;
+  return args.autoAttempts < MAX_FIGURES_AUTO_ATTEMPTS;
+}
+
+export function nextAutoFiguresAttempts(autoAttempts: number): number {
+  return autoAttempts + 1;
+}
+
+export function applyFiguresFetcherStateTransition(args: {
+  fetcherState: FiguresFetcherState;
+  wasInFlight: boolean;
+}): { wasInFlight: boolean; fetchFinished: boolean } {
+  if (args.fetcherState !== 'idle') {
+    return { wasInFlight: true, fetchFinished: false };
+  }
+  if (args.wasInFlight) {
+    return { wasInFlight: false, fetchFinished: true };
+  }
+  return { wasInFlight: false, fetchFinished: false };
+}
+
+export function shouldManualRetryFigures(fetcherState: FiguresFetcherState): boolean {
+  return fetcherState === 'idle';
+}
+
+export function shouldShowFiguresRetry(args: {
+  figuresFetchFinished: boolean;
+  isGeneratingFigures: boolean;
+}): boolean {
+  return args.figuresFetchFinished && !args.isGeneratingFigures;
+}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/parseOfficeFromBuffer.server.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/parseOfficeFromBuffer.server.spec.ts
@@ -1,0 +1,90 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { createRequire } from 'node:module';
+import { existsSync, readFileSync } from 'node:fs';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import {
+  parseOfficeFromBuffer,
+  resolveOfficeParserExtension,
+} from './parseOfficeFromBuffer.server';
+
+const require = createRequire(import.meta.url);
+const { zipSync, strToU8 } = require('fflate') as typeof import('fflate');
+
+const LARGE_MANUSCRIPT_FIXTURE =
+  process.env.DOCX_PREVIEW_FIXTURE ??
+  '/Users/stevejpurves/dev/hhmi/examples/PMC Papers/Dimensionality reduction simplifies synaptic partner matching in an olfactory circuit/manuscript combined.docx';
+
+function createMinimalDocx(): Buffer {
+  const files: Record<string, Uint8Array> = {
+    '[Content_Types].xml': strToU8(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`),
+    '_rels/.rels': strToU8(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`),
+    'word/document.xml': strToU8(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:r><w:t>Hello preview</w:t></w:r></w:p></w:body>
+</w:document>`),
+  };
+  return Buffer.from(zipSync(files));
+}
+
+describe('resolveOfficeParserExtension', () => {
+  it('resolves docx from storage paths with spaces', () => {
+    expect(resolveOfficeParserExtension('019f5fe5/manuscript/manuscript combined.docx')).toBe(
+      'docx',
+    );
+  });
+
+  it('resolves pdf from nested paths', () => {
+    expect(resolveOfficeParserExtension('uploads/paper/final.pdf')).toBe('pdf');
+  });
+
+  it('returns undefined for unsupported extensions', () => {
+    expect(resolveOfficeParserExtension('uploads/readme.txt')).toBeUndefined();
+  });
+});
+
+describe('parseOfficeFromBuffer', () => {
+  it('parses a minimal DOCX buffer using the source path extension', async () => {
+    const buffer = createMinimalDocx();
+    const ast = await parseOfficeFromBuffer(buffer, 'manuscript/manuscript.docx', {
+      extractAttachments: false,
+      newlineDelimiter: '\n',
+    });
+
+    expect(ast.type).toBe('docx');
+    expect(ast.content.length).toBeGreaterThan(0);
+    expect(ast.toText()).toContain('Hello preview');
+  });
+
+  it('parses large manuscripts when file-type misidentifies the buffer as zip', async () => {
+    if (!existsSync(LARGE_MANUSCRIPT_FIXTURE)) {
+      return;
+    }
+
+    const buffer = readFileSync(LARGE_MANUSCRIPT_FIXTURE);
+    const { fileTypeFromBuffer } = await import('file-type');
+    const detected = await fileTypeFromBuffer(buffer);
+    expect(detected?.ext).toBe('zip');
+
+    const { parseOffice } = await import('officeparser');
+    await expect(
+      parseOffice(buffer, { extractAttachments: false, newlineDelimiter: '\n' }),
+    ).rejects.toThrow(/zip files/);
+
+    const ast = await parseOfficeFromBuffer(buffer, 'manuscript/manuscript combined.docx', {
+      extractAttachments: false,
+      newlineDelimiter: '\n',
+    });
+
+    expect(ast.type).toBe('docx');
+    expect(ast.content.length).toBeGreaterThan(0);
+  });
+});

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/parseOfficeFromBuffer.server.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/parseOfficeFromBuffer.server.spec.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createRequire } from 'node:module';
-import { existsSync, readFileSync } from 'node:fs';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, expect, it } from 'vitest';
 import {
@@ -9,11 +8,11 @@ import {
 } from './parseOfficeFromBuffer.server';
 
 const require = createRequire(import.meta.url);
-const { zipSync, strToU8 } = require('fflate') as typeof import('fflate');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { zipSync, strToU8 } = require('fflate');
 
-const LARGE_MANUSCRIPT_FIXTURE =
-  process.env.DOCX_PREVIEW_FIXTURE ??
-  '/Users/stevejpurves/dev/hhmi/examples/PMC Papers/Dimensionality reduction simplifies synaptic partner matching in an olfactory circuit/manuscript combined.docx';
+/** Minimum uncompressed size that makes file-type skip [Content_Types].xml (>1 MiB). */
+const UNPARSEABLE_CONTENT_TYPES_BYTES = 1024 * 1024 + 128;
 
 function createMinimalDocx(): Buffer {
   const files: Record<string, Uint8Array> = {
@@ -33,6 +32,32 @@ function createMinimalDocx(): Buffer {
 </w:document>`),
   };
   return Buffer.from(zipSync(files));
+}
+
+/**
+ * DOCX whose [Content_Types].xml exceeds file-type's 1 MiB entry read limit (stored,
+ * not deflated). Magic-byte detection returns generic zip; extension routing still parses.
+ */
+function createZipMisidentifiedDocx(): Buffer {
+  const contentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <!--${'x'.repeat(UNPARSEABLE_CONTENT_TYPES_BYTES)}-->
+</Types>`;
+
+  const files: Record<string, Uint8Array> = {
+    '[Content_Types].xml': strToU8(contentTypes),
+    '_rels/.rels': strToU8(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`),
+    'word/document.xml': strToU8(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:r><w:t>Late content types test</w:t></w:r></w:p></w:body>
+</w:document>`),
+  };
+
+  return Buffer.from(zipSync(files, { level: 0 }));
 }
 
 describe('resolveOfficeParserExtension', () => {
@@ -64,12 +89,8 @@ describe('parseOfficeFromBuffer', () => {
     expect(ast.toText()).toContain('Hello preview');
   });
 
-  it('parses large manuscripts when file-type misidentifies the buffer as zip', async () => {
-    if (!existsSync(LARGE_MANUSCRIPT_FIXTURE)) {
-      return;
-    }
-
-    const buffer = readFileSync(LARGE_MANUSCRIPT_FIXTURE);
+  it('parses DOCX when file-type misidentifies the buffer as zip', async () => {
+    const buffer = createZipMisidentifiedDocx();
     const { fileTypeFromBuffer } = await import('file-type');
     const detected = await fileTypeFromBuffer(buffer);
     expect(detected?.ext).toBe('zip');
@@ -86,5 +107,6 @@ describe('parseOfficeFromBuffer', () => {
 
     expect(ast.type).toBe('docx');
     expect(ast.content.length).toBeGreaterThan(0);
+    expect(ast.toText()).toContain('Late content types test');
   });
 });

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/parseOfficeFromBuffer.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/parseOfficeFromBuffer.server.ts
@@ -17,6 +17,39 @@ type ParserFn = (buffer: Buffer, config: OfficeParserConfig) => Promise<OfficePa
 const require = createRequire(import.meta.url);
 const officeparserRoot = join(dirname(require.resolve('officeparser')), '..');
 
+/** Mirrors officeparser's public `parseOffice` default config (see dist/officeparser.browser.mjs). */
+const OFFICEPARSER_DEFAULT_CONFIG = {
+  ignoreNotes: false,
+  newlineDelimiter: '\n',
+  putNotesAtLast: false,
+  outputErrorToConsole: false,
+  extractAttachments: false,
+  ocr: false,
+  ocrLanguage: 'eng',
+  includeRawContent: false,
+  serializeRawContent: true,
+  preserveXmlWhitespace: false,
+  pdfWorkerSrc: '',
+  ocrConfig: {},
+  includeBreakNodes: false,
+} satisfies OfficeParserConfig;
+
+const PARSER_MODULES: Record<string, { modulePath: string; exportName: string }> = {
+  docx: { modulePath: 'dist/parsers/WordParser.js', exportName: 'parseWord' },
+  docm: { modulePath: 'dist/parsers/WordParser.js', exportName: 'parseWord' },
+  dotx: { modulePath: 'dist/parsers/WordParser.js', exportName: 'parseWord' },
+  dotm: { modulePath: 'dist/parsers/WordParser.js', exportName: 'parseWord' },
+  pptx: { modulePath: 'dist/parsers/PowerPointParser.js', exportName: 'parsePowerPoint' },
+  xlsx: { modulePath: 'dist/parsers/ExcelParser.js', exportName: 'parseExcel' },
+  odt: { modulePath: 'dist/parsers/OpenOfficeParser.js', exportName: 'parseOpenOffice' },
+  odp: { modulePath: 'dist/parsers/OpenOfficeParser.js', exportName: 'parseOpenOffice' },
+  ods: { modulePath: 'dist/parsers/OpenOfficeParser.js', exportName: 'parseOpenOffice' },
+  pdf: { modulePath: 'dist/parsers/PdfParser.js', exportName: 'parsePdf' },
+  rtf: { modulePath: 'dist/parsers/RtfParser.js', exportName: 'parseRtf' },
+};
+
+const parserByExtension = new Map<string, ParserFn>();
+
 function loadParser(modulePath: string, exportName: string): ParserFn {
   const mod = require(join(officeparserRoot, modulePath)) as Record<string, ParserFn>;
   const fn = mod[exportName];
@@ -26,32 +59,25 @@ function loadParser(modulePath: string, exportName: string): ParserFn {
   return fn;
 }
 
-let parsersByExtension: Record<string, ParserFn> | null = null;
+function normalizeOfficeParserConfig(config: OfficeParserConfig): OfficeParserConfig {
+  return { ...OFFICEPARSER_DEFAULT_CONFIG, ...config };
+}
 
-function getParsersByExtension(): Record<string, ParserFn> {
-  if (!parsersByExtension) {
-    const parseWord = loadParser('dist/parsers/WordParser.js', 'parseWord');
-    const parsePowerPoint = loadParser('dist/parsers/PowerPointParser.js', 'parsePowerPoint');
-    const parseExcel = loadParser('dist/parsers/ExcelParser.js', 'parseExcel');
-    const parseOpenOffice = loadParser('dist/parsers/OpenOfficeParser.js', 'parseOpenOffice');
-    const parsePdf = loadParser('dist/parsers/PdfParser.js', 'parsePdf');
-    const parseRtf = loadParser('dist/parsers/RtfParser.js', 'parseRtf');
+function getParserForExtension(ext: string): ParserFn | undefined {
+  const spec = PARSER_MODULES[ext];
+  if (!spec) return undefined;
 
-    parsersByExtension = {
-      docx: parseWord,
-      docm: parseWord,
-      dotx: parseWord,
-      dotm: parseWord,
-      pptx: parsePowerPoint,
-      xlsx: parseExcel,
-      odt: parseOpenOffice,
-      odp: parseOpenOffice,
-      ods: parseOpenOffice,
-      pdf: parsePdf,
-      rtf: parseRtf,
-    };
+  const cached = parserByExtension.get(ext);
+  if (cached) return cached;
+
+  try {
+    const parser = loadParser(spec.modulePath, spec.exportName);
+    parserByExtension.set(ext, parser);
+    return parser;
+  } catch (err) {
+    console.warn('parseOfficeFromBuffer: failed to load internal parser', ext, err);
+    return undefined;
   }
-  return parsersByExtension;
 }
 
 /** Resolve the officeparser routing extension (without dot) from a storage path or name. */
@@ -70,14 +96,24 @@ export async function parseOfficeFromBuffer(
   config: OfficeParserConfig = {},
 ): Promise<OfficeParserAST> {
   const buffer = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  const normalizedConfig = normalizeOfficeParserConfig(config);
   const ext = resolveOfficeParserExtension(sourcePath);
+
   if (ext) {
-    const parser = getParsersByExtension()[ext];
+    const parser = getParserForExtension(ext);
     if (parser) {
-      return parser(buffer, config);
+      try {
+        return await parser(buffer, normalizedConfig);
+      } catch (err) {
+        console.warn(
+          'parseOfficeFromBuffer: internal parser failed, falling back to parseOffice',
+          ext,
+          err,
+        );
+      }
     }
   }
 
   const { parseOffice } = await import('officeparser');
-  return parseOffice(buffer, config);
+  return parseOffice(buffer, normalizedConfig);
 }

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/parseOfficeFromBuffer.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/parseOfficeFromBuffer.server.ts
@@ -1,0 +1,83 @@
+/**
+ * Parse office document bytes using the known source path extension.
+ *
+ * officeparser's buffer entry point relies on file-type magic-byte detection. Large
+ * DOCX files with late [Content_Types].xml can be misidentified as generic zip. We
+ * already validate extensions via isPreviewCandidate, so route directly to the
+ * format-specific parser when the path is known.
+ */
+
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { officeParserFormatForPath } from '@curvenote/scms-core';
+import type { OfficeParserAST, OfficeParserConfig } from 'officeparser';
+
+type ParserFn = (buffer: Buffer, config: OfficeParserConfig) => Promise<OfficeParserAST>;
+
+const require = createRequire(import.meta.url);
+const officeparserRoot = join(dirname(require.resolve('officeparser')), '..');
+
+function loadParser(modulePath: string, exportName: string): ParserFn {
+  const mod = require(join(officeparserRoot, modulePath)) as Record<string, ParserFn>;
+  const fn = mod[exportName];
+  if (typeof fn !== 'function') {
+    throw new Error(`officeparser parser not found: ${exportName} in ${modulePath}`);
+  }
+  return fn;
+}
+
+let parsersByExtension: Record<string, ParserFn> | null = null;
+
+function getParsersByExtension(): Record<string, ParserFn> {
+  if (!parsersByExtension) {
+    const parseWord = loadParser('dist/parsers/WordParser.js', 'parseWord');
+    const parsePowerPoint = loadParser('dist/parsers/PowerPointParser.js', 'parsePowerPoint');
+    const parseExcel = loadParser('dist/parsers/ExcelParser.js', 'parseExcel');
+    const parseOpenOffice = loadParser('dist/parsers/OpenOfficeParser.js', 'parseOpenOffice');
+    const parsePdf = loadParser('dist/parsers/PdfParser.js', 'parsePdf');
+    const parseRtf = loadParser('dist/parsers/RtfParser.js', 'parseRtf');
+
+    parsersByExtension = {
+      docx: parseWord,
+      docm: parseWord,
+      dotx: parseWord,
+      dotm: parseWord,
+      pptx: parsePowerPoint,
+      xlsx: parseExcel,
+      odt: parseOpenOffice,
+      odp: parseOpenOffice,
+      ods: parseOpenOffice,
+      pdf: parsePdf,
+      rtf: parseRtf,
+    };
+  }
+  return parsersByExtension;
+}
+
+/** Resolve the officeparser routing extension (without dot) from a storage path or name. */
+export function resolveOfficeParserExtension(sourcePath: string): string | undefined {
+  const format = officeParserFormatForPath(sourcePath);
+  if (!format) return undefined;
+  return format.extensions[0]?.slice(1);
+}
+
+/**
+ * Parse document bytes, using sourcePath for format routing instead of magic-byte detection.
+ */
+export async function parseOfficeFromBuffer(
+  input: ArrayBuffer | Buffer,
+  sourcePath: string,
+  config: OfficeParserConfig = {},
+): Promise<OfficeParserAST> {
+  const buffer = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  const ext = resolveOfficeParserExtension(sourcePath);
+  if (ext) {
+    const parser = getParsersByExtension()[ext];
+    if (parser) {
+      return parser(buffer, config);
+    }
+  }
+
+  const { parseOffice } = await import('officeparser');
+  return parseOffice(buffer, config);
+}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFirstPagePreview.server.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFirstPagePreview.server.spec.ts
@@ -1,0 +1,36 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import type { OfficeContentNode } from 'officeparser';
+import {
+  isPdfFastPathTextSufficient,
+  PDF_FAST_PATH_MIN_TEXT_LENGTH,
+} from './pdfFirstPagePreview.server';
+import type { PreviewAstData } from './previewAstUtils.server';
+
+function pagePreview(text: string): PreviewAstData {
+  return {
+    type: 'pdf',
+    metadata: { pages: 1 },
+    content: [
+      {
+        type: 'page',
+        children: [{ type: 'paragraph', children: [{ type: 'text', text }] }],
+        metadata: { pageNumber: 1 },
+      } as OfficeContentNode,
+    ],
+    wasTruncated: false,
+  };
+}
+
+describe('isPdfFastPathTextSufficient', () => {
+  it('returns true when text meets the minimum threshold', () => {
+    expect(
+      isPdfFastPathTextSufficient(pagePreview('A'.repeat(PDF_FAST_PATH_MIN_TEXT_LENGTH))),
+    ).toBe(true);
+  });
+
+  it('returns false when text is below the minimum threshold', () => {
+    expect(isPdfFastPathTextSufficient(pagePreview('short'))).toBe(false);
+    expect(isPdfFastPathTextSufficient(pagePreview(''))).toBe(false);
+  });
+});

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFirstPagePreview.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFirstPagePreview.server.ts
@@ -1,0 +1,97 @@
+/**
+ * Fast PDF first-page text preview using pdfjs directly (pages 1–2 only).
+ * Avoids a full-document officeparser pass for phase-A text preview.
+ */
+
+import { createRequire } from 'node:module';
+import type { OfficeContentNode } from 'officeparser';
+import {
+  astContentToPlainText,
+  shouldIncludeSecondPage,
+  type PreviewAstData,
+} from './previewAstUtils.server';
+
+/** Minimum extractable text before falling back to officeparser for scanned/image PDFs. */
+export const PDF_FAST_PATH_MIN_TEXT_LENGTH = 50;
+
+function paragraphFromText(text: string): OfficeContentNode {
+  return { type: 'paragraph', children: [{ type: 'text', text }] } as OfficeContentNode;
+}
+
+function pageFromText(text: string, pageNumber: number): OfficeContentNode {
+  return {
+    type: 'page',
+    children: text ? [paragraphFromText(text)] : [],
+    metadata: { pageNumber },
+  } as OfficeContentNode;
+}
+
+async function loadPdfJs() {
+  const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  try {
+    const require = createRequire(import.meta.url);
+    pdfjs.GlobalWorkerOptions.workerSrc = require.resolve('pdfjs-dist/legacy/build/pdf.worker.mjs');
+  } catch {
+    // Worker auto-resolution is best-effort; pdfjs may still load in some environments.
+  }
+  return pdfjs;
+}
+
+async function extractPageText(
+  pdfDocument: {
+    getPage: (n: number) => Promise<{ getTextContent: () => Promise<{ items: unknown[] }> }>;
+  },
+  pageNumber: number,
+): Promise<string> {
+  const page = await pdfDocument.getPage(pageNumber);
+  const textContent = await page.getTextContent();
+  const parts: string[] = [];
+  for (const item of textContent.items) {
+    if (typeof item === 'object' && item !== null && 'str' in item) {
+      const str = (item as { str?: unknown }).str;
+      if (typeof str === 'string' && str.length > 0) {
+        parts.push(str);
+      }
+    }
+  }
+  return parts.join(' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Build a first-page (and optionally second-page) PDF preview AST from raw bytes.
+ * Only reads pages 1–2 from the PDF; does not extract embedded images.
+ */
+export async function parsePdfFirstPagePreview(arrayBuffer: ArrayBuffer): Promise<PreviewAstData> {
+  const pdfjs = await loadPdfJs();
+  const loadingTask = pdfjs.getDocument({
+    data: new Uint8Array(arrayBuffer),
+    verbosity: 0,
+  });
+  const pdfDocument = await loadingTask.promise;
+  try {
+    const numPages = pdfDocument.numPages;
+    const page1Node = pageFromText(numPages >= 1 ? await extractPageText(pdfDocument, 1) : '', 1);
+    const content: OfficeContentNode[] = [page1Node];
+
+    if (numPages >= 2) {
+      const page2Node = pageFromText(await extractPageText(pdfDocument, 2), 2);
+      if (shouldIncludeSecondPage(page1Node, page2Node)) {
+        content.push(page2Node);
+      }
+    }
+
+    return {
+      type: 'pdf',
+      metadata: { pages: numPages },
+      content,
+      wasTruncated: content.length < numPages,
+    };
+  } finally {
+    await pdfDocument.destroy();
+  }
+}
+
+/** True when the pdfjs fast path extracted enough text for preview and metadata extract. */
+export function isPdfFastPathTextSufficient(ast: PreviewAstData): boolean {
+  return astContentToPlainText(ast.content).length >= PDF_FAST_PATH_MIN_TEXT_LENGTH;
+}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewAstUtils.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewAstUtils.server.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared AST helpers for document preview (text truncation, plain-text extraction).
+ * Kept separate so pdfFirstPagePreview can import without circular dependency on fetchPreviews.
+ */
+
+import type { OfficeParserAST, OfficeContentNode } from 'officeparser';
+
+/** A first page with this much text is enough for metadata extraction on its own. */
+export const FIRST_PAGE_MIN_TEXT_LENGTH = 500;
+
+/** Page two must be this much larger than a sparse first page before we include it. */
+const SECOND_PAGE_SIGNIFICANTLY_LARGER_RATIO = 1.5;
+
+/**
+ * Target amount of extractable text (chars) to collect for non-paged ASTs (e.g. DOCX).
+ */
+export const FIRST_PAGE_TARGET_TEXT_LENGTH = 4000;
+
+/** Hard ceiling on top-level nodes for non-paged AST truncation. */
+export const FIRST_PAGE_MAX_CONTENT_NODES = 40;
+
+/** First-page AST (text/content only — no base64 attachments). */
+export interface PreviewAstData {
+  type: OfficeParserAST['type'];
+  metadata: OfficeParserAST['metadata'];
+  content: OfficeContentNode[];
+  wasTruncated: boolean;
+}
+
+function nodeToPlainText(node: OfficeContentNode): string {
+  if (node.type === 'text') {
+    return (node as { text?: string }).text ?? '';
+  }
+  if (node.type === 'image' || node.type === 'chart' || node.type === 'drawing') {
+    return '';
+  }
+  const children = (node as { children?: OfficeContentNode[] }).children;
+  if (!children?.length) {
+    const direct = (node as { text?: string }).text;
+    return direct != null ? String(direct) : '';
+  }
+  return children.map(nodeToPlainText).join('');
+}
+
+function extractableTextLength(nodes: OfficeContentNode[]): number {
+  return astContentToPlainText(nodes).length;
+}
+
+function isPageNode(node: OfficeContentNode): boolean {
+  return node.type === 'page';
+}
+
+export function shouldIncludeSecondPage(
+  firstPage: OfficeContentNode,
+  secondPage?: OfficeContentNode,
+): boolean {
+  if (!secondPage) return false;
+  const firstPageLength = extractableTextLength([firstPage]);
+  if (firstPageLength >= FIRST_PAGE_MIN_TEXT_LENGTH) return false;
+  const secondPageLength = extractableTextLength([secondPage]);
+  if (secondPageLength === 0) return false;
+  return (
+    secondPageLength >=
+    Math.max(FIRST_PAGE_MIN_TEXT_LENGTH, firstPageLength * SECOND_PAGE_SIGNIFICANTLY_LARGER_RATIO)
+  );
+}
+
+function selectFirstPageContentByBudget(fullContent: OfficeContentNode[]): OfficeContentNode[] {
+  let textLength = 0;
+  let count = 0;
+  for (; count < fullContent.length; count += 1) {
+    if (count >= FIRST_PAGE_MAX_CONTENT_NODES) break;
+    textLength += extractableTextLength([fullContent[count]]);
+    if (textLength >= FIRST_PAGE_TARGET_TEXT_LENGTH) {
+      count += 1;
+      break;
+    }
+  }
+  return fullContent.slice(0, count);
+}
+
+export function truncateAstToFirstPage(ast: OfficeParserAST): PreviewAstData {
+  const fullContent = ast.content ?? [];
+  const pageNodes = fullContent.filter(isPageNode);
+  const usePages = pageNodes.length > 0;
+  const content = usePages
+    ? pageNodes.slice(0, shouldIncludeSecondPage(pageNodes[0], pageNodes[1]) ? 2 : 1)
+    : selectFirstPageContentByBudget(fullContent);
+  const wasTruncated = usePages
+    ? content.length < pageNodes.length
+    : content.length < fullContent.length;
+  return {
+    type: ast.type,
+    metadata: ast.metadata,
+    content,
+    wasTruncated,
+  };
+}
+
+export function astContentToPlainText(content: OfficeContentNode[]): string {
+  const parts = content.map((node) => {
+    const text = nodeToPlainText(node);
+    if (node.type === 'paragraph' || node.type === 'heading' || node.type === 'list') {
+      return text ? `${text}\n` : '\n';
+    }
+    if (node.type === 'table') {
+      const children = (node as { children?: OfficeContentNode[] }).children ?? [];
+      const rowTexts = children
+        .filter((c) => (c as { type?: string }).type === 'row')
+        .map((row) => {
+          const cells = (row as { children?: OfficeContentNode[] }).children ?? [];
+          return cells
+            .map((c) => nodeToPlainText(c as OfficeContentNode))
+            .filter(Boolean)
+            .join('\t');
+        });
+      return rowTexts.join('\n') + '\n';
+    }
+    return text;
+  });
+  return parts.join('').trim();
+}
+
+export function emptyPreviewAst(sourcePath: string): PreviewAstData {
+  const type: OfficeParserAST['type'] = sourcePath.toLowerCase().endsWith('.pdf') ? 'pdf' : 'docx';
+  return { type, metadata: {} as OfficeParserAST['metadata'], content: [], wasTruncated: false };
+}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
@@ -79,6 +79,7 @@ import { shouldTrackWorkViewedOnLoader } from './loaderAnalytics.server.js';
 import { data, redirect, useFetcher, useParams, useRevalidator } from 'react-router';
 import {
   handleFetchPreviewsIntent,
+  handleFetchPreviewFiguresIntent,
   deletePreviewArtifactsForVersion,
   persistThumbnailListingForVersion,
   signPreviewFigures,
@@ -138,6 +139,7 @@ const WorkUploadActionSchema = zfd.formData({
     'toggle-check',
     'confirm-work',
     'fetch-previews',
+    'fetch-preview-figures',
     'extract-metadata',
     'clear-extracted-metadata',
   ]),
@@ -866,6 +868,38 @@ export async function action(args: Route.ActionArgs) {
         }
       }
 
+      if (uploadIntent === 'fetch-preview-figures') {
+        if (!workVersionId) {
+          return data(
+            { error: { type: 'general', message: 'Work version ID is required' } },
+            { status: 400 },
+          );
+        }
+        if (
+          !userHasScope(baseCtx.user, scopes.app.works.metadataExtract, undefined, {
+            ignoreSystemAdmin: true,
+          })
+        ) {
+          return data(
+            {
+              error: {
+                type: 'general',
+                message: 'You do not have permission to generate document preview figures',
+              },
+            },
+            { status: 403 },
+          );
+        }
+        try {
+          const { previews } = await handleFetchPreviewFiguresIntent(workVersionId, baseCtx);
+          return data({ ok: true, previewFiguresGenerated: previews.length });
+        } catch (err) {
+          const message =
+            err instanceof Error ? err.message : 'Failed to generate document preview figures';
+          return data({ error: { type: 'general', message } }, { status: 500 });
+        }
+      }
+
       if (uploadIntent === 'clear-extracted-metadata') {
         if (!workVersionId) {
           return data(
@@ -1155,8 +1189,10 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
   const [authorMetadata, setAuthorMetadata] = useState<AuthorFieldMetadata>(authorFieldMetadata);
   const revalidator = useRevalidator();
   const fetchPreviewsFetcher = useFetcher();
+  const fetchPreviewFiguresFetcher = useFetcher();
   const autoTitleFromFilenameFetcher = useFetcher();
   const hasTriggeredFetchPreviews = useRef(false);
+  const hasTriggeredFetchPreviewFigures = useRef(false);
   // Tracks preview paths we've already observed, so a background preview that
   // resolves after its file was removed only raises its toast once.
   const seenPreviewPathsRef = useRef<Set<string> | null>(null);
@@ -1207,6 +1243,8 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
   const missingPreviewPaths = previewFilePaths.filter((p) => !previewPaths.has(p));
   const shouldFetchPreviews =
     hasMetadataExtractScope && previewFilePaths.length > 0 && missingPreviewPaths.length > 0;
+  const shouldFetchPreviewFigures =
+    hasMetadataExtractScope && previewList.some((p) => p.figuresPending === true);
 
   // When a background preview finishes after its file was removed from the dropzone,
   // tell the user it was cached for a future upload of the same file.
@@ -1246,6 +1284,18 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
     );
   }, [shouldFetchPreviews, fetchPreviewsFetcher.state, fetchPreviewsFetcher]);
 
+  useEffect(() => {
+    if (!shouldFetchPreviewFigures) {
+      hasTriggeredFetchPreviewFigures.current = false;
+      return;
+    }
+    if (hasTriggeredFetchPreviewFigures.current || fetchPreviewFiguresFetcher.state !== 'idle') {
+      return;
+    }
+    hasTriggeredFetchPreviewFigures.current = true;
+    fetchPreviewFiguresFetcher.submit({ intent: 'fetch-preview-figures' }, { method: 'POST' });
+  }, [shouldFetchPreviewFigures, fetchPreviewFiguresFetcher.state, fetchPreviewFiguresFetcher]);
+
   // Show toast when fetch-previews action returns an error
   useEffect(() => {
     if (fetchPreviewsFetcher.state === 'idle' && fetchPreviewsFetcher.data?.error) {
@@ -1253,12 +1303,19 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
     }
   }, [fetchPreviewsFetcher.state, fetchPreviewsFetcher.data]);
 
+  useEffect(() => {
+    if (fetchPreviewFiguresFetcher.state === 'idle' && fetchPreviewFiguresFetcher.data?.error) {
+      ui.toastError(fetchPreviewFiguresFetcher.data.error.message);
+    }
+  }, [fetchPreviewFiguresFetcher.state, fetchPreviewFiguresFetcher.data]);
+
   // Re-kick preview generation after the user retries a skipped preview. The
   // auto-fetch effect above will not fire again on its own once it has run, so
   // resubmit here (only when idle) to restart the generation + busy state.
   const handleRetryPreview = useCallback(() => {
     if (fetchPreviewsFetcher.state !== 'idle') return;
     hasTriggeredFetchPreviews.current = true;
+    hasTriggeredFetchPreviewFigures.current = false;
     fetchPreviewsFetcher.submit(
       { intent: 'fetch-previews', uploadFlowTrigger: 'manual_preview_retry' },
       { method: 'POST' },
@@ -1267,7 +1324,12 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
 
   const isGeneratingPreviews =
     fetchPreviewsFetcher.state === 'loading' || fetchPreviewsFetcher.state === 'submitting';
-  const isPreviewsLoading = revalidator.state === 'loading' || isGeneratingPreviews;
+  const isGeneratingFigures =
+    fetchPreviewFiguresFetcher.state === 'loading' ||
+    fetchPreviewFiguresFetcher.state === 'submitting';
+  const isPreviewsLoading =
+    isGeneratingPreviews ||
+    (revalidator.state === 'loading' && !isGeneratingFigures && !shouldFetchPreviewFigures);
   const rotatingPreviewMessage = useRotatingMessage(PREVIEW_BUSY_MESSAGES, isGeneratingPreviews);
   const previewOverlayMessage = isGeneratingPreviews
     ? rotatingPreviewMessage
@@ -1345,6 +1407,7 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
               value={effectiveSelectedThumbnail}
               onChange={setSelectedThumbnail}
               pinnedThumbnail={inheritedThumbnail ?? null}
+              isFiguresLoading={isGeneratingFigures}
             />
           ) : null}
           {hasChecksFeature && canDispatchChecks ? (

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
@@ -1193,6 +1193,7 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
   const autoTitleFromFilenameFetcher = useFetcher();
   const hasTriggeredFetchPreviews = useRef(false);
   const hasTriggeredFetchPreviewFigures = useRef(false);
+  const [hasSkippedFigures, setHasSkippedFigures] = useState(false);
   // Tracks preview paths we've already observed, so a background preview that
   // resolves after its file was removed only raises its toast once.
   const seenPreviewPathsRef = useRef<Set<string> | null>(null);
@@ -1244,7 +1245,9 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
   const shouldFetchPreviews =
     hasMetadataExtractScope && previewFilePaths.length > 0 && missingPreviewPaths.length > 0;
   const shouldFetchPreviewFigures =
-    hasMetadataExtractScope && previewList.some((p) => p.figuresPending === true);
+    hasMetadataExtractScope &&
+    previewList.some((p) => p.figuresPending === true) &&
+    !hasSkippedFigures;
 
   // When a background preview finishes after its file was removed from the dropzone,
   // tell the user it was cached for a future upload of the same file.
@@ -1270,6 +1273,12 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
       );
     }
   }, [hasMetadataExtractScope, rawPreviews, previewFilePaths]);
+
+  useEffect(() => {
+    if (shouldFetchPreviews) {
+      setHasSkippedFigures(false);
+    }
+  }, [shouldFetchPreviews]);
 
   useEffect(() => {
     if (!shouldFetchPreviews) {
@@ -1316,17 +1325,23 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
     if (fetchPreviewsFetcher.state !== 'idle') return;
     hasTriggeredFetchPreviews.current = true;
     hasTriggeredFetchPreviewFigures.current = false;
+    setHasSkippedFigures(false);
     fetchPreviewsFetcher.submit(
       { intent: 'fetch-previews', uploadFlowTrigger: 'manual_preview_retry' },
       { method: 'POST' },
     );
   }, [fetchPreviewsFetcher]);
 
+  const handleSkipFigures = useCallback(() => {
+    setHasSkippedFigures(true);
+  }, []);
+
   const isGeneratingPreviews =
     fetchPreviewsFetcher.state === 'loading' || fetchPreviewsFetcher.state === 'submitting';
   const isGeneratingFigures =
-    fetchPreviewFiguresFetcher.state === 'loading' ||
-    fetchPreviewFiguresFetcher.state === 'submitting';
+    !hasSkippedFigures &&
+    (fetchPreviewFiguresFetcher.state === 'loading' ||
+      fetchPreviewFiguresFetcher.state === 'submitting');
   const isPreviewsLoading =
     isGeneratingPreviews ||
     (revalidator.state === 'loading' && !isGeneratingFigures && !shouldFetchPreviewFigures);
@@ -1408,6 +1423,7 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
               onChange={setSelectedThumbnail}
               pinnedThumbnail={inheritedThumbnail ?? null}
               isFiguresLoading={isGeneratingFigures}
+              onSkipFigures={handleSkipFigures}
             />
           ) : null}
           {hasChecksFeature && canDispatchChecks ? (

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
@@ -1192,8 +1192,11 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
   const fetchPreviewFiguresFetcher = useFetcher();
   const autoTitleFromFilenameFetcher = useFetcher();
   const hasTriggeredFetchPreviews = useRef(false);
-  const hasTriggeredFetchPreviewFigures = useRef(false);
+  /** Auto phase-B attempts per pending cycle; manual retry bypasses this cap. */
+  const figuresAutoAttempts = useRef(0);
   const [hasSkippedFigures, setHasSkippedFigures] = useState(false);
+  const [figuresFetchFinished, setFiguresFetchFinished] = useState(false);
+  const figuresFetchWasInFlight = useRef(false);
   // Tracks preview paths we've already observed, so a background preview that
   // resolves after its file was removed only raises its toast once.
   const seenPreviewPathsRef = useRef<Set<string> | null>(null);
@@ -1274,9 +1277,13 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
     }
   }, [hasMetadataExtractScope, rawPreviews, previewFilePaths]);
 
+  const MAX_FIGURES_AUTO_ATTEMPTS = 2;
+
   useEffect(() => {
     if (shouldFetchPreviews) {
       setHasSkippedFigures(false);
+      figuresAutoAttempts.current = 0;
+      setFiguresFetchFinished(false);
     }
   }, [shouldFetchPreviews]);
 
@@ -1295,15 +1302,25 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
 
   useEffect(() => {
     if (!shouldFetchPreviewFigures) {
-      hasTriggeredFetchPreviewFigures.current = false;
+      figuresAutoAttempts.current = 0;
       return;
     }
-    if (hasTriggeredFetchPreviewFigures.current || fetchPreviewFiguresFetcher.state !== 'idle') {
-      return;
-    }
-    hasTriggeredFetchPreviewFigures.current = true;
+    if (fetchPreviewFiguresFetcher.state !== 'idle') return;
+    if (figuresAutoAttempts.current >= MAX_FIGURES_AUTO_ATTEMPTS) return;
+    figuresAutoAttempts.current += 1;
     fetchPreviewFiguresFetcher.submit({ intent: 'fetch-preview-figures' }, { method: 'POST' });
   }, [shouldFetchPreviewFigures, fetchPreviewFiguresFetcher.state, fetchPreviewFiguresFetcher]);
+
+  useEffect(() => {
+    if (fetchPreviewFiguresFetcher.state !== 'idle') {
+      figuresFetchWasInFlight.current = true;
+      return;
+    }
+    if (figuresFetchWasInFlight.current) {
+      figuresFetchWasInFlight.current = false;
+      setFiguresFetchFinished(true);
+    }
+  }, [fetchPreviewFiguresFetcher.state]);
 
   // Show toast when fetch-previews action returns an error
   useEffect(() => {
@@ -1324,13 +1341,21 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
   const handleRetryPreview = useCallback(() => {
     if (fetchPreviewsFetcher.state !== 'idle') return;
     hasTriggeredFetchPreviews.current = true;
-    hasTriggeredFetchPreviewFigures.current = false;
+    figuresAutoAttempts.current = 0;
+    setFiguresFetchFinished(false);
     setHasSkippedFigures(false);
     fetchPreviewsFetcher.submit(
       { intent: 'fetch-previews', uploadFlowTrigger: 'manual_preview_retry' },
       { method: 'POST' },
     );
   }, [fetchPreviewsFetcher]);
+
+  const handleRetryFigures = useCallback(() => {
+    if (fetchPreviewFiguresFetcher.state !== 'idle') return;
+    setHasSkippedFigures(false);
+    setFiguresFetchFinished(false);
+    fetchPreviewFiguresFetcher.submit({ intent: 'fetch-preview-figures' }, { method: 'POST' });
+  }, [fetchPreviewFiguresFetcher]);
 
   const handleSkipFigures = useCallback(() => {
     setHasSkippedFigures(true);
@@ -1423,6 +1448,8 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
               onChange={setSelectedThumbnail}
               pinnedThumbnail={inheritedThumbnail ?? null}
               isFiguresLoading={isGeneratingFigures}
+              showFiguresRetry={figuresFetchFinished && !isGeneratingFigures}
+              onRetryFigures={handleRetryFigures}
               onSkipFigures={handleSkipFigures}
             />
           ) : null}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
@@ -107,6 +107,15 @@ import {
 import { CaptureMetadataSection } from './CaptureMetadataSection';
 import { isPreviewCandidate } from './metadata-extract/previewGuards';
 import {
+  applyFiguresFetcherStateTransition,
+  nextAutoFiguresAttempts,
+  pendingFigurePathsKey,
+  shouldAutoSubmitFiguresFetch,
+  shouldManualRetryFigures,
+  shouldResetFiguresAutoAttemptsForPendingKey,
+  shouldShowFiguresRetry,
+} from './metadata-extract/figuresAutoRetry';
+import {
   summarizePreviewCandidateFiles,
   sanitizeUploadFlowFailureReason,
   normalizeUploadFlowTrigger,
@@ -1192,8 +1201,9 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
   const fetchPreviewFiguresFetcher = useFetcher();
   const autoTitleFromFilenameFetcher = useFetcher();
   const hasTriggeredFetchPreviews = useRef(false);
-  /** Auto phase-B attempts per pending cycle; manual retry bypasses this cap. */
+  /** Auto phase-B attempts per pending path set; manual retry bypasses this cap. */
   const figuresAutoAttempts = useRef(0);
+  const lastPendingFigurePathsKeyRef = useRef('');
   const [hasSkippedFigures, setHasSkippedFigures] = useState(false);
   const [figuresFetchFinished, setFiguresFetchFinished] = useState(false);
   const figuresFetchWasInFlight = useRef(false);
@@ -1251,6 +1261,10 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
     hasMetadataExtractScope &&
     previewList.some((p) => p.figuresPending === true) &&
     !hasSkippedFigures;
+  const pendingFigurePathsSignature = useMemo(
+    () => pendingFigurePathsKey(previewList),
+    [previewList],
+  );
 
   // When a background preview finishes after its file was removed from the dropzone,
   // tell the user it was cached for a future upload of the same file.
@@ -1277,15 +1291,28 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
     }
   }, [hasMetadataExtractScope, rawPreviews, previewFilePaths]);
 
-  const MAX_FIGURES_AUTO_ATTEMPTS = 2;
-
   useEffect(() => {
     if (shouldFetchPreviews) {
       setHasSkippedFigures(false);
       figuresAutoAttempts.current = 0;
+      lastPendingFigurePathsKeyRef.current = pendingFigurePathsSignature;
       setFiguresFetchFinished(false);
     }
-  }, [shouldFetchPreviews]);
+  }, [shouldFetchPreviews, pendingFigurePathsSignature]);
+
+  useEffect(() => {
+    if (
+      !shouldResetFiguresAutoAttemptsForPendingKey({
+        previousKey: lastPendingFigurePathsKeyRef.current,
+        nextKey: pendingFigurePathsSignature,
+      })
+    ) {
+      return;
+    }
+    lastPendingFigurePathsKeyRef.current = pendingFigurePathsSignature;
+    figuresAutoAttempts.current = 0;
+    setFiguresFetchFinished(false);
+  }, [pendingFigurePathsSignature]);
 
   useEffect(() => {
     if (!shouldFetchPreviews) {
@@ -1305,19 +1332,26 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
       figuresAutoAttempts.current = 0;
       return;
     }
-    if (fetchPreviewFiguresFetcher.state !== 'idle') return;
-    if (figuresAutoAttempts.current >= MAX_FIGURES_AUTO_ATTEMPTS) return;
-    figuresAutoAttempts.current += 1;
+    if (
+      !shouldAutoSubmitFiguresFetch({
+        shouldFetchPreviewFigures,
+        fetcherState: fetchPreviewFiguresFetcher.state,
+        autoAttempts: figuresAutoAttempts.current,
+      })
+    ) {
+      return;
+    }
+    figuresAutoAttempts.current = nextAutoFiguresAttempts(figuresAutoAttempts.current);
     fetchPreviewFiguresFetcher.submit({ intent: 'fetch-preview-figures' }, { method: 'POST' });
   }, [shouldFetchPreviewFigures, fetchPreviewFiguresFetcher.state, fetchPreviewFiguresFetcher]);
 
   useEffect(() => {
-    if (fetchPreviewFiguresFetcher.state !== 'idle') {
-      figuresFetchWasInFlight.current = true;
-      return;
-    }
-    if (figuresFetchWasInFlight.current) {
-      figuresFetchWasInFlight.current = false;
+    const transition = applyFiguresFetcherStateTransition({
+      fetcherState: fetchPreviewFiguresFetcher.state,
+      wasInFlight: figuresFetchWasInFlight.current,
+    });
+    figuresFetchWasInFlight.current = transition.wasInFlight;
+    if (transition.fetchFinished) {
       setFiguresFetchFinished(true);
     }
   }, [fetchPreviewFiguresFetcher.state]);
@@ -1351,7 +1385,7 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
   }, [fetchPreviewsFetcher]);
 
   const handleRetryFigures = useCallback(() => {
-    if (fetchPreviewFiguresFetcher.state !== 'idle') return;
+    if (!shouldManualRetryFigures(fetchPreviewFiguresFetcher.state)) return;
     setHasSkippedFigures(false);
     setFiguresFetchFinished(false);
     fetchPreviewFiguresFetcher.submit({ intent: 'fetch-preview-figures' }, { method: 'POST' });
@@ -1448,7 +1482,10 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
               onChange={setSelectedThumbnail}
               pinnedThumbnail={inheritedThumbnail ?? null}
               isFiguresLoading={isGeneratingFigures}
-              showFiguresRetry={figuresFetchFinished && !isGeneratingFigures}
+              showFiguresRetry={shouldShowFiguresRetry({
+                figuresFetchFinished,
+                isGeneratingFigures,
+              })}
               onRetryFigures={handleRetryFigures}
               onSkipFigures={handleSkipFigures}
             />

--- a/platform/scms/package.template.json
+++ b/platform/scms/package.template.json
@@ -148,6 +148,7 @@
     "cronstrue": "^3.24.0",
     "date-fns": "3.6.0",
     "officeparser": "^6.0.4",
+    "pdfjs-dist": "5.6.205",
     "fuse.js": "^7.1.0",
     "isbot": "^5",
     "js-yaml": "^4.1.1",


### PR DESCRIPTION
* speed up previews by splitting our thumbnail parsing from text parsing
* fix instance where docx files are not previewed because the parser things they are zip files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the manuscript upload metadata-extract path with new parsing routes (pdfjs, internal officeparser loaders) and a two-request cache lifecycle; behavior is covered by new unit tests but regressions in preview/thumbnail selection would affect uploads.
> 
> **Overview**
> **Document previews are split into two phases** so metadata and first-page text can appear before thumbnail candidates are ready. Phase A (`fetch-previews` / `fetchDocumentPreviewText`) caches a truncated text AST with **no** figure extraction; phase B (`fetch-preview-figures`) runs later, re-parses with attachments, and writes webp thumbnails. Cached previews gain **`figuresPending`** until phase B completes; upload analysis treats pending figures as **unknown** image presence.
> 
> **Phase A is faster by design:** PDFs use a **`pdfjs-dist`** first-page text path (pages 1–2 only), falling back to officeparser when text is too sparse; DOCX and others parse via **`parseOfficeFromBuffer`**, which routes by **storage path extension** instead of magic-byte detection—fixing DOCX that `file-type` mislabels as zip. AST truncation/plain-text helpers move to **`previewAstUtils.server`**. Phase B parallelizes figure downscale/storage with **`p-limit`**.
> 
> The **upload route** auto-triggers phase B when previews are `figuresPending`, with capped auto-retries (`figuresAutoRetry`), manual re-try, and client **skip** to continue without thumbnails. **`ChooseThumbnailSection`** shows busy overlays, a placeholder beside pinned thumbnails, and a 15s escape hatch to skip generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c21c8eb419cb8bd4dc61720a28bc8c4c87b6ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->