### PR TITLE
⚡️ speedup pdf extract

### DIFF
--- a/.changeset/pdf-upload-figure-extraction.md
+++ b/.changeset/pdf-upload-figure-extraction.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms': patch
+---
+
+Add a fast pdfjs path for PDF figure extraction during upload phase B (thumbnail gallery), with a 99-page scan cap and existing 24-figure limit. Skip tiny/oversized rasters before BMP materialization, dedupe repeated XObject paints, and show a PDF-specific gallery busy message. Remove the redundant All Figures preview tab, move `resolvePreviewImagePresence` to a client-safe module, and retry thumbnail extraction when phase B returns no figures.

--- a/.changeset/upload-preview-cache-id-rename.md
+++ b/.changeset/upload-preview-cache-id-rename.md
@@ -1,0 +1,7 @@
+---
+'@curvenote/scms-core': patch
+'@curvenote/scms-server': patch
+'@curvenote/scms': patch
+---
+
+Rename version-scoped document preview cache Object ids from `docx:preview:v3:` to `upload:preview:` (PDF and DOCX alike). Delete legacy `docx:preview:v3`, `docx:preview:v2`, and md5-only rows on confirm-work cleanup, draft work deletion, and preview artifact removal. When cloning a draft version, seed preview cache from legacy source rows when the new-prefix row is absent.

--- a/packages/scms-core/src/utils/documentPreviewCache.spec.ts
+++ b/packages/scms-core/src/utils/documentPreviewCache.spec.ts
@@ -4,11 +4,13 @@ import {
   documentPreviewCacheId,
   previewCandidateMd5s,
   previewCacheObjectIds,
+  legacyVersionScopedPreviewCacheIds,
+  allPreviewCacheObjectIdsForCleanup,
 } from './documentPreviewCache.js';
 
 describe('documentPreviewCacheId', () => {
   it('scopes cache id by work version and md5', () => {
-    expect(documentPreviewCacheId('wv-1', 'abc123')).toBe('docx:preview:v3:wv-1:abc123');
+    expect(documentPreviewCacheId('wv-1', 'abc123')).toBe('upload:preview:wv-1:abc123');
   });
 });
 
@@ -69,6 +71,35 @@ describe('previewCacheObjectIds', () => {
           a: { path: 'a.pdf', type: 'application/pdf', md5: 'm1' },
         },
       }),
+    ).toEqual(['upload:preview:wv-2:m1']);
+  });
+});
+
+describe('legacyVersionScopedPreviewCacheIds', () => {
+  it('maps md5s to legacy version-scoped object ids', () => {
+    expect(
+      legacyVersionScopedPreviewCacheIds('wv-2', {
+        files: {
+          a: { path: 'a.pdf', type: 'application/pdf', md5: 'm1' },
+        },
+      }),
     ).toEqual(['docx:preview:v3:wv-2:m1']);
+  });
+});
+
+describe('allPreviewCacheObjectIdsForCleanup', () => {
+  it('includes current and legacy cache ids', () => {
+    expect(
+      allPreviewCacheObjectIdsForCleanup('wv-2', {
+        files: {
+          a: { path: 'a.pdf', type: 'application/pdf', md5: 'm1' },
+        },
+      }),
+    ).toEqual([
+      'upload:preview:wv-2:m1',
+      'docx:preview:v3:wv-2:m1',
+      'docx:preview:v2:m1',
+      'docx:preview:m1',
+    ]);
   });
 });

--- a/packages/scms-core/src/utils/documentPreviewCache.spec.ts
+++ b/packages/scms-core/src/utils/documentPreviewCache.spec.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   documentPreviewCacheId,
+  documentPreviewCacheSourceLookupIds,
   previewCandidateMd5s,
   previewCacheObjectIds,
   legacyVersionScopedPreviewCacheIds,
@@ -11,6 +12,15 @@ import {
 describe('documentPreviewCacheId', () => {
   it('scopes cache id by work version and md5', () => {
     expect(documentPreviewCacheId('wv-1', 'abc123')).toBe('upload:preview:wv-1:abc123');
+  });
+});
+
+describe('documentPreviewCacheSourceLookupIds', () => {
+  it('includes current and version-scoped legacy ids', () => {
+    expect(documentPreviewCacheSourceLookupIds('wv-1', 'abc123')).toEqual([
+      'upload:preview:wv-1:abc123',
+      'docx:preview:v3:wv-1:abc123',
+    ]);
   });
 });
 

--- a/packages/scms-core/src/utils/documentPreviewCache.ts
+++ b/packages/scms-core/src/utils/documentPreviewCache.ts
@@ -23,6 +23,18 @@ export function documentPreviewCacheId(workVersionId: string, md5: string): stri
   return `${DOCUMENT_PREVIEW_CACHE_PREFIX}${workVersionId}:${md5}`;
 }
 
+/** Object-table ids to try when reading a cached preview (current, then version-scoped legacy). */
+export function documentPreviewCacheSourceLookupIds(workVersionId: string, md5: string): string[] {
+  return Array.from(
+    new Set([
+      documentPreviewCacheId(workVersionId, md5),
+      ...LEGACY_VERSION_SCOPED_PREVIEW_CACHE_PREFIXES.map(
+        (prefix) => `${prefix}${workVersionId}:${md5}`,
+      ),
+    ]),
+  );
+}
+
 /** Distinct md5s of the preview-candidate files in a work version's metadata.files. */
 export function previewCandidateMd5s(metadata: unknown): string[] {
   const files = (metadata as FilesMetadata | null | undefined)?.files;

--- a/packages/scms-core/src/utils/documentPreviewCache.ts
+++ b/packages/scms-core/src/utils/documentPreviewCache.ts
@@ -1,13 +1,18 @@
 import { isPreviewCandidate } from './manuscriptFormats.js';
 
-/** Object table type/id prefix for cached document preview entries (versioned). */
-export const DOCUMENT_PREVIEW_CACHE_PREFIX = 'docx:preview:v3:';
+/** Object table type/id prefix for cached upload document preview entries. */
+export const DOCUMENT_PREVIEW_CACHE_PREFIX = 'upload:preview:';
 
 /**
  * Older cache prefixes whose rows are keyed by md5 only (no work version). Still removed
  * during confirm-work cleanup so legacy rows don't linger after the scheme change.
  */
 export const LEGACY_PREVIEW_CACHE_PREFIXES = ['docx:preview:v2:', 'docx:preview:'] as const;
+
+/**
+ * Version-scoped legacy prefixes (same `{workVersionId}:{md5}` suffix as the current scheme).
+ */
+export const LEGACY_VERSION_SCOPED_PREVIEW_CACHE_PREFIXES = ['docx:preview:v3:'] as const;
 
 type FilesMetadata = {
   files?: Record<string, { path?: string; name?: string; type?: string; md5?: string }>;
@@ -49,5 +54,33 @@ export function legacyPreviewCacheIds(metadata: unknown): string[] {
     new Set(
       md5s.flatMap((md5) => LEGACY_PREVIEW_CACHE_PREFIXES.map((prefix) => `${prefix}${md5}`)),
     ),
+  );
+}
+
+/**
+ * Legacy version-scoped cache ids (e.g. docx:preview:v3) for cleanup after prefix changes.
+ */
+export function legacyVersionScopedPreviewCacheIds(
+  workVersionId: string,
+  metadata: unknown,
+): string[] {
+  return previewCandidateMd5s(metadata).flatMap((md5) =>
+    LEGACY_VERSION_SCOPED_PREVIEW_CACHE_PREFIXES.map(
+      (prefix) => `${prefix}${workVersionId}:${md5}`,
+    ),
+  );
+}
+
+/** Current and legacy Object-table ids to delete for a work version's preview cache. */
+export function allPreviewCacheObjectIdsForCleanup(
+  workVersionId: string,
+  metadata: unknown,
+): string[] {
+  return Array.from(
+    new Set([
+      ...previewCacheObjectIds(workVersionId, metadata),
+      ...legacyVersionScopedPreviewCacheIds(workVersionId, metadata),
+      ...legacyPreviewCacheIds(metadata),
+    ]),
   );
 }

--- a/packages/scms-server/src/backend/works/versions/cloneDraftWorkVersion.server.test.ts
+++ b/packages/scms-server/src/backend/works/versions/cloneDraftWorkVersion.server.test.ts
@@ -269,7 +269,7 @@ describe('seedDocumentPreviewCacheFromSource', () => {
     const tx = {
       object: {
         findUnique: vi.fn(async ({ where }: { where: { id: string } }) => {
-          if (where.id === 'docx:preview:v3:src:md5-a') {
+          if (where.id === 'upload:preview:src:md5-a') {
             return { data: previewData };
           }
           return null;
@@ -293,8 +293,8 @@ describe('seedDocumentPreviewCacheFromSource', () => {
     expect(tx.object.createMany).toHaveBeenCalledWith({
       data: [
         expect.objectContaining({
-          id: 'docx:preview:v3:tgt:md5-a',
-          type: 'docx:preview:v3:tgt:md5-a',
+          id: 'upload:preview:tgt:md5-a',
+          type: 'upload:preview:tgt:md5-a',
           data: previewData,
           created_by_id: 'user-1',
         }),

--- a/packages/scms-server/src/backend/works/versions/cloneDraftWorkVersion.server.test.ts
+++ b/packages/scms-server/src/backend/works/versions/cloneDraftWorkVersion.server.test.ts
@@ -303,6 +303,51 @@ describe('seedDocumentPreviewCacheFromSource', () => {
     });
   });
 
+  it('falls back to legacy version-scoped source cache rows', async () => {
+    const previewData = { ast: {}, figures: [] };
+    const tx = {
+      object: {
+        findUnique: vi.fn(async ({ where }: { where: { id: string } }) => {
+          if (where.id === 'docx:preview:v3:src:md5-a') {
+            return { data: previewData };
+          }
+          return null;
+        }),
+        createMany: vi.fn(async () => ({ count: 1 })),
+      },
+    } as any;
+
+    const count = await seedDocumentPreviewCacheFromSource(tx, {
+      sourceWorkVersionId: 'src',
+      targetWorkVersionId: 'tgt',
+      metadata: {
+        files: {
+          a: { path: 'a.pdf', type: 'application/pdf', md5: 'md5-a' },
+        },
+      },
+      createdById: 'user-1',
+    });
+
+    expect(count).toBe(1);
+    expect(tx.object.findUnique).toHaveBeenCalledWith({
+      where: { id: 'upload:preview:src:md5-a' },
+      select: { data: true },
+    });
+    expect(tx.object.findUnique).toHaveBeenCalledWith({
+      where: { id: 'docx:preview:v3:src:md5-a' },
+      select: { data: true },
+    });
+    expect(tx.object.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          id: 'upload:preview:tgt:md5-a',
+          data: previewData,
+        }),
+      ],
+      skipDuplicates: true,
+    });
+  });
+
   it('skips when source cache row is missing', async () => {
     const tx = {
       object: {

--- a/packages/scms-server/src/backend/works/versions/cloneDraftWorkVersion.server.ts
+++ b/packages/scms-server/src/backend/works/versions/cloneDraftWorkVersion.server.ts
@@ -1,4 +1,9 @@
-import { error404, documentPreviewCacheId, previewCandidateMd5s } from '@curvenote/scms-core';
+import {
+  error404,
+  documentPreviewCacheId,
+  documentPreviewCacheSourceLookupIds,
+  previewCandidateMd5s,
+} from '@curvenote/scms-core';
 import type { ActivityType, Prisma } from '@curvenote/scms-db';
 import { formatDate } from '@curvenote/common';
 import { uuidv7 } from 'uuidv7';
@@ -53,21 +58,27 @@ export async function seedDocumentPreviewCacheFromSource(
   const rows: Prisma.ObjectCreateManyInput[] = [];
 
   for (const md5 of md5s) {
-    const sourceId = documentPreviewCacheId(args.sourceWorkVersionId, md5);
     const targetId = documentPreviewCacheId(args.targetWorkVersionId, md5);
 
-    const sourceRow = await tx.object.findUnique({
-      where: { id: sourceId },
-      select: { data: true },
-    });
-    if (sourceRow?.data == null) continue;
+    let sourceData: Prisma.InputJsonValue | null = null;
+    for (const sourceId of documentPreviewCacheSourceLookupIds(args.sourceWorkVersionId, md5)) {
+      const sourceRow = await tx.object.findUnique({
+        where: { id: sourceId },
+        select: { data: true },
+      });
+      if (sourceRow?.data != null) {
+        sourceData = sourceRow.data as Prisma.InputJsonValue;
+        break;
+      }
+    }
+    if (sourceData == null) continue;
 
     rows.push({
       id: targetId,
       type: targetId,
       date_created: now,
       date_modified: now,
-      data: sourceRow.data as Prisma.InputJsonValue,
+      data: sourceData,
       occ: 0,
       ...(args.createdById ? { created_by_id: args.createdById } : {}),
     });

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/ChooseThumbnailSection.tsx
@@ -16,6 +16,7 @@ import {
   resolveThumbnailSelection,
 } from './thumbnailSelection';
 import type { DocumentPreviewItem } from './fetchPreviews.server';
+import { figuresBusyMessageForPreviews } from './previewFigureMessages';
 import { useDelayedFlag } from './useDelayedFlag';
 
 /** Reveal the skip escape hatch after this long in the figures busy state. */
@@ -387,7 +388,7 @@ export function ChooseThumbnailSection({
       ? 'No images yet'
       : 'No figures were found in the current document previews.';
 
-  const figuresBusyMessage = 'Generating thumbnail options…';
+  const figuresBusyMessage = figuresBusyMessageForPreviews(previewList, isFiguresLoading);
   const hasPinnedThumbnail = Boolean(pinnedThumbnail);
   const hasExtractedFigures = figures.length > 0;
   const hasGalleryTiles = hasPinnedThumbnail || hasExtractedFigures;

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/DocumentPreviewer.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/DocumentPreviewer.tsx
@@ -56,7 +56,7 @@ function resolveFormatting(
 
 interface DocumentPreviewerProps {
   previews: DocumentPreviewItem[];
-  /** Controlled active tab value (file index as string, or ALL_FIGURES_TAB). */
+  /** Controlled active tab value (file index as string). */
   activeTab?: string;
   onActiveTabChange?: (tab: string) => void;
 }
@@ -304,8 +304,6 @@ function SingleFileView({
   );
 }
 
-export const ALL_FIGURES_TAB = 'all-figures';
-
 const PREVIEW_TAB_TITLE_MAX = 20;
 
 function shortenPreviewTabTitle(name: string, max = PREVIEW_TAB_TITLE_MAX): string {
@@ -346,49 +344,6 @@ export function collectAllFigures(previews: DocumentPreviewItem[]): DocumentFigu
   return out;
 }
 
-function AllFiguresView({ figures }: { figures: DocumentFigure[] }) {
-  if (figures.length === 0) {
-    return (
-      <div className={PREVIEW_CONTENT_CLASS}>
-        <p className="text-sm text-muted-foreground">no figures found</p>
-      </div>
-    );
-  }
-  return (
-    <div className={PREVIEW_CONTENT_CLASS}>
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
-        {figures.map(({ figure, sourceName }) => {
-          const label = figure.altText ?? figure.name ?? 'Figure';
-          return (
-            <figure key={figure.key} className="flex flex-col gap-1">
-              <div className="flex overflow-hidden justify-center items-center min-h-0 rounded aspect-square bg-stone-100 dark:bg-stone-800">
-                {figure.signedUrl ? (
-                  <img
-                    src={figure.signedUrl}
-                    alt={label}
-                    className="object-contain w-full h-full"
-                  />
-                ) : (
-                  <span className="text-xs text-muted-foreground">[No data]</span>
-                )}
-              </div>
-              <figcaption
-                className="text-xs truncate text-muted-foreground"
-                title={figure.altText ?? figure.name}
-              >
-                {label}
-              </figcaption>
-              <p className="text-xs truncate text-muted-foreground/80" title={sourceName}>
-                {sourceName}
-              </p>
-            </figure>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
 export const DocumentPreviewer = ({
   previews,
   activeTab,
@@ -398,8 +353,6 @@ export const DocumentPreviewer = ({
   const [internalTab, setInternalTab] = useState('0');
   const fileTab = activeTab ?? internalTab;
   const setFileTab = onActiveTabChange ?? setInternalTab;
-
-  const allFigures = collectAllFigures(previews);
 
   return (
     <ui.Tabs value={fileTab} onValueChange={setFileTab} className="w-full">
@@ -418,12 +371,6 @@ export const DocumentPreviewer = ({
             </ui.TabsTrigger>
           );
         })}
-        <ui.TabsTrigger
-          value={ALL_FIGURES_TAB}
-          className="rounded-none border-b-2 border-stone-300 dark:border-stone-600 text-stone-500 dark:text-stone-400 data-[state=active]:border-primary data-[state=active]:text-primary data-[state=active]:bg-transparent data-[state=inactive]:bg-transparent shadow-none"
-        >
-          All Figures
-        </ui.TabsTrigger>
       </ui.TabsList>
       {previews.map((item, index) => (
         <ui.TabsContent
@@ -440,14 +387,6 @@ export const DocumentPreviewer = ({
           </div>
         </ui.TabsContent>
       ))}
-      <ui.TabsContent
-        value={ALL_FIGURES_TAB}
-        className="mt-4 rounded-none border-0 bg-transparent p-0"
-      >
-        <div className={PREVIEW_CONTENT_SURFACE_CLASS}>
-          <AllFiguresView figures={allFigures} />
-        </div>
-      </ui.TabsContent>
     </ui.Tabs>
   );
 };

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/MetadataExtractSection.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/MetadataExtractSection.tsx
@@ -3,7 +3,6 @@ import { useFetcher } from 'react-router';
 import { Eye, List } from 'lucide-react';
 import { SectionWithHeading, ui } from '@curvenote/scms-core';
 import type { Route } from '../+types/route';
-import { ALL_FIGURES_TAB } from './DocumentPreviewer';
 import { DocumentPreviewCard } from './DocumentPreviewCard';
 import { MetadataFormCard } from './MetadataFormCard';
 import type { DocumentPreviewItem } from './fetchPreviews.server';
@@ -131,9 +130,11 @@ export function MetadataExtractSection({
     const nextPaths = previewList.map((preview) => preview.path);
     prevPreviewPathsRef.current = nextPaths;
 
-    if (activeTab === ALL_FIGURES_TAB) return;
     const currentIndex = Number(activeTab);
-    if (!Number.isInteger(currentIndex)) return;
+    if (!Number.isInteger(currentIndex)) {
+      if (nextPaths.length > 0) setActiveTab('0');
+      return;
+    }
 
     const activePath = prevPaths[currentIndex];
     if (activePath == null) {
@@ -243,11 +244,9 @@ export function MetadataExtractSection({
   const isClearingExtraction =
     clearMetadataFetcher.state === 'loading' || clearMetadataFetcher.state === 'submitting';
 
-  // Resolve the file backing the active tab; non-file tabs (e.g. All Figures)
-  // fall back to the first file.
+  // Resolve the file backing the active tab; invalid values fall back to the first file.
   const activeFile = (() => {
     if (!hasPreviews) return undefined;
-    if (activeTab === ALL_FIGURES_TAB) return previewList[0];
     const index = Number(activeTab);
     return Number.isInteger(index) && index >= 0 && index < previewList.length
       ? previewList[index]

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.spec.ts
@@ -1,7 +1,11 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, expect, it } from 'vitest';
 import type { OfficeContentNode, OfficeParserAST } from 'officeparser';
-import { astContentToPlainText, truncateAstToFirstPage } from './fetchPreviews.server';
+import {
+  astContentToPlainText,
+  shouldExtractPreviewFigures,
+  truncateAstToFirstPage,
+} from './fetchPreviews.server';
 import { resolvePreviewImagePresence } from './previewImagePresence';
 
 function textNode(text: string): OfficeContentNode {
@@ -96,6 +100,63 @@ describe('fetch preview truncation', () => {
 
     expect(result.content).toHaveLength(40);
     expect(result.wasTruncated).toBe(true);
+  });
+});
+
+describe('shouldExtractPreviewFigures', () => {
+  it('extracts when figures are still pending', () => {
+    expect(shouldExtractPreviewFigures({ figuresPending: true, figures: [] })).toBe(true);
+  });
+
+  it('skips completed previews unless force retry is requested', () => {
+    expect(
+      shouldExtractPreviewFigures({
+        figuresPending: false,
+        figuresExtractionSkipped: false,
+        figures: [],
+      }),
+    ).toBe(false);
+  });
+
+  it('force retry re-runs confident zero-figure completions', () => {
+    expect(
+      shouldExtractPreviewFigures(
+        {
+          figuresPending: false,
+          figuresExtractionSkipped: false,
+          figures: [],
+        },
+        { forceRetry: true },
+      ),
+    ).toBe(true);
+  });
+
+  it('force retry does not re-run skipped or unavailable previews', () => {
+    expect(
+      shouldExtractPreviewFigures(
+        { figuresPending: false, figuresExtractionSkipped: true, figures: [] },
+        { forceRetry: true },
+      ),
+    ).toBe(false);
+    expect(
+      shouldExtractPreviewFigures(
+        { figuresPending: false, previewUnavailable: true, figures: [] },
+        { forceRetry: true },
+      ),
+    ).toBe(false);
+  });
+
+  it('force retry does not re-run previews that already have figures', () => {
+    expect(
+      shouldExtractPreviewFigures(
+        {
+          figuresPending: false,
+          figuresExtractionSkipped: false,
+          figures: [{ key: 'figure.webp' }],
+        },
+        { forceRetry: true },
+      ),
+    ).toBe(false);
   });
 });
 

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.spec.ts
@@ -1,11 +1,8 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, expect, it } from 'vitest';
 import type { OfficeContentNode, OfficeParserAST } from 'officeparser';
-import {
-  astContentToPlainText,
-  resolvePreviewImagePresence,
-  truncateAstToFirstPage,
-} from './fetchPreviews.server';
+import { astContentToPlainText, truncateAstToFirstPage } from './fetchPreviews.server';
+import { resolvePreviewImagePresence } from './previewImagePresence';
 
 function textNode(text: string): OfficeContentNode {
   return { type: 'text', text } as OfficeContentNode;

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
@@ -23,7 +23,6 @@ import {
   computeManuscriptSourceSignature,
   UPLOAD_ANALYSIS_METADATA_KEY,
   type FileMetadataSectionItem,
-  type UploadFactPresence,
 } from '@curvenote/scms-core';
 import type { Context } from '@curvenote/scms-server';
 import type { Prisma } from '@curvenote/scms-db';
@@ -42,6 +41,9 @@ import {
   truncateAstToFirstPage,
   type PreviewAstData,
 } from './previewAstUtils.server';
+import { resolvePreviewImagePresence } from './previewImagePresence';
+
+export { resolvePreviewImagePresence } from './previewImagePresence';
 
 /** Longest edge (px) of a downscaled candidate figure thumbnail. */
 const PREVIEW_FIGURE_MAX_EDGE = 384;
@@ -116,34 +118,6 @@ interface PreviewWorkContext {
   backend: StorageBackend;
   figureBucket: KnownBuckets | null;
   prisma: Awaited<ReturnType<typeof getPrismaClient>>;
-}
-
-export function resolvePreviewImagePresence(
-  previewCandidatePaths: string[],
-  previews: Pick<
-    DocumentPreviewItem,
-    'path' | 'figures' | 'previewUnavailable' | 'figuresExtractionSkipped' | 'figuresPending'
-  >[],
-): UploadFactPresence {
-  if (previewCandidatePaths.length === 0) return 'unknown';
-  const previewPaths = new Set(previews.map((preview) => preview.path));
-  const hasMissingPreview = previewCandidatePaths.some((path) => !previewPaths.has(path));
-  if (hasMissingPreview || previews.some((preview) => preview.previewUnavailable === true)) {
-    return 'unknown';
-  }
-  if (previews.some((preview) => preview.figuresPending === true)) {
-    return 'unknown';
-  }
-  if (previews.some((preview) => preview.figures.length > 0)) {
-    return 'present';
-  }
-  if (previews.some((preview) => preview.figuresExtractionSkipped === true)) {
-    return 'unknown';
-  }
-  const allConfidentlyAbsent = previews.every(
-    (preview) => preview.figuresExtractionSkipped === false && preview.figures.length === 0,
-  );
-  return allConfidentlyAbsent && previews.length > 0 ? 'absent' : 'unknown';
 }
 
 async function persistPreviewUploadAnalysis({

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
@@ -6,7 +6,7 @@
  * - Phase B (fetch-preview-figures): deferred attachment extraction + thumbnail storage.
  *
  * PDF phase A uses a pdfjs first-page fast path; DOCX uses officeparser without attachments.
- * Phase B re-parses with officeparser + extractAttachments (v1 tradeoff).
+ * PDF phase B uses a capped pdfjs image scan; other formats use officeparser + extractAttachments.
  */
 
 import {
@@ -332,6 +332,23 @@ async function extractAndStoreFigures(
   return results.filter((fig): fig is PreviewFigure => fig != null);
 }
 
+async function extractFigureAttachmentsFromBuffer(
+  path: string,
+  file: FileMetadataSectionItem,
+  arrayBuffer: ArrayBuffer,
+): Promise<OfficeAttachment[]> {
+  if (isPdfFile(path, file)) {
+    const { extractPdfFigureAttachments } = await import('./pdfFigureExtraction.server');
+    return extractPdfFigureAttachments(arrayBuffer, MAX_PREVIEW_FIGURES);
+  }
+  const { parseOfficeFromBuffer } = await import('./parseOfficeFromBuffer.server');
+  const fullAst = await parseOfficeFromBuffer(arrayBuffer, path, {
+    extractAttachments: true,
+    newlineDelimiter: '\n',
+  });
+  return fullAst.attachments ?? [];
+}
+
 async function loadPreviewWorkContext(
   workVersionId: string,
   ctx: Context,
@@ -563,17 +580,32 @@ export async function fetchDocumentPreviewFigures(
         continue;
       }
 
-      const { parseOfficeFromBuffer } = await import('./parseOfficeFromBuffer.server');
-      const fullAst = await parseOfficeFromBuffer(arrayBuffer, path, {
-        extractAttachments: true,
-        newlineDelimiter: '\n',
-      });
-      const figures = await extractAndStoreFigures(fullAst.attachments ?? [], {
+      const startedAt = Date.now();
+      const usePdfFastPath = isPdfFile(path, file);
+      console.info(
+        'fetchDocumentPreviewFigures: extracting',
+        path,
+        usePdfFastPath ? 'pdf-fast-path' : 'officeparser',
+      );
+
+      const attachments = await extractFigureAttachmentsFromBuffer(path, file, arrayBuffer);
+      const figures = await extractAndStoreFigures(attachments, {
         sourcePath: path,
         md5: md5 as string,
         backend,
         bucket: figureBucket,
       });
+
+      console.info(
+        'fetchDocumentPreviewFigures: done',
+        path,
+        usePdfFastPath ? 'pdf-fast-path' : 'officeparser',
+        {
+          attachmentCount: attachments.length,
+          storedFigureCount: figures.length,
+          durationMs: Date.now() - startedAt,
+        },
+      );
 
       const updated: CachedPreview = {
         ...cached,

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
@@ -31,10 +31,7 @@ import type { OfficeAttachment } from 'officeparser';
 import pLimit from 'p-limit';
 import { isPreviewCandidate } from './previewGuards';
 import { downscaleToWebp, isRenderableFigureMime } from './imagePipeline.server';
-import {
-  documentPreviewCacheId,
-  allPreviewCacheObjectIdsForCleanup,
-} from './previewCache';
+import { documentPreviewCacheId, allPreviewCacheObjectIdsForCleanup } from './previewCache';
 import {
   emptyPreviewAst,
   truncateAstToFirstPage,

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
@@ -33,8 +33,7 @@ import { isPreviewCandidate } from './previewGuards';
 import { downscaleToWebp, isRenderableFigureMime } from './imagePipeline.server';
 import {
   documentPreviewCacheId,
-  legacyPreviewCacheIds,
-  previewCacheObjectIds,
+  allPreviewCacheObjectIdsForCleanup,
 } from './previewCache';
 import {
   emptyPreviewAst,
@@ -803,12 +802,7 @@ export async function deletePreviewArtifactsForVersion(
   try {
     const work = await findWorkByVersion(workVersionId);
     const metadata = work?.metadata as Record<string, unknown> | undefined;
-    const cacheIds = Array.from(
-      new Set([
-        ...previewCacheObjectIds(workVersionId, metadata),
-        ...legacyPreviewCacheIds(metadata),
-      ]),
-    );
+    const cacheIds = allPreviewCacheObjectIdsForCleanup(workVersionId, metadata);
     if (cacheIds.length === 0) return { rows: 0 };
 
     const prisma = await getPrismaClient();

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/fetchPreviews.server.ts
@@ -497,12 +497,32 @@ export async function fetchDocumentPreviewText(
   return { previews: sortedPreviews };
 }
 
+/** Whether phase B should run figure extraction for a cached preview row. */
+export function shouldExtractPreviewFigures(
+  cached: {
+    figuresPending?: boolean;
+    figuresExtractionSkipped?: boolean;
+    previewUnavailable?: boolean;
+    figures?: readonly unknown[];
+  },
+  options: { forceRetry?: boolean } = {},
+): boolean {
+  if (cached.figuresPending === true) return true;
+  if (!options.forceRetry) return false;
+  if (cached.previewUnavailable === true || cached.figuresExtractionSkipped === true) {
+    return false;
+  }
+  return (cached.figures?.length ?? 0) === 0;
+}
+
 /**
  * Phase B: extract and store candidate figures for previews marked figuresPending.
+ * Manual retries pass forceRetry so zero-figure completions can be re-extracted.
  */
 export async function fetchDocumentPreviewFigures(
   workVersionId: string,
   ctx: Context,
+  options: { forceRetry?: boolean } = {},
 ): Promise<FetchPreviewsResult> {
   const previewCtx = await loadPreviewWorkContext(workVersionId, ctx);
   if (!previewCtx) return { previews: [] };
@@ -519,7 +539,7 @@ export async function fetchDocumentPreviewFigures(
     const cached = await readCachedPreview(prisma, cacheId);
     if (!cached) continue;
 
-    if (cached.figuresPending !== true) {
+    if (!shouldExtractPreviewFigures(cached, options)) {
       previews.push(cachedToDocumentPreviewItem(path, file, cached));
       continue;
     }
@@ -638,11 +658,12 @@ export async function handleFetchPreviewsIntent(
 export async function handleFetchPreviewFiguresIntent(
   workVersionId: string | undefined,
   ctx: Context,
+  options: { forceRetry?: boolean } = {},
 ): Promise<{ previews: DocumentPreviewItem[] }> {
   if (!workVersionId) {
     throw new Error('Work version ID is required');
   }
-  const result = await fetchDocumentPreviewFigures(workVersionId, ctx);
+  const result = await fetchDocumentPreviewFigures(workVersionId, ctx, options);
   return { previews: result.previews };
 }
 

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/figuresAutoRetry.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/figuresAutoRetry.spec.ts
@@ -152,9 +152,29 @@ describe('shouldShowFiguresRetry', () => {
     );
   });
 
+  it('shows retry when extraction succeeded with no figures even before a client fetch finished', () => {
+    expect(
+      shouldShowFiguresRetry({
+        figuresFetchFinished: false,
+        isGeneratingFigures: false,
+        figuresExtractionSucceededWithNoFigures: true,
+      }),
+    ).toBe(true);
+  });
+
   it('hides retry while generation is in progress', () => {
     expect(shouldShowFiguresRetry({ figuresFetchFinished: true, isGeneratingFigures: true })).toBe(
       false,
     );
+  });
+
+  it('hides retry while generation is in progress even when extraction reported no figures', () => {
+    expect(
+      shouldShowFiguresRetry({
+        figuresFetchFinished: false,
+        isGeneratingFigures: true,
+        figuresExtractionSucceededWithNoFigures: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/figuresAutoRetry.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/figuresAutoRetry.ts
@@ -63,6 +63,9 @@ export function shouldManualRetryFigures(fetcherState: FiguresFetcherState): boo
 export function shouldShowFiguresRetry(args: {
   figuresFetchFinished: boolean;
   isGeneratingFigures: boolean;
+  /** True when figure extraction finished confidently with zero figures (see resolvePreviewImagePresence). */
+  figuresExtractionSucceededWithNoFigures?: boolean;
 }): boolean {
-  return args.figuresFetchFinished && !args.isGeneratingFigures;
+  if (args.isGeneratingFigures) return false;
+  return args.figuresFetchFinished || args.figuresExtractionSucceededWithNoFigures === true;
 }

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFigureExtraction.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFigureExtraction.server.ts
@@ -109,6 +109,21 @@ export function isPdfFigureWithinMaterializationLimits(width: number, height: nu
   return width * height <= PDF_FIGURE_MAX_PIXELS;
 }
 
+async function waitForPdfObject<T>(
+  objs: {
+    get: (name: string, callback: (value: T) => void) => void;
+  },
+  name: string,
+): Promise<T | undefined> {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve(undefined), PDF_IMAGE_RESOLVE_TIMEOUT_MS);
+    objs.get(name, (value) => {
+      clearTimeout(timeout);
+      resolve(value);
+    });
+  });
+}
+
 async function resolvePdfImageObject(
   page: {
     objs: {
@@ -122,26 +137,16 @@ async function resolvePdfImageObject(
   },
   imgName: string,
 ): Promise<PdfImageObject | undefined> {
-  const targetObjs =
-    page.objs.has(imgName) || !page.commonObjs.has(imgName) ? page.objs : page.commonObjs;
-  return resolvePdfObject<PdfImageObject>(targetObjs, imgName);
-}
-
-async function resolvePdfObject<T>(
-  objs: {
-    has: (name: string) => boolean;
-    get: (name: string, callback: (value: T) => void) => void;
-  },
-  name: string,
-): Promise<T | undefined> {
-  if (!objs.has(name)) return undefined;
-  return new Promise((resolve) => {
-    const timeout = setTimeout(() => resolve(undefined), PDF_IMAGE_RESOLVE_TIMEOUT_MS);
-    objs.get(name, (value) => {
-      clearTimeout(timeout);
-      resolve(value);
-    });
-  });
+  if (page.objs.has(imgName)) {
+    return waitForPdfObject<PdfImageObject>(page.objs, imgName);
+  }
+  if (page.commonObjs.has(imgName)) {
+    return waitForPdfObject<PdfImageObject>(page.commonObjs, imgName);
+  }
+  // Image may still be loading; wait per-name instead of pre-resolving all OPS.dependency entries.
+  const fromObjs = await waitForPdfObject<PdfImageObject>(page.objs, imgName);
+  if (fromObjs) return fromObjs;
+  return waitForPdfObject<PdfImageObject>(page.commonObjs, imgName);
 }
 
 async function extractImagesFromPage(

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFigureExtraction.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFigureExtraction.server.ts
@@ -182,9 +182,9 @@ async function extractImagesFromPage(
     try {
       const imgObj = await resolvePdfImageObject(page, imgName);
       if (!imgObj?.data || imgObj.width <= 0 || imgObj.height <= 0) continue;
+      seenImageNames.add(imgName);
       if (!isPdfFigureWithinMaterializationLimits(imgObj.width, imgObj.height)) continue;
 
-      seenImageNames.add(imgName);
       imageCounter += 1;
       const rgba = convertToRgbaBuffer(imgObj.data, imgObj.width, imgObj.height, imgObj.kind);
       const bmpBuffer = encodeRgbaAsBmp(imgObj.width, imgObj.height, rgba);

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFigureExtraction.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFigureExtraction.server.ts
@@ -1,0 +1,223 @@
+/**
+ * Fast PDF figure extraction for phase-B thumbnail candidates.
+ *
+ * Scans a capped page range with pdfjs directly (no full officeparser pass).
+ * Intended as a first pass — may miss figures on later pages or exotic encodings.
+ */
+
+import type { OfficeAttachment } from 'officeparser';
+import { loadPdfJs } from './pdfJsUtils.server';
+
+/** First-pass page scan limit for PDF figure extraction. */
+export const PDF_FIGURE_MAX_PAGES = 32;
+
+/** Skip tiny raster objects (icons, bullets, decoration). */
+export const PDF_FIGURE_MIN_EDGE_PX = 32;
+
+const PDF_IMAGE_RESOLVE_TIMEOUT_MS = 500;
+
+interface PdfImageObject {
+  data: Uint8Array | Uint8ClampedArray;
+  width: number;
+  height: number;
+  kind: number;
+}
+
+function convertToRgbaBuffer(
+  data: Uint8Array | Uint8ClampedArray,
+  width: number,
+  height: number,
+  kind: number,
+): Buffer {
+  let rgbaData: Uint8ClampedArray;
+  if (kind === 1) {
+    rgbaData = new Uint8ClampedArray(width * height * 4);
+    for (let i = 0; i < width * height; i += 1) {
+      const gray = data[i];
+      rgbaData[i * 4] = gray;
+      rgbaData[i * 4 + 1] = gray;
+      rgbaData[i * 4 + 2] = gray;
+      rgbaData[i * 4 + 3] = 255;
+    }
+  } else if (kind === 2 || data.length === width * height * 3) {
+    rgbaData = new Uint8ClampedArray(width * height * 4);
+    for (let i = 0; i < width * height; i += 1) {
+      rgbaData[i * 4] = data[i * 3];
+      rgbaData[i * 4 + 1] = data[i * 3 + 1];
+      rgbaData[i * 4 + 2] = data[i * 3 + 2];
+      rgbaData[i * 4 + 3] = 255;
+    }
+  } else {
+    rgbaData = data instanceof Uint8ClampedArray ? data : new Uint8ClampedArray(data);
+  }
+  return Buffer.from(rgbaData.buffer, rgbaData.byteOffset, rgbaData.byteLength);
+}
+
+/** Encode RGBA pixels as a 24-bit BMP (flattened on white). */
+export function encodeRgbaAsBmp(width: number, height: number, rgba: Buffer): Buffer {
+  const rowSize = Math.floor((24 * width + 31) / 32) * 4;
+  const padding = rowSize - width * 3;
+  const headerSize = 54;
+  const imageSize = rowSize * height;
+  const fileSize = headerSize + imageSize;
+  const buffer = Buffer.alloc(fileSize);
+
+  buffer.write('BM', 0);
+  buffer.writeUInt32LE(fileSize, 2);
+  buffer.writeUInt32LE(headerSize, 10);
+  buffer.writeUInt32LE(40, 14);
+  buffer.writeInt32LE(width, 18);
+  buffer.writeInt32LE(-height, 22);
+  buffer.writeUInt16LE(1, 26);
+  buffer.writeUInt16LE(24, 28);
+
+  let offset = headerSize;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const i = (y * width + x) * 4;
+      const r = rgba[i];
+      const g = rgba[i + 1];
+      const b = rgba[i + 2];
+      const a = rgba[i + 3];
+      const alpha = a / 255;
+      const outR = Math.round(r * alpha + 255 * (1 - alpha));
+      const outG = Math.round(g * alpha + 255 * (1 - alpha));
+      const outB = Math.round(b * alpha + 255 * (1 - alpha));
+      buffer[offset] = outB;
+      buffer[offset + 1] = outG;
+      buffer[offset + 2] = outR;
+      offset += 3;
+    }
+    offset += padding;
+  }
+  return buffer;
+}
+
+export function isPdfFigureLargeEnough(width: number, height: number): boolean {
+  return width >= PDF_FIGURE_MIN_EDGE_PX && height >= PDF_FIGURE_MIN_EDGE_PX;
+}
+
+async function resolvePdfObject<T>(
+  objs: {
+    has: (name: string) => boolean;
+    get: (name: string, callback: (value: T) => void) => void;
+  },
+  name: string,
+): Promise<T | undefined> {
+  if (!objs.has(name)) return undefined;
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve(undefined), PDF_IMAGE_RESOLVE_TIMEOUT_MS);
+    objs.get(name, (value) => {
+      clearTimeout(timeout);
+      resolve(value);
+    });
+  });
+}
+
+async function extractImagesFromPage(
+  pdfjs: Awaited<ReturnType<typeof loadPdfJs>>,
+  page: {
+    getOperatorList: () => Promise<{ fnArray: number[]; argsArray: unknown[] }>;
+    objs: {
+      has: (name: string) => boolean;
+      get: (name: string, callback: (value: PdfImageObject) => void) => void;
+    };
+    commonObjs: {
+      has: (name: string) => boolean;
+      get: (name: string, callback: (value: PdfImageObject) => void) => void;
+    };
+  },
+  pageNumber: number,
+  imageCounterStart: number,
+): Promise<{ attachments: OfficeAttachment[]; nextCounter: number }> {
+  const attachments: OfficeAttachment[] = [];
+  let imageCounter = imageCounterStart;
+
+  const ops = await page.getOperatorList();
+  const { fnArray, argsArray } = ops;
+
+  for (let j = 0; j < fnArray.length; j += 1) {
+    const fn = fnArray[j];
+    if (fn === pdfjs.OPS.dependency) {
+      const deps = argsArray[j] as string[];
+      for (const dep of deps) {
+        try {
+          if (page.objs.has(dep)) continue;
+          await new Promise<void>((resolve) => {
+            const timeout = setTimeout(() => resolve(), PDF_IMAGE_RESOLVE_TIMEOUT_MS);
+            page.objs.get(dep, () => {
+              clearTimeout(timeout);
+              resolve();
+            });
+          });
+        } catch {
+          // Best-effort dependency resolution.
+        }
+      }
+    }
+
+    if (fn !== pdfjs.OPS.paintImageXObject && fn !== pdfjs.OPS.paintXObject) continue;
+
+    const imgName = (argsArray[j] as [string])[0];
+    try {
+      let targetObjs = page.objs;
+      if (!page.objs.has(imgName) && page.commonObjs.has(imgName)) {
+        targetObjs = page.commonObjs;
+      }
+      const imgObj = await resolvePdfObject<PdfImageObject>(targetObjs, imgName);
+      if (!imgObj?.data || imgObj.width <= 0 || imgObj.height <= 0) continue;
+      if (!isPdfFigureLargeEnough(imgObj.width, imgObj.height)) continue;
+
+      imageCounter += 1;
+      const rgba = convertToRgbaBuffer(imgObj.data, imgObj.width, imgObj.height, imgObj.kind);
+      const bmpBuffer = encodeRgbaAsBmp(imgObj.width, imgObj.height, rgba);
+      const attachmentName = `pdf_image_p${pageNumber}_${imageCounter}.bmp`;
+      attachments.push({
+        type: 'image',
+        name: attachmentName,
+        mimeType: 'image/bmp',
+        data: bmpBuffer.toString('base64'),
+      } as OfficeAttachment);
+    } catch {
+      // Image access failed; continue scanning the page.
+    }
+  }
+
+  return { attachments, nextCounter: imageCounter };
+}
+
+/**
+ * Extract candidate figure attachments from a PDF buffer using pdfjs only.
+ */
+export async function extractPdfFigureAttachments(
+  arrayBuffer: ArrayBuffer,
+  maxFigures: number,
+  maxPages: number = PDF_FIGURE_MAX_PAGES,
+): Promise<OfficeAttachment[]> {
+  const pdfjs = await loadPdfJs();
+  const loadingTask = pdfjs.getDocument({
+    data: new Uint8Array(arrayBuffer),
+    verbosity: 0,
+  });
+  const pdfDocument = await loadingTask.promise;
+  const attachments: OfficeAttachment[] = [];
+  let imageCounter = 0;
+
+  try {
+    const pagesToScan = Math.min(pdfDocument.numPages, maxPages);
+    for (let pageNumber = 1; pageNumber <= pagesToScan; pageNumber += 1) {
+      if (attachments.length >= maxFigures) break;
+      const page = await pdfDocument.getPage(pageNumber);
+      const result = await extractImagesFromPage(pdfjs, page, pageNumber, imageCounter);
+      imageCounter = result.nextCounter;
+      for (const attachment of result.attachments) {
+        attachments.push(attachment);
+        if (attachments.length >= maxFigures) break;
+      }
+    }
+  } finally {
+    await pdfDocument.destroy();
+  }
+
+  return attachments;
+}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFigureExtraction.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFigureExtraction.server.ts
@@ -14,6 +14,11 @@ export const PDF_FIGURE_MAX_PAGES = 32;
 /** Skip tiny raster objects (icons, bullets, decoration). */
 export const PDF_FIGURE_MIN_EDGE_PX = 32;
 
+/** Skip oversized rasters before RGBA/BMP materialization (downscale happens later). */
+export const PDF_FIGURE_MAX_EDGE_PX = 2048;
+
+export const PDF_FIGURE_MAX_PIXELS = PDF_FIGURE_MAX_EDGE_PX * PDF_FIGURE_MAX_EDGE_PX;
+
 const PDF_IMAGE_RESOLVE_TIMEOUT_MS = 500;
 
 interface PdfImageObject {
@@ -97,6 +102,31 @@ export function isPdfFigureLargeEnough(width: number, height: number): boolean {
   return width >= PDF_FIGURE_MIN_EDGE_PX && height >= PDF_FIGURE_MIN_EDGE_PX;
 }
 
+/** Guard against materializing huge page scans into RGBA/BMP before downscale. */
+export function isPdfFigureWithinMaterializationLimits(width: number, height: number): boolean {
+  if (!isPdfFigureLargeEnough(width, height)) return false;
+  if (width > PDF_FIGURE_MAX_EDGE_PX || height > PDF_FIGURE_MAX_EDGE_PX) return false;
+  return width * height <= PDF_FIGURE_MAX_PIXELS;
+}
+
+async function resolvePdfImageObject(
+  page: {
+    objs: {
+      has: (name: string) => boolean;
+      get: (name: string, callback: (value: PdfImageObject) => void) => void;
+    };
+    commonObjs: {
+      has: (name: string) => boolean;
+      get: (name: string, callback: (value: PdfImageObject) => void) => void;
+    };
+  },
+  imgName: string,
+): Promise<PdfImageObject | undefined> {
+  const targetObjs =
+    page.objs.has(imgName) || !page.commonObjs.has(imgName) ? page.objs : page.commonObjs;
+  return resolvePdfObject<PdfImageObject>(targetObjs, imgName);
+}
+
 async function resolvePdfObject<T>(
   objs: {
     has: (name: string) => boolean;
@@ -129,6 +159,7 @@ async function extractImagesFromPage(
   },
   pageNumber: number,
   imageCounterStart: number,
+  seenImageNames: Set<string>,
 ): Promise<{ attachments: OfficeAttachment[]; nextCounter: number }> {
   const attachments: OfficeAttachment[] = [];
   let imageCounter = imageCounterStart;
@@ -138,36 +169,17 @@ async function extractImagesFromPage(
 
   for (let j = 0; j < fnArray.length; j += 1) {
     const fn = fnArray[j];
-    if (fn === pdfjs.OPS.dependency) {
-      const deps = argsArray[j] as string[];
-      for (const dep of deps) {
-        try {
-          if (page.objs.has(dep)) continue;
-          await new Promise<void>((resolve) => {
-            const timeout = setTimeout(() => resolve(), PDF_IMAGE_RESOLVE_TIMEOUT_MS);
-            page.objs.get(dep, () => {
-              clearTimeout(timeout);
-              resolve();
-            });
-          });
-        } catch {
-          // Best-effort dependency resolution.
-        }
-      }
-    }
-
     if (fn !== pdfjs.OPS.paintImageXObject && fn !== pdfjs.OPS.paintXObject) continue;
 
     const imgName = (argsArray[j] as [string])[0];
-    try {
-      let targetObjs = page.objs;
-      if (!page.objs.has(imgName) && page.commonObjs.has(imgName)) {
-        targetObjs = page.commonObjs;
-      }
-      const imgObj = await resolvePdfObject<PdfImageObject>(targetObjs, imgName);
-      if (!imgObj?.data || imgObj.width <= 0 || imgObj.height <= 0) continue;
-      if (!isPdfFigureLargeEnough(imgObj.width, imgObj.height)) continue;
+    if (seenImageNames.has(imgName)) continue;
 
+    try {
+      const imgObj = await resolvePdfImageObject(page, imgName);
+      if (!imgObj?.data || imgObj.width <= 0 || imgObj.height <= 0) continue;
+      if (!isPdfFigureWithinMaterializationLimits(imgObj.width, imgObj.height)) continue;
+
+      seenImageNames.add(imgName);
       imageCounter += 1;
       const rgba = convertToRgbaBuffer(imgObj.data, imgObj.width, imgObj.height, imgObj.kind);
       const bmpBuffer = encodeRgbaAsBmp(imgObj.width, imgObj.height, rgba);
@@ -201,6 +213,7 @@ export async function extractPdfFigureAttachments(
   });
   const pdfDocument = await loadingTask.promise;
   const attachments: OfficeAttachment[] = [];
+  const seenImageNames = new Set<string>();
   let imageCounter = 0;
 
   try {
@@ -208,7 +221,13 @@ export async function extractPdfFigureAttachments(
     for (let pageNumber = 1; pageNumber <= pagesToScan; pageNumber += 1) {
       if (attachments.length >= maxFigures) break;
       const page = await pdfDocument.getPage(pageNumber);
-      const result = await extractImagesFromPage(pdfjs, page, pageNumber, imageCounter);
+      const result = await extractImagesFromPage(
+        pdfjs,
+        page,
+        pageNumber,
+        imageCounter,
+        seenImageNames,
+      );
       imageCounter = result.nextCounter;
       for (const attachment of result.attachments) {
         attachments.push(attachment);

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFigureExtraction.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFigureExtraction.server.ts
@@ -1,15 +1,15 @@
 /**
  * Fast PDF figure extraction for phase-B thumbnail candidates.
  *
- * Scans a capped page range with pdfjs directly (no full officeparser pass).
- * Intended as a first pass — may miss figures on later pages or exotic encodings.
+ * Scans up to {@link PDF_FIGURE_MAX_PAGES} pages with pdfjs (no full officeparser pass).
+ * Extraction stops at `maxFigures`; may miss exotic encodings (Form XObjects, etc.).
  */
 
 import type { OfficeAttachment } from 'officeparser';
 import { loadPdfJs } from './pdfJsUtils.server';
 
-/** First-pass page scan limit for PDF figure extraction. */
-export const PDF_FIGURE_MAX_PAGES = 32;
+/** Page scan limit for PDF figure extraction (pdfjs fast path). */
+export const PDF_FIGURE_MAX_PAGES = 99;
 
 /** Skip tiny raster objects (icons, bullets, decoration). */
 export const PDF_FIGURE_MIN_EDGE_PX = 32;

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFirstPagePreview.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfFirstPagePreview.server.ts
@@ -3,13 +3,13 @@
  * Avoids a full-document officeparser pass for phase-A text preview.
  */
 
-import { createRequire } from 'node:module';
 import type { OfficeContentNode } from 'officeparser';
 import {
   astContentToPlainText,
   shouldIncludeSecondPage,
   type PreviewAstData,
 } from './previewAstUtils.server';
+import { loadPdfJs } from './pdfJsUtils.server';
 
 /** Minimum extractable text before falling back to officeparser for scanned/image PDFs. */
 export const PDF_FAST_PATH_MIN_TEXT_LENGTH = 50;
@@ -24,17 +24,6 @@ function pageFromText(text: string, pageNumber: number): OfficeContentNode {
     children: text ? [paragraphFromText(text)] : [],
     metadata: { pageNumber },
   } as OfficeContentNode;
-}
-
-async function loadPdfJs() {
-  const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
-  try {
-    const require = createRequire(import.meta.url);
-    pdfjs.GlobalWorkerOptions.workerSrc = require.resolve('pdfjs-dist/legacy/build/pdf.worker.mjs');
-  } catch {
-    // Worker auto-resolution is best-effort; pdfjs may still load in some environments.
-  }
-  return pdfjs;
 }
 
 async function extractPageText(

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfJsUtils.server.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/pdfJsUtils.server.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared pdfjs-dist loader for upload preview helpers (text + figure extraction).
+ */
+
+import { createRequire } from 'node:module';
+
+export async function loadPdfJs() {
+  const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  try {
+    const require = createRequire(import.meta.url);
+    pdfjs.GlobalWorkerOptions.workerSrc = require.resolve('pdfjs-dist/legacy/build/pdf.worker.mjs');
+  } catch {
+    // Worker auto-resolution is best-effort; pdfjs may still load in some environments.
+  }
+  return pdfjs;
+}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewCache.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewCache.ts
@@ -9,6 +9,7 @@ export {
   LEGACY_PREVIEW_CACHE_PREFIXES,
   LEGACY_VERSION_SCOPED_PREVIEW_CACHE_PREFIXES,
   documentPreviewCacheId,
+  documentPreviewCacheSourceLookupIds,
   legacyPreviewCacheIds,
   legacyVersionScopedPreviewCacheIds,
   allPreviewCacheObjectIdsForCleanup,

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewCache.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewCache.ts
@@ -7,8 +7,11 @@
 export {
   DOCUMENT_PREVIEW_CACHE_PREFIX,
   LEGACY_PREVIEW_CACHE_PREFIXES,
+  LEGACY_VERSION_SCOPED_PREVIEW_CACHE_PREFIXES,
   documentPreviewCacheId,
   legacyPreviewCacheIds,
+  legacyVersionScopedPreviewCacheIds,
+  allPreviewCacheObjectIdsForCleanup,
   previewCacheObjectIds,
   previewCandidateMd5s,
 } from '@curvenote/scms-core';

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewFigureMessages.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewFigureMessages.spec.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import {
   encodeRgbaAsBmp,
   isPdfFigureLargeEnough,
+  isPdfFigureWithinMaterializationLimits,
+  PDF_FIGURE_MAX_EDGE_PX,
   PDF_FIGURE_MIN_EDGE_PX,
 } from './pdfFigureExtraction.server';
 import { figuresBusyMessageForPreviews, isPdfManuscriptPreview } from './previewFigureMessages';
@@ -16,6 +18,21 @@ describe('isPdfFigureLargeEnough', () => {
   it('rejects tiny decorative images', () => {
     expect(isPdfFigureLargeEnough(PDF_FIGURE_MIN_EDGE_PX - 1, 64)).toBe(false);
     expect(isPdfFigureLargeEnough(64, PDF_FIGURE_MIN_EDGE_PX - 1)).toBe(false);
+  });
+});
+
+describe('isPdfFigureWithinMaterializationLimits', () => {
+  it('accepts typical figure dimensions', () => {
+    expect(isPdfFigureWithinMaterializationLimits(400, 300)).toBe(true);
+    expect(isPdfFigureWithinMaterializationLimits(PDF_FIGURE_MAX_EDGE_PX, 100)).toBe(true);
+  });
+
+  it('rejects oversized rasters before materialization', () => {
+    expect(isPdfFigureWithinMaterializationLimits(PDF_FIGURE_MAX_EDGE_PX + 1, 100)).toBe(false);
+    expect(isPdfFigureWithinMaterializationLimits(100, PDF_FIGURE_MAX_EDGE_PX + 1)).toBe(false);
+    expect(
+      isPdfFigureWithinMaterializationLimits(PDF_FIGURE_MAX_EDGE_PX, PDF_FIGURE_MAX_EDGE_PX + 1),
+    ).toBe(false);
   });
 });
 

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewFigureMessages.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewFigureMessages.spec.ts
@@ -57,7 +57,7 @@ describe('figuresBusyMessageForPreviews', () => {
         true,
       ),
     ).toBe(
-      'Extracting thumbnails from PDF can take longer. This is a preview and if not all images are shown this does not mean they are missing from your document.',
+      "PDF thumbnails can take longer. Missing images in this preview doesn't mean they're missing from your document.",
     );
   });
 

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewFigureMessages.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewFigureMessages.spec.ts
@@ -1,0 +1,69 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import {
+  encodeRgbaAsBmp,
+  isPdfFigureLargeEnough,
+  PDF_FIGURE_MIN_EDGE_PX,
+} from './pdfFigureExtraction.server';
+import { figuresBusyMessageForPreviews, isPdfManuscriptPreview } from './previewFigureMessages';
+
+describe('isPdfFigureLargeEnough', () => {
+  it('accepts images at or above the minimum edge', () => {
+    expect(isPdfFigureLargeEnough(PDF_FIGURE_MIN_EDGE_PX, PDF_FIGURE_MIN_EDGE_PX)).toBe(true);
+    expect(isPdfFigureLargeEnough(200, 100)).toBe(true);
+  });
+
+  it('rejects tiny decorative images', () => {
+    expect(isPdfFigureLargeEnough(PDF_FIGURE_MIN_EDGE_PX - 1, 64)).toBe(false);
+    expect(isPdfFigureLargeEnough(64, PDF_FIGURE_MIN_EDGE_PX - 1)).toBe(false);
+  });
+});
+
+describe('encodeRgbaAsBmp', () => {
+  it('produces a BMP buffer with the expected signature', () => {
+    const rgba = Buffer.alloc(4 * 4, 0);
+    rgba[0] = 255;
+    rgba[1] = 0;
+    rgba[2] = 0;
+    rgba[3] = 255;
+    const bmp = encodeRgbaAsBmp(1, 1, rgba);
+    expect(bmp.subarray(0, 2).toString('ascii')).toBe('BM');
+    expect(bmp.length).toBeGreaterThan(54);
+  });
+});
+
+describe('figuresBusyMessageForPreviews', () => {
+  it('uses the PDF-specific message while figures are loading', () => {
+    expect(
+      figuresBusyMessageForPreviews(
+        [{ path: 'manuscript/paper.pdf', data: { type: 'application/pdf', name: 'paper.pdf' } }],
+        true,
+      ),
+    ).toBe('PDF extraction is slow and may not return all figures in this preview.');
+  });
+
+  it('keeps the default message for non-PDF previews', () => {
+    expect(
+      figuresBusyMessageForPreviews(
+        [
+          {
+            path: 'manuscript/paper.docx',
+            data: {
+              type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+              name: 'paper.docx',
+            },
+          },
+        ],
+        true,
+      ),
+    ).toBe('Generating thumbnail options…');
+  });
+});
+
+describe('isPdfManuscriptPreview', () => {
+  it('detects PDF by extension or MIME type', () => {
+    expect(isPdfManuscriptPreview({ path: 'uploads/paper.pdf' })).toBe(true);
+    expect(isPdfManuscriptPreview({ type: 'application/pdf', name: 'paper' })).toBe(true);
+    expect(isPdfManuscriptPreview({ path: 'uploads/paper.docx' })).toBe(false);
+  });
+});

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewFigureMessages.spec.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewFigureMessages.spec.ts
@@ -56,7 +56,9 @@ describe('figuresBusyMessageForPreviews', () => {
         [{ path: 'manuscript/paper.pdf', data: { type: 'application/pdf', name: 'paper.pdf' } }],
         true,
       ),
-    ).toBe('PDF extraction is slow and may not return all figures in this preview.');
+    ).toBe(
+      'Extracting thumbnails from PDF can take longer. This is a preview and if not all images are shown this does not mean they are missing from your document.',
+    );
   });
 
   it('keeps the default message for non-PDF previews', () => {

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewFigureMessages.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewFigureMessages.ts
@@ -1,0 +1,24 @@
+/** Client-safe helpers for upload preview figure UX. */
+
+export function isPdfManuscriptPreview(file: {
+  path?: string;
+  name?: string;
+  type?: string;
+}): boolean {
+  const pathOrName = file.path ?? file.name ?? '';
+  if (pathOrName.toLowerCase().endsWith('.pdf')) return true;
+  return (file.type ?? '').toLowerCase() === 'application/pdf';
+}
+
+export function figuresBusyMessageForPreviews(
+  previews: ReadonlyArray<{ path: string; data: { path?: string; name?: string; type?: string } }>,
+  isFiguresLoading: boolean,
+): string {
+  if (
+    isFiguresLoading &&
+    previews.some((preview) => isPdfManuscriptPreview({ ...preview.data, path: preview.path }))
+  ) {
+    return 'PDF extraction is slow and may not return all figures in this preview.';
+  }
+  return 'Generating thumbnail options…';
+}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewFigureMessages.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewFigureMessages.ts
@@ -18,7 +18,7 @@ export function figuresBusyMessageForPreviews(
     isFiguresLoading &&
     previews.some((preview) => isPdfManuscriptPreview({ ...preview.data, path: preview.path }))
   ) {
-    return 'Extracting thumbnails from PDF can take longer. This is a preview and if not all images are shown this does not mean they are missing from your document.';
+    return "PDF thumbnails can take longer. Missing images in this preview doesn't mean they're missing from your document.";
   }
   return 'Generating thumbnail options…';
 }

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewFigureMessages.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewFigureMessages.ts
@@ -18,7 +18,7 @@ export function figuresBusyMessageForPreviews(
     isFiguresLoading &&
     previews.some((preview) => isPdfManuscriptPreview({ ...preview.data, path: preview.path }))
   ) {
-    return 'PDF extraction is slow and may not return all figures in this preview.';
+    return 'Extracting thumbnails from PDF can take longer. This is a preview and if not all images are shown this does not mean they are missing from your document.';
   }
   return 'Generating thumbnail options…';
 }

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewImagePresence.ts
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/metadata-extract/previewImagePresence.ts
@@ -1,0 +1,35 @@
+import type { UploadFactPresence } from '@curvenote/scms-core';
+
+/** Minimal preview fields needed to infer image presence for upload analysis. */
+export type PreviewImagePresenceInput = {
+  path: string;
+  figures: readonly unknown[];
+  previewUnavailable?: boolean;
+  figuresExtractionSkipped?: boolean;
+  figuresPending?: boolean;
+};
+
+export function resolvePreviewImagePresence(
+  previewCandidatePaths: string[],
+  previews: PreviewImagePresenceInput[],
+): UploadFactPresence {
+  if (previewCandidatePaths.length === 0) return 'unknown';
+  const previewPaths = new Set(previews.map((preview) => preview.path));
+  const hasMissingPreview = previewCandidatePaths.some((path) => !previewPaths.has(path));
+  if (hasMissingPreview || previews.some((preview) => preview.previewUnavailable === true)) {
+    return 'unknown';
+  }
+  if (previews.some((preview) => preview.figuresPending === true)) {
+    return 'unknown';
+  }
+  if (previews.some((preview) => preview.figures.length > 0)) {
+    return 'present';
+  }
+  if (previews.some((preview) => preview.figuresExtractionSkipped === true)) {
+    return 'unknown';
+  }
+  const allConfidentlyAbsent = previews.every(
+    (preview) => preview.figuresExtractionSkipped === false && preview.figures.length === 0,
+  );
+  return allConfidentlyAbsent && previews.length > 0 ? 'absent' : 'unknown';
+}

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
@@ -83,12 +83,12 @@ import {
   deletePreviewArtifactsForVersion,
   persistThumbnailListingForVersion,
   signPreviewFigures,
-  resolvePreviewImagePresence,
 } from './metadata-extract/fetchPreviews.server';
 import {
   readDocumentPreviewsFromObjectTable,
   type DocumentPreviewItem,
 } from './metadata-extract/fetchPreviews.server';
+import { resolvePreviewImagePresence } from './metadata-extract/previewImagePresence';
 import { extractMetadataFromPreviews } from './metadata-extract/anthropic.server';
 import type { ExtractedMetadata } from './metadata-extract/anthropic.server';
 import { Upload, CheckSquare } from 'lucide-react';

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
@@ -902,7 +902,9 @@ export async function action(args: Route.ActionArgs) {
           );
         }
         try {
-          const { previews } = await handleFetchPreviewFiguresIntent(workVersionId, baseCtx);
+          const { previews } = await handleFetchPreviewFiguresIntent(workVersionId, baseCtx, {
+            forceRetry: force === 'true',
+          });
           return data({ ok: true, previewFiguresGenerated: previews.length });
         } catch (err) {
           const message =
@@ -1390,7 +1392,10 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
     if (!shouldManualRetryFigures(fetchPreviewFiguresFetcher.state)) return;
     setHasSkippedFigures(false);
     setFiguresFetchFinished(false);
-    fetchPreviewFiguresFetcher.submit({ intent: 'fetch-preview-figures' }, { method: 'POST' });
+    fetchPreviewFiguresFetcher.submit(
+      { intent: 'fetch-preview-figures', force: 'true' },
+      { method: 'POST' },
+    );
   }, [fetchPreviewFiguresFetcher]);
 
   const handleSkipFigures = useCallback(() => {

--- a/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
+++ b/platform/scms/app/routes/app/works.$workId.upload.$workVersionId/route.tsx
@@ -83,6 +83,7 @@ import {
   deletePreviewArtifactsForVersion,
   persistThumbnailListingForVersion,
   signPreviewFigures,
+  resolvePreviewImagePresence,
 } from './metadata-extract/fetchPreviews.server';
 import {
   readDocumentPreviewsFromObjectTable,
@@ -1422,6 +1423,9 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
     () => resolveThumbnailSelection(thumbnailLocators, selectedThumbnail),
     [thumbnailLocators, selectedThumbnail],
   );
+  const figuresExtractionSucceededWithNoFigures =
+    previewFilePaths.length > 0 &&
+    resolvePreviewImagePresence(previewFilePaths, previewList) === 'absent';
 
   useEffect(() => {
     setAuthorMetadata(authorFieldMetadata);
@@ -1486,6 +1490,7 @@ export default function WorksUpload({ loaderData }: Route.ComponentProps) {
               showFiguresRetry={shouldShowFiguresRetry({
                 figuresFetchFinished,
                 isGeneratingFigures,
+                figuresExtractionSucceededWithNoFigures,
               })}
               onRetryFigures={handleRetryFigures}
               onSkipFigures={handleSkipFigures}

--- a/platform/scms/app/routes/app/works._index/db.server.ts
+++ b/platform/scms/app/routes/app/works._index/db.server.ts
@@ -7,7 +7,7 @@ import {
 } from '@curvenote/scms-server';
 import type { WorkRole, WorkVersion } from '@curvenote/scms-db';
 import type { SecureContext } from '@curvenote/scms-server';
-import { previewCacheObjectIds } from '../works.$workId.upload.$workVersionId/metadata-extract/previewCache';
+import { allPreviewCacheObjectIdsForCleanup } from '../works.$workId.upload.$workVersionId/metadata-extract/previewCache';
 import { dbGetCheckServiceRunsByWorkVersionIds } from '../works.$workId/db.server';
 import {
   getCheckRunSummaryByKind,
@@ -294,7 +294,11 @@ export async function dangerouslyDeleteDraftWork(
   // belonging to another work/version (e.g. a byte-identical file in someone else's
   // still-open upload screen).
   const previewCacheIds = Array.from(
-    new Set(workVersions.flatMap((version) => previewCacheObjectIds(version.id, version.metadata))),
+    new Set(
+      workVersions.flatMap((version) =>
+        allPreviewCacheObjectIdsForCleanup(version.id, version.metadata),
+      ),
+    ),
   );
 
   // Delete in the correct order to handle foreign key constraints


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Object-table cache identity and cleanup across upload/clone/delete paths; PDF fast-path may miss some figure encodings compared to officeparser.
> 
> **Overview**
> **PDF upload phase B** now uses a dedicated **pdfjs** image scan instead of a full **officeparser** pass for thumbnails, with a **99-page** cap and the existing **24-figure** limit. The scanner skips tiny/oversized rasters before BMP materialization, dedupes repeated XObject paints, and shares **`loadPdfJs`** with the first-page text fast path.
> 
> **Preview cache Object ids** are renamed from `docx:preview:v3:` to **`upload:preview:`** for PDF and DOCX. Cleanup paths delete current plus legacy (`v3`, `v2`, md5-only) rows on draft delete, preview artifact removal, and confirm-work flows; **draft clone** seeds the new id from the source when only legacy rows exist.
> 
> **Upload UX:** the **All Figures** preview tab is removed; **`resolvePreviewImagePresence`** lives in a client-safe module. Thumbnail gallery shows a **PDF-specific** busy message, surfaces **re-try** when phase B confidently finds zero figures, and manual re-try sends **`force: true`** so completed zero-figure extractions can run again via **`shouldExtractPreviewFigures`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c31f00824161e10e1b3e2f3079d29b2303531179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->