### PR TITLE
📝 Document reduced HHMI checks Slack event coverage

### DIFF
--- a/.changeset/check-run-slack-telemetry.md
+++ b/.changeset/check-run-slack-telemetry.md
@@ -2,4 +2,4 @@
 '@curvenote/scms-server': patch
 ---
 
-Add generic check-run Slack event types (`CHECK_RUN_STARTED`, `CHECK_RUN_MILESTONE`, `CHECK_RUN_ERROR`, `CHECK_RUN_RETRY`, `CHECK_EULA_ACCEPTED`) so extension check packages can emit operational notifications on the existing `api.slack.webhookUrl` channel. Document the new events in the Slack integration guide; check-specific deep links remain in extension packages (e.g. `@hhmi/checks-notify`), not in core.
+Add generic check-run Slack event types (`CHECK_RUN_STARTED`, `CHECK_RUN_MILESTONE`, `CHECK_RUN_ERROR`, `CHECK_RUN_RETRY`, `CHECK_EULA_ACCEPTED`) so extension check packages can emit operational notifications on the existing `api.slack.webhookUrl` channel. Document the new events in the Slack integration guide; check-specific deep links remain in extension packages (e.g. text-integrity and proofig), not in core.

--- a/.changeset/reduce-checks-slack-docs.md
+++ b/.changeset/reduce-checks-slack-docs.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms': patch
+---
+
+Document reduced HHMI checks Slack event coverage: terminal-only milestones, no retry sweep pings.

--- a/.changeset/reduce-checks-slack-docs.md
+++ b/.changeset/reduce-checks-slack-docs.md
@@ -2,4 +2,4 @@
 '@curvenote/scms': patch
 ---
 
-Document reduced HHMI checks Slack event coverage: terminal-only milestones, no retry sweep pings.
+Document reduced check-extension Slack event coverage: terminal-only milestones, no retry sweep pings.

--- a/platform/scms/docs/slack-integration.md
+++ b/platform/scms/docs/slack-integration.md
@@ -96,16 +96,16 @@ The following events are currently implemented and available:
 ### Check Events
 
 - **`CHECK_RUN_STARTED`**: Triggered when a check run is created and its work is enqueued (including inline pre-submit validation failures, styled as danger)
-- **`CHECK_RUN_MILESTONE`**: Triggered when a check run reaches a **terminal** outcome (report complete/failed, final provider state). HHMI checks extensions do not emit intermediate progress milestones.
+- **`CHECK_RUN_MILESTONE`**: Triggered when a check run reaches a **terminal** outcome (report complete/failed, final provider state). Check extensions such as text-integrity and proofig do not emit intermediate progress milestones.
 - **`CHECK_RUN_ERROR`**: Triggered when a check run enters an error state or a handler fails
-- **`CHECK_RUN_RETRY`**: Defined in core for extension use; HHMI checks extensions no longer emit retry or auto-retry sweep summaries (a retried run surfaces via `CHECK_RUN_STARTED` on the new attempt)
+- **`CHECK_RUN_RETRY`**: Defined in core for extension use; text-integrity and proofig no longer emit retry or auto-retry sweep summaries (a retried run surfaces via `CHECK_RUN_STARTED` on the new attempt)
 - **`CHECK_EULA_ACCEPTED`**: Triggered when a user accepts a provider EULA required by a check
 
 These are generic check lifecycle events; the specific check kinds and providers that emit them live in their own feature modules, not in core.
 
 Slack notifications enable `mrkdwn_in: ['fields']`, so any metadata field value that is a full `http://` or `https://` URL will be rendered as a clickable link by Slack.
 
-Callers are responsible for putting the actual URLs into `metadata`. Use `@curvenote/scms-core` helpers for platform-wide routes (e.g. `asSiteSubmissionUrl`, `asPlatformMessageUrl`). Check-specific deep links belong in extension packages — for HHMI checks, see `@hhmi/checks-notify` (`packages/checks-notify/src/urls.ts` in the `hhmi-checks` extension), not in core.
+Callers are responsible for putting the actual URLs into `metadata`. Use `@curvenote/scms-core` helpers for platform-wide routes (e.g. `asSiteSubmissionUrl`, `asPlatformMessageUrl`). Check-specific deep links belong in extension packages (e.g. text-integrity and proofig), not in core.
 
 ## Adding New Events
 

--- a/platform/scms/docs/slack-integration.md
+++ b/platform/scms/docs/slack-integration.md
@@ -95,10 +95,10 @@ The following events are currently implemented and available:
 
 ### Check Events
 
-- **`CHECK_RUN_STARTED`**: Triggered when a check run is created and its work is enqueued
-- **`CHECK_RUN_MILESTONE`**: Triggered on meaningful check workflow milestones (e.g. provider webhooks, artifacts persisted)
+- **`CHECK_RUN_STARTED`**: Triggered when a check run is created and its work is enqueued (including inline pre-submit validation failures, styled as danger)
+- **`CHECK_RUN_MILESTONE`**: Triggered when a check run reaches a **terminal** outcome (report complete/failed, final provider state). HHMI checks extensions do not emit intermediate progress milestones.
 - **`CHECK_RUN_ERROR`**: Triggered when a check run enters an error state or a handler fails
-- **`CHECK_RUN_RETRY`**: Triggered on manual retry or an auto-retry sweep summary (when retries occurred)
+- **`CHECK_RUN_RETRY`**: Defined in core for extension use; HHMI checks extensions no longer emit retry or auto-retry sweep summaries (a retried run surfaces via `CHECK_RUN_STARTED` on the new attempt)
 - **`CHECK_EULA_ACCEPTED`**: Triggered when a user accepts a provider EULA required by a check
 
 These are generic check lifecycle events; the specific check kinds and providers that emit them live in their own feature modules, not in core.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and changeset text only; no runtime or Slack emission logic changes in this diff.
> 
> **Overview**
> Updates the **Slack integration guide** so check-run events match the slimmer notification behavior for extensions like **text-integrity** and **proofig**.
> 
> **`CHECK_RUN_STARTED`** now notes inline pre-submit validation failures (danger styling). **`CHECK_RUN_MILESTONE`** is documented as **terminal-only**—no intermediate progress pings from those extensions. **`CHECK_RUN_RETRY`** stays in core for extensions but those packages no longer send retry or auto-retry sweep messages; retries show up via **`CHECK_RUN_STARTED`** on the new attempt.
> 
> Deep-link guidance drops the `@hhmi/checks-notify` pointer in favor of naming text-integrity and proofig. A new **changeset** records the doc change for `@curvenote/scms`; an existing server changeset is aligned with the same extension naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48ed7b623f31f373344bad22f4ce59f1422283b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->