### PR TITLE
🔒 Sync task-converter package-lock.json with package.json

### DIFF
--- a/services/task-converter/package-lock.json
+++ b/services/task-converter/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@curvenote/task-converter-cloudrun",
       "version": "0.1.0",
       "dependencies": {
-        "express": "^4.18.1"
+        "express": "^4.22.2"
       }
     },
     "node_modules/accepts": {
@@ -31,9 +31,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -44,7 +44,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -231,14 +231,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -257,7 +257,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -383,9 +383,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -578,12 +578,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -694,14 +695,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -713,13 +714,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
## Problem

`docker build` of `services/task-converter` fails at `Dockerfile:33`:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and package-lock.json ... are in sync.
npm error Invalid: lock file's express@4.22.1 does not satisfy express@4.22.2
npm error Invalid: lock file's body-parser@1.20.4 does not satisfy body-parser@1.20.6
npm error Invalid: lock file's qs@6.14.1 does not satisfy qs@6.15.3
npm error Invalid: lock file's side-channel@1.1.0 does not satisfy side-channel@1.1.1
npm error Invalid: lock file's side-channel-list@1.0.0 does not satisfy side-channel-list@1.0.1
npm error Invalid: lock file's es-object-atoms@1.1.1 does not satisfy es-object-atoms@1.1.2
npm error Invalid: lock file's hasown@2.0.2 does not satisfy hasown@2.0.4
```

## Cause

`services/task-converter/package.json` declares `express: ^4.22.2`. The lockfile root
`packages[""]` entry still declared `express: ^4.18.1` and resolved `express@4.22.1`.

The dependency bump in 1d7cddc5 (`🛡️coordinated dependency upgrade`) changed `package.json`
but did not regenerate this lockfile.

`npm ci` aborts when the two files disagree. It never updates the lockfile. Host-side
scripts in this repo use Bun, so nothing exercised this `package-lock.json` until
`docker build`. That is why the drift stayed hidden.

## Fix

Regenerated the lockfile with `npm install --package-lock-only`, the procedure documented
in `services/task-converter/README.md`. `package.json` is unchanged — the lockfile was the
stale side.

Updated versions:

| package | before | after |
| --- | --- | --- |
| `express` (root dep range) | `^4.18.1` | `^4.22.2` |
| `express` | 4.22.1 | 4.22.2 |
| `body-parser` | 1.20.4 | 1.20.6 |
| `qs` | 6.14.1 | 6.15.3 |
| `side-channel` | 1.1.0 | 1.1.1 |
| `side-channel-list` | 1.0.0 | 1.0.1 |
| `es-object-atoms` | 1.1.1 | 1.1.2 |
| `hasown` | 2.0.2 | 2.0.4 |

## Impact

This blocks first-time local setup. The path is:

```
bun run dx:rebuild -> bun run db:rebuild -> scripts/ensure-task-converter-image.sh
  -> bun run build:local -> docker build -t task-converter-local .
```

It also blocks `bun run build` in `services/task-converter`, which sends the same
Dockerfile to GCP Cloud Build.

## Verification

- `npm ci --dry-run` exits 0. Before this change it exited with `EUSAGE`.
- `docker build -t task-converter-local .` completes. The `RUN npm ci` layer built fresh,
  not from cache: `added 68 packages, and audited 69 packages in 746ms`.

## Out of scope

`npm audit` reports one high-severity advisory: `path-to-regexp@0.1.12`
(GHSA-37ch-88jc-xwx2). It is pre-existing and unchanged by this PR. `express@4.22.2` pins
`~0.1.12`, so a separate `npm audit fix` can move it to 0.1.13.

https://claude.ai/code/session_01DDsPZ77SJqf8yehsipACV6
