### PR TITLE
🔧🚛 no token checks on `start` or `build`

### DIFF
--- a/.changeset/anonymous-start-build.md
+++ b/.changeset/anonymous-start-build.md
@@ -1,0 +1,5 @@
+---
+'curvenote': patch
+---
+
+Run `curvenote start` and `curvenote build` without token refresh so local preview and builds work offline and do not fail when a saved token cannot reach the API

--- a/packages/curvenote/src/web.ts
+++ b/packages/curvenote/src/web.ts
@@ -22,9 +22,9 @@ function makeCurvenoteStartCLI(program: Command) {
   const command = makeStartCommand().action(
     clirun(web.curvenoteStart, {
       program,
+      anonymous: true,
       requireSiteConfig: true,
       keepAlive: true,
-      hideNoTokenWarning: true,
     }),
   );
   return command;
@@ -34,6 +34,7 @@ function makeBuildCLI(program: Command) {
   const command = makeBuildCommand().action(
     clirun(web.curvenoteBuild, {
       program,
+      anonymous: true,
       requireSiteConfig: true,
       keepAlive: (_, opts) => !!opts.watch,
     }),


### PR DESCRIPTION
`curvenote start/build` should not need a token check or token refresh, marked these as anonymous sessions which speeds up usage and enables offline use

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CLI session wiring for local commands only; deploy and other authenticated flows are untouched.
> 
> **Overview**
> **`curvenote start`** and **`curvenote build`** now use anonymous CLI sessions (`anonymous: true` in `clirun`) instead of loading a saved token through **`getSession`**. That skips token refresh and API auth for local preview and static builds, so those commands work offline and no longer fail when a stored token cannot reach the API.
> 
> For **`start`**, the previous **`hideNoTokenWarning`** workaround is removed because anonymous mode never enters the authenticated session path. **`deploy`** is unchanged and still uses a normal session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6ea6842448ce544e29046ba4565dc40960c4428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->