### PR TITLE
🧑‍🔧 pubsub helper export

### DIFF
--- a/.changeset/export-send-job-pubsub.md
+++ b/.changeset/export-send-job-pubsub.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-server': patch
+---
+
+Export `sendJobPubSubMessage` (and related Pub/Sub types) from the jobs public API so extension packages can dispatch Cloud Run workers without embedding publish logic in core.

--- a/packages/scms-server/src/backend/jobs/index.ts
+++ b/packages/scms-server/src/backend/jobs/index.ts
@@ -14,3 +14,10 @@ export * from './run/runHandler.server.js';
 export * from './run/onJobTerminal.server.js';
 export * from './run/handleTransportFailure.server.js';
 export * from './workerJobUrl.server.js';
+export {
+  sendJobPubSubMessage,
+  withJobIdInAttributes,
+  type PubSubTarget,
+  type PubSubMessageArgs,
+  type DevLocalPush,
+} from './pubsub.server.js';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Barrel re-export only; no changes to publish behavior or job dispatch logic.
> 
> **Overview**
> **`@curvenote/scms-server`** now exposes the job Pub/Sub publish helper and its types from the jobs barrel (`backend/jobs/index.ts`) instead of keeping them internal to `pubsub.server.ts`.
> 
> Consumers can import **`sendJobPubSubMessage`**, **`withJobIdInAttributes`**, and types **`PubSubTarget`**, **`PubSubMessageArgs`**, and **`DevLocalPush`** from the jobs public API so extension packages can trigger Cloud Run workers without duplicating publish logic in core. A patch **changeset** documents the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d25d058f6665d3a2ff066155c4b88c1628e61d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->