### PR TITLE
✨ Refresh site-admin submission details page

### DIFF
--- a/.changeset/refresh-submission-details-page.md
+++ b/.changeset/refresh-submission-details-page.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-core': patch
+'@curvenote/scms-sites-ext': patch
+---
+
+Refresh the site-admin submission details page with a summary card and dialog-based editors for collection, kind, and slugs

--- a/ee/sites/src/publicationDateCalendar.spec.ts
+++ b/ee/sites/src/publicationDateCalendar.spec.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import { formatPublicationDate } from './publicationDateCalendar.js';
+
+describe('formatPublicationDate', () => {
+  it('formats an ISO date as day month year', () => {
+    expect(formatPublicationDate('2024-08-27')).toBe('27 August 2024');
+  });
+});

--- a/ee/sites/src/publicationDateCalendar.ts
+++ b/ee/sites/src/publicationDateCalendar.ts
@@ -1,5 +1,14 @@
+import { formatDate } from '@curvenote/scms-core';
+
 /** Earliest publication year offered in publication-date calendar dropdowns. */
 export const PUBLICATION_DATE_CALENDAR_FROM_YEAR = 1990;
+
+const PUBLICATION_DATE_DISPLAY_FORMAT = 'd MMMM yyyy';
+
+/** Formats a publication date for the summary card and listing. */
+export function formatPublicationDate(date: string): string {
+  return formatDate(date, PUBLICATION_DATE_DISPLAY_FORMAT);
+}
 
 /** Local calendar midnight — avoids timezone/`toISOString` day shifts in matchers. */
 function startOfLocalDay(date: Date): Date {

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/AttributeChangeDialog.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/AttributeChangeDialog.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { ui } from '@curvenote/scms-core';
+import type { AttributeChangeOption } from './AttributeChangeDialog.utils.js';
+
+type AttributeChangeDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  calloutType: 'warning' | 'info';
+  calloutMessage: string;
+  options: AttributeChangeOption[];
+  currentId: string;
+  confirmLabel: string;
+  isSubmitting: boolean;
+  error?: string;
+  onConfirm: (selectedId: string, label: string) => void;
+};
+
+type AttributeChangeDialogBodyProps = Omit<AttributeChangeDialogProps, 'open' | 'onOpenChange'>;
+
+function AttributeChangeDialogBody({
+  title,
+  calloutType,
+  calloutMessage,
+  options,
+  currentId,
+  confirmLabel,
+  isSubmitting,
+  error,
+  onConfirm,
+}: AttributeChangeDialogBodyProps) {
+  const [selectedId, setSelectedId] = useState(currentId);
+  const hasChange = selectedId !== currentId;
+  const submittingLabel = confirmLabel.replace(/^Change /, 'Changing ');
+
+  const handleConfirm = () => {
+    const selectedOption = options.find((option) => option.id === selectedId);
+    if (!hasChange || !selectedOption) {
+      return;
+    }
+    onConfirm(selectedId, selectedOption.label);
+  };
+
+  return (
+    <>
+      <ui.DialogHeader>
+        <ui.DialogTitle>{title}</ui.DialogTitle>
+        {calloutType === 'info' && <ui.DialogDescription>{calloutMessage}</ui.DialogDescription>}
+      </ui.DialogHeader>
+      <div className="space-y-4">
+        {calloutType === 'warning' && (
+          <ui.SimpleAlert type="warning" message={calloutMessage} size="compact" />
+        )}
+        {error ? <ui.SimpleAlert type="error" message={error} size="compact" /> : null}
+        <ui.RadioGroup
+          value={selectedId}
+          onValueChange={setSelectedId}
+          className="grid gap-2"
+          disabled={isSubmitting}
+        >
+          {options.map((option) => {
+            const optionId = `attribute-change-${option.id}`;
+            return (
+              <div key={option.id} className="flex items-start gap-2">
+                <ui.RadioGroupItem
+                  value={option.id}
+                  id={optionId}
+                  className="mt-0.5"
+                  disabled={isSubmitting}
+                />
+                <label htmlFor={optionId} className="min-w-0 cursor-pointer text-sm leading-snug">
+                  {option.label}
+                </label>
+              </div>
+            );
+          })}
+        </ui.RadioGroup>
+      </div>
+      <ui.DialogFooter>
+        <ui.DialogClose asChild>
+          <ui.Button variant="outline" disabled={isSubmitting}>
+            Cancel
+          </ui.Button>
+        </ui.DialogClose>
+        <ui.Button onClick={handleConfirm} disabled={!hasChange || isSubmitting}>
+          {isSubmitting ? submittingLabel : confirmLabel}
+        </ui.Button>
+      </ui.DialogFooter>
+    </>
+  );
+}
+
+export function AttributeChangeDialog({
+  open,
+  onOpenChange,
+  ...bodyProps
+}: AttributeChangeDialogProps) {
+  return (
+    <ui.Dialog open={open} onOpenChange={onOpenChange}>
+      <ui.DialogContent>{open && <AttributeChangeDialogBody {...bodyProps} />}</ui.DialogContent>
+    </ui.Dialog>
+  );
+}

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/AttributeChangeDialog.utils.spec.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/AttributeChangeDialog.utils.spec.ts
@@ -16,8 +16,22 @@ describe('buildAttributeChangeOptions', () => {
         { id: '2', name: 'articles' },
       ]),
     ).toEqual([
-      { id: '1', label: 'Blog Posts' },
       { id: '2', label: 'articles' },
+      { id: '1', label: 'Blog Posts' },
+    ]);
+  });
+
+  it('sorts options alphabetically by displayed label', () => {
+    expect(
+      buildAttributeChangeOptions([
+        { id: '1', name: 'blog' },
+        { id: '2', name: 'papers', content: { title: 'Articles' } },
+        { id: '3', name: 'notes', content: { title: 'zeta' } },
+      ]),
+    ).toEqual([
+      { id: '2', label: 'Articles' },
+      { id: '1', label: 'blog' },
+      { id: '3', label: 'zeta' },
     ]);
   });
 });

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/AttributeChangeDialog.utils.spec.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/AttributeChangeDialog.utils.spec.ts
@@ -1,0 +1,75 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import {
+  buildAttributeChangeOptions,
+  getFetcherIdleDialogAction,
+  getOptimisticNameOrTitle,
+  resolveCollectionChangeOutcome,
+  resolveKindChangeOutcome,
+} from './AttributeChangeDialog.utils.js';
+
+describe('buildAttributeChangeOptions', () => {
+  it('uses title when present, otherwise name', () => {
+    expect(
+      buildAttributeChangeOptions([
+        { id: '1', name: 'blog-posts', content: { title: 'Blog Posts' } },
+        { id: '2', name: 'articles' },
+      ]),
+    ).toEqual([
+      { id: '1', label: 'Blog Posts' },
+      { id: '2', label: 'articles' },
+    ]);
+  });
+});
+
+describe('getOptimisticNameOrTitle', () => {
+  it('prefers formData name_or_title over fallbacks', () => {
+    const formData = new FormData();
+    formData.set('name_or_title', 'From form');
+
+    expect(getOptimisticNameOrTitle(formData, 'Fallback', 'Other')).toBe('From form');
+    expect(getOptimisticNameOrTitle(undefined, 'Fallback', 'Other')).toBe('Fallback');
+    expect(getOptimisticNameOrTitle(undefined, undefined, 'Other')).toBe('Other');
+    expect(getOptimisticNameOrTitle(undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveCollectionChangeOutcome', () => {
+  it('maps fetcher data to outcomes', () => {
+    expect(resolveCollectionChangeOutcome(undefined)).toBe('pending');
+    expect(resolveCollectionChangeOutcome({ error: 'bad' })).toBe('error');
+    expect(resolveCollectionChangeOutcome({ collection: { id: 'c1' } })).toBe('success');
+    expect(resolveCollectionChangeOutcome({})).toBe('pending');
+  });
+});
+
+describe('resolveKindChangeOutcome', () => {
+  it('maps fetcher data to outcomes', () => {
+    expect(resolveKindChangeOutcome(undefined)).toBe('pending');
+    expect(resolveKindChangeOutcome({ error: 'bad' })).toBe('error');
+    expect(resolveKindChangeOutcome({ kindId: 'k1' })).toBe('success');
+    expect(resolveKindChangeOutcome({})).toBe('pending');
+  });
+});
+
+describe('getFetcherIdleDialogAction', () => {
+  it('closes the dialog on success after a submit completes', () => {
+    expect(getFetcherIdleDialogAction(true, 'submitting', 'idle', 'success')).toEqual({
+      closeDialog: true,
+      clearAwaiting: true,
+    });
+  });
+
+  it('keeps the dialog open on error after a submit completes', () => {
+    expect(getFetcherIdleDialogAction(true, 'loading', 'idle', 'error')).toEqual({
+      closeDialog: false,
+      clearAwaiting: true,
+    });
+  });
+
+  it('does nothing when not awaiting or fetcher did not return to idle', () => {
+    expect(getFetcherIdleDialogAction(false, 'submitting', 'idle', 'success')).toBeNull();
+    expect(getFetcherIdleDialogAction(true, 'idle', 'submitting', 'pending')).toBeNull();
+    expect(getFetcherIdleDialogAction(true, 'submitting', 'idle', 'pending')).toBeNull();
+  });
+});

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/AttributeChangeDialog.utils.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/AttributeChangeDialog.utils.ts
@@ -1,0 +1,93 @@
+export type AttributeChangeOption = {
+  id: string;
+  label: string;
+};
+
+export type AttributeChangeFetcherOutcome = 'pending' | 'success' | 'error';
+
+type AttributeChangeItem = {
+  id: string;
+  name: string;
+  content?: { title?: string };
+};
+
+export function buildAttributeChangeOptions(items: AttributeChangeItem[]): AttributeChangeOption[] {
+  return items.map((item) => ({
+    id: item.id,
+    label: item.content?.title ?? item.name,
+  }));
+}
+
+export function getOptimisticNameOrTitle(
+  formData: FormData | undefined,
+  ...fallbacks: (string | undefined)[]
+): string | undefined {
+  const fromForm = formData?.get('name_or_title');
+  if (typeof fromForm === 'string' && fromForm.length > 0) {
+    return fromForm;
+  }
+
+  for (const fallback of fallbacks) {
+    if (fallback) {
+      return fallback;
+    }
+  }
+
+  return undefined;
+}
+
+export function resolveCollectionChangeOutcome(
+  data: { error?: string; collection?: { id: string } } | undefined,
+): AttributeChangeFetcherOutcome {
+  if (!data) {
+    return 'pending';
+  }
+  if (data.error) {
+    return 'error';
+  }
+  if (data.collection) {
+    return 'success';
+  }
+  return 'pending';
+}
+
+export function resolveKindChangeOutcome(
+  data: { error?: string; kindId?: string } | undefined,
+): AttributeChangeFetcherOutcome {
+  if (!data) {
+    return 'pending';
+  }
+  if (data.error) {
+    return 'error';
+  }
+  if (data.kindId) {
+    return 'success';
+  }
+  return 'pending';
+}
+
+export type FetcherIdleDialogAction = {
+  closeDialog: boolean;
+  clearAwaiting: boolean;
+};
+
+export function getFetcherIdleDialogAction(
+  awaitingResult: boolean,
+  prevFetcherState: string,
+  currentFetcherState: string,
+  outcome: AttributeChangeFetcherOutcome,
+): FetcherIdleDialogAction | null {
+  if (!awaitingResult || prevFetcherState === 'idle' || currentFetcherState !== 'idle') {
+    return null;
+  }
+
+  if (outcome === 'success') {
+    return { closeDialog: true, clearAwaiting: true };
+  }
+
+  if (outcome === 'error') {
+    return { closeDialog: false, clearAwaiting: true };
+  }
+
+  return null;
+}

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/AttributeChangeDialog.utils.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/AttributeChangeDialog.utils.ts
@@ -12,10 +12,12 @@ type AttributeChangeItem = {
 };
 
 export function buildAttributeChangeOptions(items: AttributeChangeItem[]): AttributeChangeOption[] {
-  return items.map((item) => ({
-    id: item.id,
-    label: item.content?.title ?? item.name,
-  }));
+  return items
+    .map((item) => ({
+      id: item.id,
+      label: item.content?.title ?? item.name,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
 }
 
 export function getOptimisticNameOrTitle(

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/Collections.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/Collections.tsx
@@ -1,10 +1,12 @@
-import { useFetcher } from 'react-router';
-import { Replace, SquareCheckBig } from 'lucide-react';
-import classNames from 'classnames';
-import { primitives } from '@curvenote/scms-core';
-import { useRef } from 'react';
 import type { SubmissionEditorCollection } from './types.js';
 import { DetailFieldEditorShell, DetailFieldEditorTrigger } from './DetailFieldEditor.js';
+import { AttributeChangeDialog } from './AttributeChangeDialog.js';
+import {
+  buildAttributeChangeOptions,
+  getOptimisticNameOrTitle,
+  resolveCollectionChangeOutcome,
+} from './AttributeChangeDialog.utils.js';
+import { useAttributeChangeDialog } from './useAttributeChangeDialog.js';
 
 type CollectionsProps = {
   submissionId: string;
@@ -19,20 +21,16 @@ export function Collections({
   collections,
   canUpdate,
 }: CollectionsProps) {
-  const fetcher = useFetcher<{ error?: string }>();
-  const popoverRef = useRef<primitives.PopoverActions>(null);
+  const { open, handleOpenChange, beginSubmit, fetcher } = useAttributeChangeDialog<{
+    error?: string;
+    collection?: { id: string; name: string };
+  }>({ resolveOutcome: resolveCollectionChangeOutcome });
+
   const current = collections.find((c) => c.id === collectionId);
+  const options = buildAttributeChangeOptions(collections);
 
-  function handleSetCollection(
-    e: React.FormEvent<HTMLFormElement>,
-    newCollectionId: string,
-    nameOrTitle: string,
-  ) {
-    e.preventDefault();
-    e.stopPropagation();
-
-    if (confirm(`Change the collection of this submission to "${nameOrTitle}"?`) === false) return;
-
+  const handleConfirm = (newCollectionId: string, nameOrTitle: string) => {
+    beginSubmit();
     fetcher.submit(
       {
         submission_id: submissionId,
@@ -42,90 +40,41 @@ export function Collections({
       },
       { method: 'POST' },
     );
+  };
 
-    popoverRef.current?.closePopover();
-  }
-
-  // optimistic ui
-  const collectionTitle =
-    (fetcher.formData?.get('name_or_title') as string) ??
-    current?.content?.title ??
-    current?.name ??
-    'Unknown';
-  const collectionName = current?.content?.name;
-
-  const cardContent = (
-    <div className="text-md">
-      <table className="w-full">
-        <thead>
-          <tr className="border-b-[1px] border-gray-500 bg-gray-100">
-            <th className="px-3 py-1 text-left">title</th>
-            <th className="px-3 py-1 text-left">name</th>
-            <th className="px-3 py-1 text-center">in use</th>
-            <th className="px-3 py-1 text-center align-text-bottom" title="set as primary">
-              <SquareCheckBig className="inline-block w-4 h-4" />
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {collections.map((c) => (
-            <tr key={c.id} className="even:bg-gray-50">
-              <td className="px-3 py-1 text-left" title={c.id}>
-                {c.content?.title && c.name ? `${c.content?.title} (${c?.name})` : '-'}
-              </td>
-              <td className="px-3 py-1 text-left" title={c.id}>
-                {c.name}
-              </td>
-              <td className="px-3 py-1 text-center">
-                {c.id === collectionId ? (
-                  <SquareCheckBig className="inline-block w-4 h-4 stroke-green-600" />
-                ) : (
-                  ''
-                )}
-              </td>
-              <td className="px-3 py-1 text-center">
-                <fetcher.Form
-                  onSubmit={(e) => handleSetCollection(e, c.id, c.content?.title ?? c.name)}
-                >
-                  <button
-                    className={classNames('align-text-bottom', {
-                      'cursor-pointer': c.id !== collectionId,
-                    })}
-                    type="submit"
-                    title="set as primary"
-                  >
-                    <Replace
-                      className={classNames('inline-block w-4 h-4', {
-                        'stroke-gray-300': c.id === collectionId,
-                        'cursor-pointer': c.id !== collectionId,
-                      })}
-                    />
-                  </button>
-                </fetcher.Form>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+  const collectionTitle = getOptimisticNameOrTitle(
+    fetcher.formData,
+    current?.content?.title,
+    current?.name,
+    'Unknown',
   );
+  const collectionName = current?.content?.name;
 
   return (
     <div className="w-full min-w-0">
       <DetailFieldEditorShell value={collectionTitle ?? collectionName ?? 'unknown'}>
-        {canUpdate ? (
-          <primitives.PopoverWrapper
-            ref={popoverRef}
-            className="min-w-[310px] z-20 p-6 pb-4"
-            content={cardContent}
-          >
-            <DetailFieldEditorTrigger
-              title={`${current?.name ?? 'unknown'} ${current?.id ?? ''}`}
-            />
-          </primitives.PopoverWrapper>
-        ) : null}
+        {canUpdate && (
+          <DetailFieldEditorTrigger
+            title="Change collection"
+            onClick={() => handleOpenChange(true)}
+          />
+        )}
       </DetailFieldEditorShell>
-      {fetcher.data?.error && <div className="text-xs text-red-600">{fetcher.data.error}</div>}
+      {canUpdate && (
+        <AttributeChangeDialog
+          open={open}
+          onOpenChange={handleOpenChange}
+          title="Change collection"
+          calloutType="warning"
+          calloutMessage="Changing the collection may change the workflow that applies to this submission. The current kind may no longer be valid for the new collection and would need to be updated."
+          options={options}
+          currentId={collectionId}
+          confirmLabel="Change collection"
+          isSubmitting={fetcher.state !== 'idle'}
+          error={fetcher.data?.error}
+          onConfirm={handleConfirm}
+        />
+      )}
     </div>
   );
 }

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/Collections.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/Collections.tsx
@@ -1,21 +1,24 @@
 import { useFetcher } from 'react-router';
-import { Replace, SquarePen, SquareCheckBig } from 'lucide-react';
+import { Replace, SquareCheckBig } from 'lucide-react';
 import classNames from 'classnames';
 import { primitives } from '@curvenote/scms-core';
 import { useRef } from 'react';
 import type { SubmissionEditorCollection } from './types.js';
+import { DetailFieldEditorShell, DetailFieldEditorTrigger } from './DetailFieldEditor.js';
+
+type CollectionsProps = {
+  submissionId: string;
+  collectionId: string;
+  collections: SubmissionEditorCollection[];
+  canUpdate: boolean;
+};
 
 export function Collections({
   submissionId,
   collectionId,
   collections,
   canUpdate,
-}: {
-  submissionId: string;
-  collectionId: string;
-  collections: SubmissionEditorCollection[];
-  canUpdate: boolean;
-}) {
+}: CollectionsProps) {
   const fetcher = useFetcher<{ error?: string }>();
   const popoverRef = useRef<primitives.PopoverActions>(null);
   const current = collections.find((c) => c.id === collectionId);
@@ -108,21 +111,21 @@ export function Collections({
   );
 
   return (
-    <primitives.PopoverWrapper
-      ref={popoverRef}
-      className="min-w-[310px] z-20 p-6 pb-4"
-      content={cardContent}
-    >
-      <div className="flex flex-col items-right">
-        <div
-          className="text-right underline cursor-pointer"
-          title={`${current?.name ?? 'unknown'} ${current?.id ?? ''}`}
-        >
-          {collectionTitle ?? collectionName ?? 'unknown'}
-          {canUpdate && <SquarePen className="inline-block w-4 h-4 ml-[2px] mb-[2px]" />}
-        </div>
-        {fetcher.data?.error && <div className="text-xs text-red-600">{fetcher.data.error}</div>}
-      </div>
-    </primitives.PopoverWrapper>
+    <div className="w-full min-w-0">
+      <DetailFieldEditorShell value={collectionTitle ?? collectionName ?? 'unknown'}>
+        {canUpdate ? (
+          <primitives.PopoverWrapper
+            ref={popoverRef}
+            className="min-w-[310px] z-20 p-6 pb-4"
+            content={cardContent}
+          >
+            <DetailFieldEditorTrigger
+              title={`${current?.name ?? 'unknown'} ${current?.id ?? ''}`}
+            />
+          </primitives.PopoverWrapper>
+        ) : null}
+      </DetailFieldEditorShell>
+      {fetcher.data?.error && <div className="text-xs text-red-600">{fetcher.data.error}</div>}
+    </div>
   );
 }

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/ConfirmSlugActionDialog.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/ConfirmSlugActionDialog.tsx
@@ -1,0 +1,56 @@
+import { cn, ui } from '@curvenote/scms-core';
+import { getSlugConfirmCopy, type SlugConfirmAction } from './SlugManagerDialog.utils.js';
+
+const DESTRUCTIVE_SOFT_BUTTON_CLASS = cn(
+  'bg-destructive/10 text-red-800 shadow-xs hover:bg-destructive/15 hover:text-red-800 dark:bg-destructive/20 dark:text-red-300 dark:hover:bg-destructive/30 dark:hover:text-red-200',
+);
+
+type ConfirmSlugActionDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  action: SlugConfirmAction;
+  slug: string;
+  isSubmitting: boolean;
+  error?: string;
+  onConfirm: () => void;
+};
+
+export function ConfirmSlugActionDialog({
+  open,
+  onOpenChange,
+  action,
+  slug,
+  isSubmitting,
+  error,
+  onConfirm,
+}: ConfirmSlugActionDialogProps) {
+  const copy = getSlugConfirmCopy(action, slug);
+  const isRemove = action === 'remove';
+
+  return (
+    <ui.Dialog open={open} onOpenChange={onOpenChange}>
+      <ui.DialogContent>
+        <ui.DialogHeader>
+          <ui.DialogTitle>{copy.title}</ui.DialogTitle>
+          <ui.DialogDescription>{copy.description}</ui.DialogDescription>
+        </ui.DialogHeader>
+        {error ? <ui.SimpleAlert type="error" message={error} size="compact" /> : null}
+        <ui.DialogFooter>
+          <ui.DialogClose asChild>
+            <ui.Button variant="outline" disabled={isSubmitting}>
+              Cancel
+            </ui.Button>
+          </ui.DialogClose>
+          <ui.Button
+            variant={isRemove ? 'ghost' : 'default'}
+            className={isRemove ? DESTRUCTIVE_SOFT_BUTTON_CLASS : undefined}
+            onClick={onConfirm}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? copy.submittingLabel : copy.confirmLabel}
+          </ui.Button>
+        </ui.DialogFooter>
+      </ui.DialogContent>
+    </ui.Dialog>
+  );
+}

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/DetailFieldEditor.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/DetailFieldEditor.tsx
@@ -1,0 +1,49 @@
+import { forwardRef, type ComponentPropsWithoutRef, type ReactNode } from 'react';
+import { SquarePen } from 'lucide-react';
+import { cn, ui } from '@curvenote/scms-core';
+
+type DetailFieldEditorShellProps = {
+  children: ReactNode;
+  value: ReactNode;
+  valueClassName?: string;
+};
+
+export function DetailFieldEditorShell({
+  children,
+  value,
+  valueClassName,
+}: DetailFieldEditorShellProps) {
+  return (
+    <div className="flex w-full min-w-0 items-center justify-between gap-2">
+      <span className={cn('min-w-0 truncate text-sm text-muted-foreground', valueClassName)}>
+        {value}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+type DetailFieldEditorTriggerProps = Omit<
+  ComponentPropsWithoutRef<typeof ui.Button>,
+  'children' | 'value'
+>;
+
+export const DetailFieldEditorTrigger = forwardRef<
+  HTMLButtonElement,
+  DetailFieldEditorTriggerProps
+>(function DetailFieldEditorTriggerButton({ title, className, ...props }, ref) {
+  return (
+    <ui.Button
+      ref={ref}
+      type="button"
+      variant="ghost"
+      size="icon-xs"
+      title={title}
+      aria-label={title ?? 'Edit'}
+      {...props}
+      className={cn('shrink-0 text-muted-foreground', className)}
+    >
+      <SquarePen aria-hidden />
+    </ui.Button>
+  );
+});

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/Kinds.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/Kinds.tsx
@@ -1,14 +1,16 @@
-import { useFetcher } from 'react-router';
-import { SquareCheckBig, Replace } from 'lucide-react';
-import classNames from 'classnames';
-import { primitives } from '@curvenote/scms-core';
-import { useRef } from 'react';
 import type { SubmissionEditorCollection } from './types.js';
 import { DetailFieldEditorShell, DetailFieldEditorTrigger } from './DetailFieldEditor.js';
+import { AttributeChangeDialog } from './AttributeChangeDialog.js';
+import {
+  buildAttributeChangeOptions,
+  getOptimisticNameOrTitle,
+  resolveKindChangeOutcome,
+} from './AttributeChangeDialog.utils.js';
+import { useAttributeChangeDialog } from './useAttributeChangeDialog.js';
 
 type KindsProps = {
   submissionId: string;
-  collection: SubmissionEditorCollection;
+  collection?: SubmissionEditorCollection;
   kindId: string;
   kindNameOrTitle: string;
   canUpdate: boolean;
@@ -21,21 +23,23 @@ export function Kinds({
   kindNameOrTitle,
   canUpdate,
 }: KindsProps) {
-  const fetcher = useFetcher<{ error?: string; kindId: string; kindName: string }>();
-  const popoverRef = useRef<primitives.PopoverActions>(null);
-  const submissionKindMatch = collection?.kinds?.some((k) => k.id === kindId);
-  const current = collection?.kinds.find((k) => k.id === kindId);
+  const { open, handleOpenChange, beginSubmit, fetcher } = useAttributeChangeDialog<{
+    error?: string;
+    kindId: string;
+    kindName: string;
+  }>({ resolveOutcome: resolveKindChangeOutcome });
 
-  function handleSetKind(
-    e: React.FormEvent<HTMLFormElement>,
-    newKindId: string,
-    nameOrTitle: string,
-  ) {
-    e.preventDefault();
-    e.stopPropagation();
+  const kinds = collection?.kinds ?? [];
+  const submissionKindMatch = kinds.some((kind) => kind.id === kindId);
+  const current = kinds.find((k) => k.id === kindId);
+  const options = buildAttributeChangeOptions(kinds);
+  const canChangeKind = canUpdate && collection != null;
 
-    if (confirm(`Change the kind of this submission to "${nameOrTitle}"?`) === false) return;
-
+  const handleConfirm = (newKindId: string, nameOrTitle: string) => {
+    if (!collection) {
+      return;
+    }
+    beginSubmit();
     fetcher.submit(
       {
         submission_id: submissionId,
@@ -46,65 +50,13 @@ export function Kinds({
       },
       { method: 'POST' },
     );
+  };
 
-    popoverRef.current?.closePopover();
-  }
-
-  // optimistic ui
-  const kindTitle =
-    (fetcher.formData?.get('name_or_title') as string) ??
-    current?.content?.title ??
-    current?.name ??
-    kindNameOrTitle;
-
-  const cardContent = (
-    <div className="text-md">
-      <table className="w-full">
-        <thead>
-          <tr className="border-b-[1px] border-gray-500 bg-gray-100">
-            <th className="px-3 py-1 text-left">name</th>
-            <th className="px-3 py-1 text-center">in use</th>
-            <th className="px-3 py-1 text-center align-text-bottom" title="set as primary">
-              <SquareCheckBig className="inline-block w-4 h-4" />
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {collection?.kinds.map((k) => (
-            <tr key={k.id} className="even:bg-gray-50">
-              <td className="px-3 py-1 text-left" title={k.id}>
-                {k.name}
-              </td>
-              <td className="px-3 py-1 text-center">
-                {k.id === kindId ? (
-                  <SquareCheckBig className="inline-block w-4 h-4 stroke-green-600" />
-                ) : (
-                  ''
-                )}
-              </td>
-              <td className="px-3 py-1 text-center">
-                <fetcher.Form onSubmit={(e) => handleSetKind(e, k.id, k.content?.title ?? k.name)}>
-                  <button
-                    className={classNames('align-text-bottom', {
-                      'cursor-pointer': k.id !== kindId,
-                    })}
-                    type="submit"
-                    title="set as primary"
-                  >
-                    <Replace
-                      className={classNames('inline-block w-4 h-4', {
-                        'stroke-gray-300': k.id === kindId,
-                        'cursor-pointer': k.id !== kindId,
-                      })}
-                    />
-                  </button>
-                </fetcher.Form>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+  const kindTitle = getOptimisticNameOrTitle(
+    fetcher.formData,
+    current?.content?.title,
+    current?.name,
+    kindNameOrTitle,
   );
 
   return (
@@ -113,17 +65,25 @@ export function Kinds({
         value={kindTitle ?? current?.name}
         valueClassName={!submissionKindMatch ? 'font-semibold text-destructive' : undefined}
       >
-        {canUpdate ? (
-          <primitives.PopoverWrapper
-            ref={popoverRef}
-            className="z-20 p-6 pb-4 min-w-[310px]"
-            content={cardContent}
-          >
-            <DetailFieldEditorTrigger title={kindId} />
-          </primitives.PopoverWrapper>
-        ) : null}
+        {canChangeKind && (
+          <DetailFieldEditorTrigger title="Change kind" onClick={() => handleOpenChange(true)} />
+        )}
       </DetailFieldEditorShell>
-      {fetcher.data?.error && <div className="text-xs text-red-600">{fetcher.data.error}</div>}
+      {canChangeKind && (
+        <AttributeChangeDialog
+          open={open}
+          onOpenChange={handleOpenChange}
+          title="Change submission kind"
+          calloutType="info"
+          calloutMessage="This changes how the submission is classified within its collection."
+          options={options}
+          currentId={kindId}
+          confirmLabel="Change kind"
+          isSubmitting={fetcher.state !== 'idle'}
+          error={fetcher.data?.error}
+          onConfirm={handleConfirm}
+        />
+      )}
     </div>
   );
 }

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/Kinds.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/Kinds.tsx
@@ -1,9 +1,18 @@
 import { useFetcher } from 'react-router';
-import { SquarePen, SquareCheckBig, Replace } from 'lucide-react';
+import { SquareCheckBig, Replace } from 'lucide-react';
 import classNames from 'classnames';
-import { primitives, cn } from '@curvenote/scms-core';
+import { primitives } from '@curvenote/scms-core';
 import { useRef } from 'react';
 import type { SubmissionEditorCollection } from './types.js';
+import { DetailFieldEditorShell, DetailFieldEditorTrigger } from './DetailFieldEditor.js';
+
+type KindsProps = {
+  submissionId: string;
+  collection: SubmissionEditorCollection;
+  kindId: string;
+  kindNameOrTitle: string;
+  canUpdate: boolean;
+};
 
 export function Kinds({
   submissionId,
@@ -11,13 +20,7 @@ export function Kinds({
   kindId,
   kindNameOrTitle,
   canUpdate,
-}: {
-  submissionId: string;
-  collection: SubmissionEditorCollection;
-  kindId: string;
-  kindNameOrTitle: string;
-  canUpdate: boolean;
-}) {
+}: KindsProps) {
   const fetcher = useFetcher<{ error?: string; kindId: string; kindName: string }>();
   const popoverRef = useRef<primitives.PopoverActions>(null);
   const submissionKindMatch = collection?.kinds?.some((k) => k.id === kindId);
@@ -105,23 +108,22 @@ export function Kinds({
   );
 
   return (
-    <primitives.PopoverWrapper
-      ref={popoverRef}
-      className={cn('z-20 p-6 pb-4 min-w-[310px]')}
-      content={cardContent}
-    >
-      <div className="flex flex-col items-right">
-        <div
-          className={cn('text-right underline cursor-pointer', {
-            'font-semibold text-red-500': !submissionKindMatch,
-          })}
-          title={kindId}
-        >
-          {kindTitle ?? current?.name}
-          {canUpdate && <SquarePen className="inline-block w-4 h-4 ml-[2px] mb-[2px]" />}
-        </div>
-        {fetcher.data?.error && <div className="text-xs text-red-600">{fetcher.data.error}</div>}
-      </div>
-    </primitives.PopoverWrapper>
+    <div className="w-full min-w-0">
+      <DetailFieldEditorShell
+        value={kindTitle ?? current?.name}
+        valueClassName={!submissionKindMatch ? 'font-semibold text-destructive' : undefined}
+      >
+        {canUpdate ? (
+          <primitives.PopoverWrapper
+            ref={popoverRef}
+            className="z-20 p-6 pb-4 min-w-[310px]"
+            content={cardContent}
+          >
+            <DetailFieldEditorTrigger title={kindId} />
+          </primitives.PopoverWrapper>
+        ) : null}
+      </DetailFieldEditorShell>
+      {fetcher.data?.error && <div className="text-xs text-red-600">{fetcher.data.error}</div>}
+    </div>
   );
 }

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/PublicationDate.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/PublicationDate.tsx
@@ -1,8 +1,9 @@
 import { useFetcher } from 'react-router';
-import { SquarePen } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { ui } from '@curvenote/scms-core';
 import { publicationDateCalendarBounds } from '../../publicationDateCalendar.js';
+import { emptyDetailValue } from './SubmissionDetails.utils.js';
+import { DetailFieldEditorShell, DetailFieldEditorTrigger } from './DetailFieldEditor.js';
 
 export function hyphenatedFromDate(date: Date) {
   const year = date.getFullYear().toString();
@@ -23,7 +24,9 @@ export function hyphenatedToDate(date: string) {
 
 /** Invalid Date is truthy — never pass it to DayPicker's `month` / `selected`. */
 function parsePublicationDate(value?: string): Date | undefined {
-  if (!value) return undefined;
+  if (!value) {
+    return undefined;
+  }
   const parsed = hyphenatedToDate(value);
   return Number.isNaN(parsed.getTime()) ? undefined : parsed;
 }
@@ -32,15 +35,13 @@ function startOfMonth(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), 1);
 }
 
-export function PublicationDate({
-  submissionId,
-  datePublished,
-  canUpdate,
-}: {
+type PublicationDateProps = {
   submissionId: string;
   datePublished?: string;
   canUpdate: boolean;
-}) {
+};
+
+export function PublicationDate({ submissionId, datePublished, canUpdate }: PublicationDateProps) {
   const fetcher = useFetcher<{ error?: string }>();
 
   const committedDate = parsePublicationDate(datePublished);
@@ -50,71 +51,81 @@ export function PublicationDate({
     startOfMonth(committedDate ?? new Date()),
   );
 
+  const displayValue = datePublished ?? emptyDetailValue();
+
   // Sync draft state when the popover opens; reset to saved value each time.
   useEffect(() => {
-    if (!calendarOpen) return;
+    if (!calendarOpen) {
+      return;
+    }
     setSelectedDate(parsePublicationDate(datePublished));
     setVisibleMonth(startOfMonth(parsePublicationDate(datePublished) ?? new Date()));
   }, [calendarOpen, datePublished]);
 
+  const handleCancelClick = () => {
+    setSelectedDate(committedDate);
+    setCalendarOpen(false);
+  };
+
+  const handleSaveClick = () => {
+    if (!selectedDate) {
+      return;
+    }
+    setCalendarOpen(false);
+    fetcher.submit(
+      {
+        submission_id: submissionId,
+        date_published: hyphenatedFromDate(selectedDate),
+        formAction: 'set-date-published',
+      },
+      { method: 'POST' },
+    );
+  };
+
   return (
-    <ui.Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
-      <ui.PopoverTrigger asChild>
-        <div
-          className="text-right underline cursor-pointer"
-          title={`Publication Date${committedDate ? ` ${datePublished}` : ''}`}
-        >
-          {datePublished ?? 'n/a'}
-          {canUpdate && <SquarePen className="inline-block w-4 h-4 ml-[2px] mb-[2px]" />}
-        </div>
-      </ui.PopoverTrigger>
-      <ui.PopoverContent className="w-auto p-0">
-        <ui.Calendar
-          mode="single"
-          captionLayout="dropdown-buttons"
-          {...publicationDateCalendarBounds()}
-          selected={selectedDate}
-          onSelect={setSelectedDate}
-          month={visibleMonth}
-          onMonthChange={setVisibleMonth}
-          initialFocus
-        />
-        <div className="flex gap-1.5 px-2 pb-2 pt-1">
-          <ui.Button
-            className="flex-1"
-            size="sm"
-            variant="outline"
-            disabled={fetcher.state !== 'idle'}
-            type="reset"
-            onClick={() => {
-              setSelectedDate(committedDate);
-              setCalendarOpen(false);
-            }}
-          >
-            Cancel
-          </ui.Button>
-          <ui.Button
-            className="flex-1"
-            size="sm"
-            disabled={!selectedDate || fetcher.state !== 'idle'}
-            onClick={() => {
-              if (!selectedDate) return;
-              setCalendarOpen(false);
-              fetcher.submit(
-                {
-                  submission_id: submissionId,
-                  date_published: hyphenatedFromDate(selectedDate),
-                  formAction: 'set-date-published',
-                },
-                { method: 'POST' },
-              );
-            }}
-            type="submit"
-          >
-            Save
-          </ui.Button>
-        </div>
-      </ui.PopoverContent>
-    </ui.Popover>
+    <DetailFieldEditorShell value={displayValue}>
+      {canUpdate ? (
+        <ui.Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
+          <ui.PopoverTrigger asChild>
+            <DetailFieldEditorTrigger
+              title={`Publication Date${committedDate ? ` ${datePublished}` : ''}`}
+            />
+          </ui.PopoverTrigger>
+          <ui.PopoverContent align="end" side="bottom" className="p-0 w-auto">
+            <ui.Calendar
+              mode="single"
+              captionLayout="dropdown-buttons"
+              {...publicationDateCalendarBounds()}
+              selected={selectedDate}
+              onSelect={setSelectedDate}
+              month={visibleMonth}
+              onMonthChange={setVisibleMonth}
+              initialFocus
+            />
+            <div className="flex gap-1.5 px-2 pb-2 pt-1">
+              <ui.Button
+                className="flex-1"
+                size="sm"
+                variant="outline"
+                disabled={fetcher.state !== 'idle'}
+                type="reset"
+                onClick={handleCancelClick}
+              >
+                Cancel
+              </ui.Button>
+              <ui.Button
+                className="flex-1"
+                size="sm"
+                disabled={!selectedDate || fetcher.state !== 'idle'}
+                onClick={handleSaveClick}
+                type="submit"
+              >
+                Save
+              </ui.Button>
+            </div>
+          </ui.PopoverContent>
+        </ui.Popover>
+      ) : null}
+    </DetailFieldEditorShell>
   );
 }

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SlugManagerDialog.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SlugManagerDialog.tsx
@@ -1,0 +1,190 @@
+import { formatDistanceToNow } from 'date-fns';
+import { PlusIcon, Trash2 } from 'lucide-react';
+import type { KeyboardEvent } from 'react';
+import { cn, ui } from '@curvenote/scms-core';
+import type { SubmissionDetailSlugRow } from './types.js';
+
+type SlugManagerDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  slugs: SubmissionDetailSlugRow[];
+  fallback: string;
+  baseUrl: string;
+  draftSlug: string;
+  onDraftSlugChange: (value: string) => void;
+  addSlugError?: string;
+  isSubmitting: boolean;
+  onAdd: () => void;
+  onRequestRemove: (slugId: string, slug: string) => void;
+  onRequestSetPrimary: (slugId: string, slug: string) => void;
+};
+
+type SlugListRowProps = {
+  slug: string;
+  href: string;
+  badge?: 'Primary' | 'Default';
+  updatedLabel: string;
+  muted?: boolean;
+  onSetPrimary?: () => void;
+  onRemove?: () => void;
+  isSubmitting: boolean;
+};
+
+function SlugListRow({
+  slug,
+  href,
+  badge,
+  updatedLabel,
+  muted,
+  onSetPrimary,
+  onRemove,
+  isSubmitting,
+}: SlugListRowProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between gap-3 border-b border-border px-3 py-2.5 last:border-b-0',
+        muted && 'bg-muted/50',
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <a
+            className={cn(
+              'truncate text-sm hover:underline',
+              muted ? 'text-muted-foreground' : 'text-foreground',
+              badge === 'Primary' && 'font-medium',
+            )}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {slug}
+          </a>
+          {badge ? (
+            <ui.Badge variant="outline-muted" size="sm">
+              {badge}
+            </ui.Badge>
+          ) : null}
+        </div>
+        <p className="mt-0.5 text-xs text-muted-foreground">{updatedLabel}</p>
+      </div>
+      {(onSetPrimary || onRemove) && (
+        <div className="flex shrink-0 items-center gap-2">
+          {onSetPrimary && (
+            <ui.Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              disabled={isSubmitting}
+              onClick={onSetPrimary}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              Set as primary
+            </ui.Button>
+          )}
+          {onRemove && (
+            <ui.Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              title="Remove slug"
+              aria-label={`Remove ${slug}`}
+              disabled={isSubmitting}
+              onClick={onRemove}
+            >
+              <Trash2 aria-hidden />
+            </ui.Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SlugManagerDialog({
+  open,
+  onOpenChange,
+  slugs,
+  fallback,
+  baseUrl,
+  draftSlug,
+  onDraftSlugChange,
+  addSlugError,
+  isSubmitting,
+  onAdd,
+  onRequestRemove,
+  onRequestSetPrimary,
+}: SlugManagerDialogProps) {
+  const handleDraftKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Enter') {
+      return;
+    }
+    event.preventDefault();
+    onAdd();
+  };
+
+  return (
+    <ui.Dialog open={open} onOpenChange={onOpenChange}>
+      <ui.DialogContent variant="wide">
+        <ui.DialogHeader>
+          <ui.DialogTitle>Manage slugs</ui.DialogTitle>
+          <ui.DialogDescription>
+            The primary slug is the public URL. Removing a slug breaks existing external links that
+            use it.
+          </ui.DialogDescription>
+        </ui.DialogHeader>
+        <div className="space-y-4">
+          <div className="overflow-hidden rounded-md border border-border">
+            {slugs.map((slugRow) => (
+              <SlugListRow
+                key={slugRow.id}
+                slug={slugRow.slug}
+                href={`${baseUrl}${slugRow.slug}`}
+                badge={slugRow.primary ? 'Primary' : undefined}
+                updatedLabel={`Updated ${formatDistanceToNow(new Date(slugRow.date_modified))} ago`}
+                onSetPrimary={
+                  slugRow.primary
+                    ? undefined
+                    : () => {
+                        onRequestSetPrimary(slugRow.id, slugRow.slug);
+                      }
+                }
+                onRemove={() => {
+                  onRequestRemove(slugRow.id, slugRow.slug);
+                }}
+                isSubmitting={isSubmitting}
+              />
+            ))}
+            <SlugListRow
+              slug={fallback}
+              href={`${baseUrl}${fallback}`}
+              badge="Default"
+              updatedLabel="Work id fallback — not removable"
+              muted
+              isSubmitting={isSubmitting}
+            />
+          </div>
+          <div className="flex items-start gap-2">
+            <ui.TextField
+              className="min-w-0 flex-1"
+              value={draftSlug}
+              onChange={(event) => {
+                onDraftSlugChange(event.target.value);
+              }}
+              onKeyDown={handleDraftKeyDown}
+              placeholder="Enter slug"
+              disabled={isSubmitting}
+              maxLength={64}
+              error={addSlugError}
+            />
+            <ui.Button className="shrink-0" type="button" onClick={onAdd} disabled={isSubmitting}>
+              <PlusIcon className="w-4 h-4" />
+              Add a slug
+            </ui.Button>
+          </div>
+        </div>
+      </ui.DialogContent>
+    </ui.Dialog>
+  );
+}

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SlugManagerDialog.utils.spec.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SlugManagerDialog.utils.spec.ts
@@ -1,0 +1,142 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import {
+  getDisplaySlug,
+  getSlugAddFieldError,
+  getSlugConfirmCopy,
+  getSlugConfirmDialogError,
+  resolveSlugMutationOutcome,
+  getSuggestedSlugDraft,
+  validateSlugForAdd,
+} from './SlugManagerDialog.utils.js';
+import { SUBMISSION_DETAIL_FORM_ACTIONS } from './SubmissionDetails.utils.js';
+
+const sampleSlugs = [
+  {
+    id: '1',
+    slug: 'primary-slug',
+    primary: true,
+    date_created: '2024-01-01',
+    date_modified: '2024-01-02',
+  },
+  {
+    id: '2',
+    slug: 'secondary-slug',
+    primary: false,
+    date_created: '2024-01-01',
+    date_modified: '2024-01-03',
+  },
+];
+
+describe('getDisplaySlug', () => {
+  it('prefers the primary slug, then first slug, then fallback', () => {
+    expect(getDisplaySlug(sampleSlugs, 'fallback-id')).toBe('primary-slug');
+    expect(getDisplaySlug([{ ...sampleSlugs[1], primary: false }], 'fallback-id')).toBe(
+      'secondary-slug',
+    );
+    expect(getDisplaySlug([], 'fallback-id')).toBe('fallback-id');
+  });
+});
+
+describe('getSuggestedSlugDraft', () => {
+  it('returns the suggestion when it is not already used', () => {
+    expect(getSuggestedSlugDraft('myst-journal-', [])).toBe('myst-journal-');
+    expect(getSuggestedSlugDraft('myst-journal-', sampleSlugs)).toBe('myst-journal-');
+    expect(getSuggestedSlugDraft('primary-slug', sampleSlugs)).toBeUndefined();
+    expect(getSuggestedSlugDraft(undefined, sampleSlugs)).toBeUndefined();
+  });
+});
+
+describe('validateSlugForAdd', () => {
+  it('rejects empty, short, long, unsafe, uuid, and duplicate slugs', () => {
+    expect(validateSlugForAdd('', sampleSlugs)).toBe('Enter a slug');
+    expect(validateSlugForAdd('abc', sampleSlugs)).toMatch(/too short/i);
+    expect(validateSlugForAdd('a'.repeat(65), sampleSlugs)).toMatch(/too long/i);
+    expect(validateSlugForAdd('bad slug', sampleSlugs)).toMatch(/invalid characters/i);
+    expect(validateSlugForAdd('01234567-89ab-cdef-0123-456789abcdef', sampleSlugs)).toMatch(
+      /uuid/i,
+    );
+    expect(validateSlugForAdd('primary-slug', sampleSlugs)).toMatch(/already exists/i);
+  });
+
+  it('accepts a valid new slug', () => {
+    expect(validateSlugForAdd('new-valid-slug', sampleSlugs)).toBeUndefined();
+  });
+});
+
+describe('getSlugAddFieldError', () => {
+  it('prefers the local error, then an add-action fetcher error', () => {
+    const addFormData = new FormData();
+    addFormData.set('formAction', SUBMISSION_DETAIL_FORM_ACTIONS.slugAdd);
+
+    expect(
+      getSlugAddFieldError({
+        localError: 'too short',
+        fetcherFormData: undefined,
+        fetcherError: undefined,
+      }),
+    ).toBe('too short');
+    expect(
+      getSlugAddFieldError({
+        localError: undefined,
+        fetcherFormData: addFormData,
+        fetcherError: 'server error',
+      }),
+    ).toBe('server error');
+    expect(
+      getSlugAddFieldError({
+        localError: undefined,
+        fetcherFormData: undefined,
+        fetcherError: 'server error',
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('getSlugConfirmDialogError', () => {
+  it('shows the fetcher error only for the matching confirm action', () => {
+    const removeFormData = new FormData();
+    removeFormData.set('formAction', SUBMISSION_DETAIL_FORM_ACTIONS.slugRemove);
+
+    expect(
+      getSlugConfirmDialogError({
+        confirmTarget: { action: 'remove', slugId: '1', slug: 'qgr-2024' },
+        fetcherFormData: removeFormData,
+        fetcherError: 'cannot remove',
+      }),
+    ).toBe('cannot remove');
+    expect(
+      getSlugConfirmDialogError({
+        confirmTarget: { action: 'primary', slugId: '1', slug: 'qgr-2024' },
+        fetcherFormData: removeFormData,
+        fetcherError: 'cannot remove',
+      }),
+    ).toBeUndefined();
+    expect(
+      getSlugConfirmDialogError({
+        confirmTarget: null,
+        fetcherFormData: removeFormData,
+        fetcherError: 'cannot remove',
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('resolveSlugMutationOutcome', () => {
+  it('maps fetcher data to outcomes', () => {
+    expect(resolveSlugMutationOutcome(undefined)).toBe('pending');
+    expect(resolveSlugMutationOutcome({ error: 'bad' })).toBe('error');
+    expect(resolveSlugMutationOutcome({ slugs: sampleSlugs })).toBe('success');
+    expect(resolveSlugMutationOutcome({})).toBe('pending');
+  });
+});
+
+describe('getSlugConfirmCopy', () => {
+  it('returns remove and primary copy', () => {
+    expect(getSlugConfirmCopy('remove', 'qgr-2024').title).toBe('Remove slug');
+    expect(getSlugConfirmCopy('remove', 'qgr-2024').description).toContain('qgr-2024');
+
+    expect(getSlugConfirmCopy('primary', 'qgr-2024').title).toBe('Set primary slug');
+    expect(getSlugConfirmCopy('primary', 'qgr-2024').confirmLabel).toBe('Set as primary');
+  });
+});

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SlugManagerDialog.utils.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SlugManagerDialog.utils.ts
@@ -1,0 +1,146 @@
+import { isSafeSlug, looksLikeUUID } from '@curvenote/scms-core';
+import type { SubmissionDetailSlugRow } from './types.js';
+import { SUBMISSION_DETAIL_FORM_ACTIONS } from './SubmissionDetails.utils.js';
+
+export type SlugConfirmAction = 'remove' | 'primary';
+
+export type SlugConfirmTarget = {
+  action: SlugConfirmAction;
+  slugId: string;
+  slug: string;
+};
+
+const SLUG_MIN_LENGTH = 6;
+const SLUG_MAX_LENGTH = 64;
+
+export function getDisplaySlug(slugs: SubmissionDetailSlugRow[], fallback: string): string {
+  return slugs.find((s) => s.primary)?.slug ?? slugs[0]?.slug ?? fallback;
+}
+
+/** Prefill for the add-slug input (same default the legacy prompt used). */
+export function getSuggestedSlugDraft(
+  suggestion: string | undefined,
+  slugs: SubmissionDetailSlugRow[],
+): string | undefined {
+  if (!suggestion) {
+    return undefined;
+  }
+  if (slugs.some((s) => s.slug === suggestion)) {
+    return undefined;
+  }
+  return suggestion;
+}
+
+export function validateSlugForAdd(
+  slug: string,
+  existingSlugs: SubmissionDetailSlugRow[],
+): string | undefined {
+  const trimmed = slug.trim();
+  if (!trimmed) {
+    return 'Enter a slug';
+  }
+  if (trimmed.length < SLUG_MIN_LENGTH) {
+    return `Slug is too short (${trimmed.length} chars, minimum ${SLUG_MIN_LENGTH})`;
+  }
+  if (trimmed.length > SLUG_MAX_LENGTH) {
+    return `Slug is too long (${trimmed.length} chars, maximum ${SLUG_MAX_LENGTH})`;
+  }
+  if (looksLikeUUID(trimmed)) {
+    return 'Cannot use UUIDs as slugs';
+  }
+  if (!isSafeSlug(trimmed)) {
+    return 'Invalid characters in slug (use alphanumeric, "-", "_" or "." only)';
+  }
+  if (existingSlugs.some((s) => s.slug === trimmed)) {
+    return 'Slug already exists for this submission';
+  }
+  return undefined;
+}
+
+export type SlugAddFieldErrorInput = {
+  localError: string | undefined;
+  fetcherFormData: FormData | undefined;
+  fetcherError: string | undefined;
+};
+
+export function getSlugAddFieldError({
+  localError,
+  fetcherFormData,
+  fetcherError,
+}: SlugAddFieldErrorInput): string | undefined {
+  if (localError) {
+    return localError;
+  }
+  if (
+    fetcherError &&
+    fetcherFormData?.get('formAction') === SUBMISSION_DETAIL_FORM_ACTIONS.slugAdd
+  ) {
+    return fetcherError;
+  }
+  return undefined;
+}
+
+export type SlugConfirmDialogErrorInput = {
+  confirmTarget: SlugConfirmTarget | null;
+  fetcherFormData: FormData | undefined;
+  fetcherError: string | undefined;
+};
+
+export function getSlugConfirmDialogError({
+  confirmTarget,
+  fetcherFormData,
+  fetcherError,
+}: SlugConfirmDialogErrorInput): string | undefined {
+  if (!confirmTarget || !fetcherError) {
+    return undefined;
+  }
+  const formAction = fetcherFormData?.get('formAction');
+  if (
+    confirmTarget.action === 'remove' &&
+    formAction === SUBMISSION_DETAIL_FORM_ACTIONS.slugRemove
+  ) {
+    return fetcherError;
+  }
+  if (
+    confirmTarget.action === 'primary' &&
+    formAction === SUBMISSION_DETAIL_FORM_ACTIONS.slugSetPrimary
+  ) {
+    return fetcherError;
+  }
+  return undefined;
+}
+
+export type SlugMutationOutcome = 'pending' | 'success' | 'error';
+
+export function resolveSlugMutationOutcome(
+  data: { error?: string; slugs?: SubmissionDetailSlugRow[] } | undefined,
+): SlugMutationOutcome {
+  if (!data) {
+    return 'pending';
+  }
+  if (data.error) {
+    return 'error';
+  }
+  if (data.slugs) {
+    return 'success';
+  }
+  return 'pending';
+}
+
+export function getSlugConfirmCopy(action: SlugConfirmAction, slug: string) {
+  if (action === 'remove') {
+    return {
+      title: 'Remove slug',
+      description: `Are you sure you want to remove "${slug}"? This will break existing external links to the submission that use this slug.`,
+      confirmLabel: 'Remove slug',
+      submittingLabel: 'Removing...',
+    };
+  }
+
+  return {
+    title: 'Set primary slug',
+    description: `Are you sure you want to set "${slug}" as the primary slug? This will redirect all other slugs here.`,
+    confirmLabel: 'Set as primary',
+    submittingLabel: 'Setting...',
+  };
+}

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/Slugs.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/Slugs.tsx
@@ -1,14 +1,25 @@
 import { useFetcher } from 'react-router';
-import { SquarePen, SquareCheckBig, Trash2, CirclePlus } from 'lucide-react';
+import { SquareCheckBig, Trash2, CirclePlus } from 'lucide-react';
 import classNames from 'classnames';
 import { formatDistanceToNow } from 'date-fns';
 import type { SlugsDTO } from './types.server.js';
 import { primitives } from '@curvenote/scms-core';
+import { DetailFieldEditorShell, DetailFieldEditorTrigger } from './DetailFieldEditor.js';
 
 export function getSlugSuggestion(site: { name: string }, doi?: string) {
   const secondPartOfDoi = doi?.split('/')[1];
   return secondPartOfDoi ?? `${site.name}-`;
 }
+
+type SlugsProps = {
+  siteId: string;
+  submissionId: string;
+  slugs: SlugsDTO;
+  fallback: string;
+  canEdit: boolean;
+  baseUrl: string;
+  suggestion?: string;
+};
 
 export function Slugs({
   siteId,
@@ -18,25 +29,16 @@ export function Slugs({
   canEdit,
   suggestion,
   baseUrl,
-}: {
-  siteId: string;
-  submissionId: string;
-  slugs: SlugsDTO;
-  fallback: string;
-  canEdit: boolean;
-  baseUrl: string;
-  suggestion?: string;
-}) {
+}: SlugsProps) {
   const fetcher = useFetcher<{ error?: string; slugs?: SlugsDTO }>();
   const makeSuggestion = suggestion ? !slugs.find((s) => s.slug === suggestion) : false;
 
-  const handleAddFirstSlug = (e: React.MouseEvent<HTMLDivElement>) => {
-    // only hand directly adding if we have no slugs
+  const handleAddFirstSlug = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (slugs.length > 0) return;
     handleAdd(e);
   };
 
-  const handleAdd = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleAdd = (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault();
     e.stopPropagation();
 
@@ -176,24 +178,19 @@ export function Slugs({
   );
 
   return (
-    <>
-      <div>Slug</div>
-      <primitives.PopoverWrapper
-        className="min-w-[310px] z-20 p-6 pb-4"
-        skip={slugs.length === 0}
-        content={cardContent}
-      >
-        <div className="flex flex-col items-right">
-          <div
-            className={classNames('text-right', { 'underline cursor-pointer': canEdit })}
-            onClick={handleAddFirstSlug}
+    <div className="w-full min-w-0">
+      <DetailFieldEditorShell value={slug}>
+        {canEdit ? (
+          <primitives.PopoverWrapper
+            className="min-w-[310px] z-20 p-6 pb-4"
+            skip={slugs.length === 0}
+            content={cardContent}
           >
-            {slug}
-            {canEdit && <SquarePen className="inline-block w-4 h-4 ml-[2px] mb-[2px]" />}
-          </div>
-          {fetcher.data?.error && <div className="text-xs text-red-600">{fetcher.data.error}</div>}
-        </div>
-      </primitives.PopoverWrapper>
-    </>
+            <DetailFieldEditorTrigger onClick={handleAddFirstSlug} />
+          </primitives.PopoverWrapper>
+        ) : null}
+      </DetailFieldEditorShell>
+      {fetcher.data?.error && <div className="text-xs text-red-600">{fetcher.data.error}</div>}
+    </div>
   );
 }

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/Slugs.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/Slugs.tsx
@@ -1,10 +1,19 @@
 import { useFetcher } from 'react-router';
-import { SquareCheckBig, Trash2, CirclePlus } from 'lucide-react';
-import classNames from 'classnames';
-import { formatDistanceToNow } from 'date-fns';
+import { useState } from 'react';
 import type { SlugsDTO } from './types.server.js';
-import { primitives } from '@curvenote/scms-core';
 import { DetailFieldEditorShell, DetailFieldEditorTrigger } from './DetailFieldEditor.js';
+import { SlugManagerDialog } from './SlugManagerDialog.js';
+import { ConfirmSlugActionDialog } from './ConfirmSlugActionDialog.js';
+import {
+  getDisplaySlug,
+  getSlugAddFieldError,
+  getSlugConfirmDialogError,
+  getSuggestedSlugDraft,
+  resolveSlugMutationOutcome,
+  validateSlugForAdd,
+  type SlugConfirmTarget,
+} from './SlugManagerDialog.utils.js';
+import { SUBMISSION_DETAIL_FORM_ACTIONS } from './SubmissionDetails.utils.js';
 
 export function getSlugSuggestion(site: { name: string }, doi?: string) {
   const secondPartOfDoi = doi?.split('/')[1];
@@ -31,166 +40,163 @@ export function Slugs({
   baseUrl,
 }: SlugsProps) {
   const fetcher = useFetcher<{ error?: string; slugs?: SlugsDTO }>();
-  const makeSuggestion = suggestion ? !slugs.find((s) => s.slug === suggestion) : false;
+  const [managerOpen, setManagerOpen] = useState(false);
+  const [confirmTarget, setConfirmTarget] = useState<SlugConfirmTarget | null>(null);
+  const [draftSlug, setDraftSlug] = useState('');
+  const [localError, setLocalError] = useState<string | undefined>();
+  const [awaitingResult, setAwaitingResult] = useState(false);
+  const [prevFetcherState, setPrevFetcherState] = useState(fetcher.state);
 
-  const handleAddFirstSlug = (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (slugs.length > 0) return;
-    handleAdd(e);
+  if (fetcher.state !== prevFetcherState) {
+    const outcome = resolveSlugMutationOutcome(fetcher.data);
+    if (awaitingResult && prevFetcherState !== 'idle' && fetcher.state === 'idle') {
+      if (outcome === 'success') {
+        const updatedSlugs = fetcher.data?.slugs ?? slugs;
+        setConfirmTarget(null);
+        setDraftSlug(getSuggestedSlugDraft(suggestion, updatedSlugs) ?? '');
+        setLocalError(undefined);
+        setAwaitingResult(false);
+      } else if (outcome === 'error') {
+        setAwaitingResult(false);
+      }
+    }
+    setPrevFetcherState(fetcher.state);
+  }
+
+  const displaySlug = getDisplaySlug(slugs, fallback);
+  const isSubmitting = fetcher.state !== 'idle';
+  const addSlugError = managerOpen
+    ? getSlugAddFieldError({
+        localError,
+        fetcherFormData: fetcher.formData,
+        fetcherError: fetcher.data?.error,
+      })
+    : undefined;
+  const confirmError = getSlugConfirmDialogError({
+    confirmTarget,
+    fetcherFormData: fetcher.formData,
+    fetcherError: fetcher.data?.error,
+  });
+
+  const handleDraftSlugChange = (value: string) => {
+    setDraftSlug(value);
+    if (localError) {
+      setLocalError(undefined);
+    }
   };
 
-  const handleAdd = (e: React.MouseEvent<HTMLElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
+  const handleManagerOpenChange = (nextOpen: boolean) => {
+    setManagerOpen(nextOpen);
+    if (!nextOpen) {
+      setConfirmTarget(null);
+      setDraftSlug('');
+      setLocalError(undefined);
+      setAwaitingResult(false);
+    }
+  };
 
-    if (!canEdit) return;
+  const handleConfirmOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setConfirmTarget(null);
+    }
+  };
 
-    const newSlug = prompt('Enter new slug (6 < 64 chars)', makeSuggestion ? suggestion : '');
-    if (!newSlug) return;
+  const handleOpenManager = () => {
+    setDraftSlug(getSuggestedSlugDraft(suggestion, slugs) ?? '');
+    setLocalError(undefined);
+    setManagerOpen(true);
+  };
 
-    const exists = slugs.find((s) => s.slug === newSlug);
-    if (exists) {
-      alert('slug already exists');
+  const handleAdd = () => {
+    const validationError = validateSlugForAdd(draftSlug, slugs);
+    if (validationError) {
+      setLocalError(validationError);
       return;
     }
 
+    setLocalError(undefined);
+    setAwaitingResult(true);
     fetcher.submit(
-      { slug: newSlug, formAction: 'slug-add', submission_id: submissionId, site_id: siteId },
+      {
+        slug: draftSlug.trim(),
+        formAction: SUBMISSION_DETAIL_FORM_ACTIONS.slugAdd,
+        submission_id: submissionId,
+        site_id: siteId,
+      },
       { method: 'POST' },
     );
   };
 
-  const handleRemove = (e: React.FormEvent<HTMLFormElement>, slug_id: string, slug: string) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    if (
-      confirm(
-        `Are you sure you want to remove "${slug}"? this break existing external links to the submission that use this slug.`,
-      ) === false
-    )
+  const handleConfirmAction = () => {
+    if (!confirmTarget) {
       return;
+    }
 
-    fetcher.submit({ slug_id, formAction: 'slug-remove' }, { method: 'POST' });
+    setLocalError(undefined);
+    setAwaitingResult(true);
+
+    if (confirmTarget.action === 'remove') {
+      fetcher.submit(
+        {
+          slug_id: confirmTarget.slugId,
+          formAction: SUBMISSION_DETAIL_FORM_ACTIONS.slugRemove,
+        },
+        { method: 'POST' },
+      );
+      return;
+    }
+
+    fetcher.submit(
+      {
+        slug_id: confirmTarget.slugId,
+        formAction: SUBMISSION_DETAIL_FORM_ACTIONS.slugSetPrimary,
+      },
+      { method: 'POST' },
+    );
   };
 
-  const handleSetPrimary = (e: React.FormEvent<HTMLFormElement>, slug_id: string, slug: string) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    if (
-      confirm(
-        `Are you sure you want to set "${slug}" as the primary slug? this will redirect all other slugs to here.`,
-      ) === false
-    )
-      return;
-
-    fetcher.submit({ slug_id, formAction: 'slug-set-primary' }, { method: 'POST' });
+  const handleRequestRemove = (slugId: string, slug: string) => {
+    setConfirmTarget({ action: 'remove', slugId, slug });
   };
 
-  const slug = slugs.find((s) => s.primary)?.slug ?? slugs[0]?.slug ?? fallback;
-
-  const tick = <SquareCheckBig className="inline-block w-4 h-4 mb-[2px] stroke-green-600" />;
-  const cardContent = (
-    <div className="text-md">
-      <table>
-        <thead>
-          <tr className="border-b-[1px] border-gray-500 bg-gray-100">
-            <th className="px-3 py-1 text-left">primary</th>
-            <th className="px-3 py-1 text-left">slug</th>
-            <th className="px-3 py-1 text-left">updated</th>
-            <th className="px-3 py-1 text-left align-text-bottom" title="set as primary">
-              <SquareCheckBig className="inline-block w-4 h-4" />
-            </th>
-            <th className="px-3 py-1 text-left align-text-bottom" title="remove slug">
-              <Trash2 className="inline-block w-4 h-4 opacity-80 hover:opacity-100" />
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {slugs.map((s) => {
-            const deleting =
-              fetcher.state === 'submitting' &&
-              fetcher.formData?.get('formAction') === 'slug-remove' &&
-              fetcher.formData?.get('slug_id') === s.id;
-            return (
-              <tr
-                key={s.id}
-                className={classNames('even:bg-gray-50', {
-                  'text-gray-500 line-through': deleting,
-                })}
-              >
-                <td className="px-3 py-1 text-center pointer-events-none">
-                  {s.primary && <>{tick}</>}
-                </td>
-                <td className="px-3 py-1 text-left">
-                  <a
-                    className="underline cursor-pointer"
-                    href={`${baseUrl}${s.slug}`}
-                    target="_blank"
-                    rel="noopener noreferer"
-                  >
-                    {s.slug}
-                  </a>
-                </td>
-                <td className="px-3 py-1 text-left pointer-events-none">
-                  {formatDistanceToNow(new Date(s.date_modified))} ago
-                </td>
-                <td className="px-3 py-1 text-center">
-                  <fetcher.Form onSubmit={(e) => handleSetPrimary(e, s.id, s.slug)}>
-                    <button className="align-text-bottom" type="submit" title="set as primary">
-                      <SquareCheckBig className="inline-block w-4 h-4 opacity-80 hover:opacity-100" />
-                    </button>
-                  </fetcher.Form>
-                </td>
-                <td className="px-3 py-1 text-center">
-                  <fetcher.Form onSubmit={(e) => handleRemove(e, s.id, s.slug)}>
-                    <button className="align-text-bottom" type="submit" title="remove slug">
-                      <Trash2 className="inline-block w-4 h-4 opacity-80 hover:opacity-100" />
-                    </button>
-                  </fetcher.Form>
-                </td>
-              </tr>
-            );
-          })}
-          <tr className="even:bg-gray-50">
-            <td className="px-3 py-1 text-center">{slugs.length === 0 && <>{tick}</>}</td>
-            <td className="px-3 py-1 text-left underline">
-              <a
-                className="underline cursor-pointer"
-                href={`${baseUrl}${fallback}`}
-                target="_blank"
-                rel="noopener noreferer"
-              >
-                {fallback}
-              </a>
-            </td>
-            <td className="px-3 py-1 text-left text-gray-400">default</td>
-            <td></td>
-            <td></td>
-          </tr>
-        </tbody>
-      </table>
-      <div className="pt-2 text-right *:align-middle cursor-pointer" onClick={handleAdd}>
-        <CirclePlus className="inline-block w-4 h-4 mr-1" />
-        <span className="underline">Add A Slug</span>
-      </div>
-    </div>
-  );
+  const handleRequestSetPrimary = (slugId: string, slug: string) => {
+    setConfirmTarget({ action: 'primary', slugId, slug });
+  };
 
   return (
     <div className="w-full min-w-0">
-      <DetailFieldEditorShell value={slug}>
-        {canEdit ? (
-          <primitives.PopoverWrapper
-            className="min-w-[310px] z-20 p-6 pb-4"
-            skip={slugs.length === 0}
-            content={cardContent}
-          >
-            <DetailFieldEditorTrigger onClick={handleAddFirstSlug} />
-          </primitives.PopoverWrapper>
-        ) : null}
+      <DetailFieldEditorShell value={displaySlug}>
+        {canEdit && <DetailFieldEditorTrigger title="Manage slugs" onClick={handleOpenManager} />}
       </DetailFieldEditorShell>
-      {fetcher.data?.error && <div className="text-xs text-red-600">{fetcher.data.error}</div>}
+      {canEdit && (
+        <>
+          <SlugManagerDialog
+            open={managerOpen}
+            onOpenChange={handleManagerOpenChange}
+            slugs={slugs}
+            fallback={fallback}
+            baseUrl={baseUrl}
+            draftSlug={draftSlug}
+            onDraftSlugChange={handleDraftSlugChange}
+            addSlugError={addSlugError}
+            isSubmitting={isSubmitting}
+            onAdd={handleAdd}
+            onRequestRemove={handleRequestRemove}
+            onRequestSetPrimary={handleRequestSetPrimary}
+          />
+          {confirmTarget && (
+            <ConfirmSlugActionDialog
+              open
+              onOpenChange={handleConfirmOpenChange}
+              action={confirmTarget.action}
+              slug={confirmTarget.slug}
+              isSubmitting={isSubmitting}
+              error={confirmError}
+              onConfirm={handleConfirmAction}
+            />
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.tsx
@@ -1,29 +1,101 @@
-import {
-  primitives,
-  clientCheckSiteScopes,
-  formatDate,
-  SectionWithHeading,
-  scopes,
-} from '@curvenote/scms-core';
-import type { SiteContext } from '@curvenote/scms-server';
-import { SquareCheckBig, ExternalLink, Eye, FileText } from 'lucide-react';
+import { primitives, clientCheckSiteScopes, formatDate, scopes, cn } from '@curvenote/scms-core';
+import { SquareCheckBig, ExternalLink, Eye } from 'lucide-react';
 import classNames from 'classnames';
-import type {
-  SubmissionDetailSlugRow,
-  SubmissionDetailSiteContext,
-  SubmissionDetailSubmission,
-  SubmissionDetailVersion,
-  SubmissionEditorCollection,
-} from './types.js';
+import type { ReactNode } from 'react';
 import { Slugs, getSlugSuggestion } from './Slugs.js';
 import { Kinds } from './Kinds.js';
 import { buildUrl } from 'doi-utils';
 import { useLoaderData } from 'react-router';
 import { Collections } from './Collections.js';
 import { PublicationDate } from './PublicationDate.js';
-import type { Workflow } from '@curvenote/scms-core';
+import type { SubmissionDetailPageData } from './loader.server.js';
+import {
+  emptyDetailValue,
+  getStatusBanners,
+  versionCountLabel,
+  type StatusBanner,
+} from './SubmissionDetails.utils.js';
 
-export function SubmissionDetails({ baseUrl }: { baseUrl?: string }) {
+type DetailRowProps = {
+  label: string;
+  children: ReactNode;
+  labelClassName?: string;
+};
+
+type StatusBannerRowProps = {
+  banner: StatusBanner;
+};
+
+type SubmissionDetailsProps = {
+  baseUrl?: string;
+};
+
+function DetailRow({ label, children, labelClassName }: DetailRowProps) {
+  return (
+    <div className="flex flex-col gap-1 px-4 py-3 border-b border-border last:border-b-0 md:flex-row md:items-center md:gap-4 md:px-6">
+      <div className={cn('text-sm shrink-0 text-foreground md:w-44 lg:w-48', labelClassName)}>
+        {label}
+      </div>
+      <div className="flex gap-2 items-center min-w-0 flex-1">{children}</div>
+    </div>
+  );
+}
+
+function StatusBannerRow({ banner }: StatusBannerRowProps) {
+  if (banner.kind === 'published') {
+    return (
+      <div
+        className="flex flex-wrap gap-x-2 gap-y-1 items-center px-4 py-3 text-sm border-b bg-success/10 border-border text-foreground md:px-6"
+        title="view latest published"
+      >
+        <SquareCheckBig
+          className="inline-block w-4 h-4 stroke-[3px] stroke-success shrink-0 align-text-bottom"
+          aria-hidden
+        />
+        <span className="break-words">
+          Version created {formatDate(banner.dateCreated, 'MMMM dd, y HH:ss')} is{' '}
+          <strong>Published</strong>
+        </span>
+        <a
+          href={banner.href}
+          className="inline-flex gap-1 items-center text-primary hover:underline"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          view latest
+          <ExternalLink className="inline-block w-4 h-4 shrink-0" aria-hidden />
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-wrap gap-x-2 gap-y-1 items-center px-4 py-3 text-sm border-b bg-warning/10 border-border text-foreground md:px-6"
+      title={`open preview for version ${formatDate(banner.dateCreated, 'MMMM dd, y HH:ss')}`}
+    >
+      <Eye
+        className="inline-block w-4 h-4 stroke-[2px] stroke-warning shrink-0 align-text-bottom"
+        aria-hidden
+      />
+      <span className="break-words">
+        {formatDate(banner.dateCreated, 'MMMM dd, y HH:ss')} version is{' '}
+        <strong className="capitalize">{banner.statusLabel}</strong>
+      </span>
+      <a
+        href={banner.href}
+        className="inline-flex gap-1 items-center text-primary hover:underline"
+        target="_blank"
+        rel="noreferrer noopener"
+      >
+        (preview
+        <ExternalLink className="inline-block w-4 h-4 shrink-0" aria-hidden />)
+      </a>
+    </div>
+  );
+}
+
+export function SubmissionDetails({ baseUrl }: SubmissionDetailsProps) {
   const {
     userScopes,
     submission,
@@ -33,18 +105,7 @@ export function SubmissionDetails({ baseUrl }: { baseUrl?: string }) {
     slugs,
     collections,
     workflow,
-  } = useLoaderData() as {
-    user: SiteContext['user'];
-    userScopes: string[];
-    submission: SubmissionDetailSubmission;
-    submissionVersions: SubmissionDetailVersion[];
-    site: SubmissionDetailSiteContext;
-    signature: string;
-    slugs: SubmissionDetailSlugRow[];
-    collections: SubmissionEditorCollection[];
-    workflow: Workflow;
-    poll: boolean;
-  };
+  } = useLoaderData<SubmissionDetailPageData>();
 
   let activeVersionIndex = submissionVersions.findIndex(
     (version) => version.id === submission.active_version_id,
@@ -53,19 +114,11 @@ export function SubmissionDetails({ baseUrl }: { baseUrl?: string }) {
   const activeVersion = submissionVersions[activeVersionIndex];
   const currentState = workflow.states[activeVersion.status];
   const hasActiveNotPublished = !currentState?.published;
-  const previewUrl = hasActiveNotPublished
-    ? `${baseUrl}/previews/${activeVersion.id}?preview=${signature}`
-    : undefined;
 
-  // note relies on backend returning sorted versions, with most recent first
   const published = submission.published_version_id
     ? submissionVersions.find((v) => v.id === submission.published_version_id)
     : undefined;
   const datePublished = submission.date_published;
-  const hasPublished = !!published;
-
-  // TODO this can fall back to submission.work_id once that is in place
-  const publishedUrl = `${baseUrl}/articles/${submission.slug ?? published?.site_work.id}`;
 
   const doi = activeVersion.site_work.doi;
 
@@ -77,129 +130,92 @@ export function SubmissionDetails({ baseUrl }: { baseUrl?: string }) {
 
   const canUpdate = clientCheckSiteScopes(userScopes, [scopes.site.submissions.update], site.name);
 
+  const statusBanners = getStatusBanners({
+    baseUrl,
+    signature,
+    activeVersion,
+    activeStatusLabel: currentState?.label ?? activeVersion.status,
+    hasActiveNotPublished,
+    publishedVersion: published,
+    submissionSlug: submission.slug,
+  });
+
   return (
-    <SectionWithHeading heading="Submission Details" icon={FileText}>
-      <primitives.Card lift className="p-8">
-        <div className="space-y-4">
-          {hasActiveNotPublished && (
-            <div
-              className="space-x-1"
-              title={`open preview for version ${formatDate(activeVersion.date_created, 'hh:mm MMMM dd, y')}`}
+    <div>
+      <div className="flex justify-between items-center mb-3">
+        <span className="text-xs tracking-wider uppercase text-muted-foreground">
+          SUBMISSION DETAILS
+        </span>
+        <span className="text-sm text-muted-foreground">
+          {versionCountLabel(submissionVersions.length)}
+        </span>
+      </div>
+
+      <primitives.Card lift className="overflow-hidden p-0 rounded-md">
+        {statusBanners.map((banner) => (
+          <StatusBannerRow key={banner.kind} banner={banner} />
+        ))}
+
+        <DetailRow label="Publication Date">
+          <PublicationDate
+            submissionId={submission.id}
+            datePublished={datePublished}
+            canUpdate={canUpdate}
+          />
+        </DetailRow>
+
+        <DetailRow
+          label="Collection"
+          labelClassName={classNames({
+            'font-semibold text-destructive': !submissionCollectionMatch,
+          })}
+        >
+          <Collections
+            submissionId={submission.id}
+            collectionId={submission.collection.id}
+            collections={collections}
+            canUpdate={canUpdate}
+          />
+        </DetailRow>
+
+        <DetailRow label="Submission Kind">
+          <Kinds
+            submissionId={submission.id}
+            collection={referenceCollection!}
+            kindId={submission.kind.id}
+            kindNameOrTitle={submission.kind.content?.title ?? submission.kind.name}
+            canUpdate={canUpdate}
+          />
+        </DetailRow>
+
+        <DetailRow label="Slug">
+          <Slugs
+            siteId={site.id}
+            submissionId={submission.id}
+            slugs={slugs}
+            fallback={activeVersion.site_work.id}
+            canEdit={canUpdate}
+            suggestion={slugSuggestion}
+            baseUrl={`${baseUrl}/articles/`}
+          />
+        </DetailRow>
+
+        <DetailRow label="DOI">
+          {doi ? (
+            <a
+              href={buildUrl(doi)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex gap-1 items-center text-sm break-all text-primary hover:underline"
             >
-              <Eye className="inline-block w-5 h-5 stroke-[2px] stroke-orange-500 align-text-bottom" />{' '}
-              {formatDate(activeVersion.date_created, 'MMMM dd, y HH:ss')} version is{' '}
-              {currentState?.label ?? activeVersion.status}{' '}
-              <a
-                href={previewUrl}
-                className="inline-block -mt-[2px] first-letter:cursor-pointer"
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                (
-                <span className="underline">
-                  preview
-                  <ExternalLink className="inline-block w-4 h-4 align-middle ml-[2px] mb-[2px]" />
-                </span>
-                )
-              </a>
-            </div>
+              {doi}
+              <ExternalLink className="inline-block w-4 h-4 shrink-0" aria-hidden />
+            </a>
+          ) : (
+            <span className="text-sm text-muted-foreground">{emptyDetailValue()}</span>
           )}
-          {hasPublished && (
-            <div className="space-x-1" title="view latest published">
-              <SquareCheckBig className="inline-block w-5 h-5 stroke-[3px] stroke-green-700 align-text-bottom" />{' '}
-              Version created {formatDate(published.date_created, 'MMMM dd, y HH:ss')} is PUBLISHED
-              <a
-                href={publishedUrl}
-                className="inline-block -mt-[2px] cursor-pointer"
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                (<span className="underline">view latest</span>
-                <ExternalLink className="inline-block w-4 h-4 align-middle ml-[2px] mb-[2px]" />)
-              </a>
-            </div>
-          )}
-          <div>
-            {submissionVersions.length} Version
-            <span>{submissionVersions.length !== 1 ? 's' : ''}</span>
-          </div>
-          <div className="flex justify-between">
-            <div
-              className=""
-              title="The publication date, set manually or based on the original published version"
-            >
-              Publication Date
-            </div>
-            <PublicationDate
-              submissionId={submission.id}
-              datePublished={datePublished}
-              canUpdate={canUpdate}
-            />
-          </div>
-          <div
-            className={classNames('flex justify-between', {
-              'font-semibold text-red-500': !submissionCollectionMatch,
-            })}
-          >
-            <div className="">Collection</div>
-            <Collections
-              submissionId={submission.id}
-              collectionId={submission.collection.id}
-              collections={collections}
-              canUpdate={canUpdate}
-            />
-          </div>
-          <div className={classNames('flex justify-between')}>
-            <div className="">Submission Kind</div>
-            <Kinds
-              submissionId={submission.id}
-              collection={referenceCollection!}
-              kindId={submission.kind.id}
-              kindNameOrTitle={submission.kind.content?.title ?? submission.kind.name}
-              canUpdate={canUpdate}
-            />
-          </div>
-          <div className="flex justify-between">
-            <Slugs
-              siteId={site.id}
-              submissionId={submission.id}
-              slugs={slugs}
-              fallback={activeVersion.site_work.id}
-              canEdit={clientCheckSiteScopes(
-                userScopes,
-                [scopes.site.submissions.update],
-                site.name,
-              )}
-              suggestion={slugSuggestion}
-              baseUrl={`${baseUrl}/articles/`}
-            />
-          </div>
-          <div className="flex justify-between">
-            <div className="">DOI</div>
-            {doi ? (
-              <p>
-                <a
-                  href={buildUrl(doi)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline"
-                >
-                  {doi}
-                  <ExternalLink className="inline-block w-4 h-4 align-middle ml-[2px] mb-[2px]" />
-                </a>
-              </p>
-            ) : (
-              <p className="text-gray-500">none</p>
-            )}
-          </div>
-          <div className="flex justify-between">
-            <div className="text-gray-500">MyST Project Key</div>
-            <p className={classNames('text-gray-500')}>
-              {submissionVersions?.[0]?.site_work.key ?? 'none'}
-            </p>
-          </div>
-        </div>
+        </DetailRow>
       </primitives.Card>
-    </SectionWithHeading>
+    </div>
   );
 }

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.tsx
@@ -181,7 +181,7 @@ export function SubmissionDetails({ baseUrl }: SubmissionDetailsProps) {
         <DetailRow label="Submission Kind">
           <Kinds
             submissionId={submission.id}
-            collection={referenceCollection!}
+            collection={referenceCollection}
             kindId={submission.kind.id}
             kindNameOrTitle={submission.kind.content?.title ?? submission.kind.name}
             canUpdate={canUpdate}

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.tsx
@@ -15,6 +15,7 @@ import {
   versionCountLabel,
   type StatusBanner,
 } from './SubmissionDetails.utils.js';
+import { formatPublicationDate } from '../../publicationDateCalendar.js';
 
 type DetailRowProps = {
   label: string;
@@ -78,7 +79,7 @@ function StatusBannerRow({ banner }: StatusBannerRowProps) {
         className="inline-block w-4 h-4 stroke-[2px] stroke-warning shrink-0 align-text-bottom"
         aria-hidden
       />
-      <span className="break-words">
+      <span className="wrap-break-word">
         {formatDate(banner.dateCreated, 'MMMM dd, y HH:ss')} version is{' '}
         <strong className="capitalize">{banner.statusLabel}</strong>
       </span>
@@ -143,7 +144,7 @@ export function SubmissionDetails({ baseUrl }: SubmissionDetailsProps) {
   return (
     <div>
       <div className="flex justify-between items-center mb-3">
-        <span className="text-xs tracking-wider uppercase text-muted-foreground">
+        <span className="text-xs font-medium tracking-wider uppercase text-muted-foreground">
           SUBMISSION DETAILS
         </span>
         <span className="text-sm text-muted-foreground">
@@ -159,7 +160,7 @@ export function SubmissionDetails({ baseUrl }: SubmissionDetailsProps) {
         <DetailRow label="Publication Date">
           <PublicationDate
             submissionId={submission.id}
-            datePublished={datePublished}
+            datePublished={datePublished ? formatPublicationDate(datePublished) : undefined}
             canUpdate={canUpdate}
           />
         </DetailRow>

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.tsx
@@ -1,5 +1,12 @@
-import { primitives, clientCheckSiteScopes, formatDate, scopes, cn } from '@curvenote/scms-core';
-import { SquareCheckBig, ExternalLink, Eye } from 'lucide-react';
+import {
+  primitives,
+  clientCheckSiteScopes,
+  formatDate,
+  scopes,
+  cn,
+  getStatusBannerTone,
+} from '@curvenote/scms-core';
+import { SquareCheckBig, ExternalLink } from 'lucide-react';
 import classNames from 'classnames';
 import type { ReactNode } from 'react';
 import { Slugs, getSlugSuggestion } from './Slugs.js';
@@ -53,7 +60,7 @@ function StatusBannerRow({ banner }: StatusBannerRowProps) {
           className="inline-block w-4 h-4 stroke-[3px] stroke-success shrink-0 align-text-bottom"
           aria-hidden
         />
-        <span className="break-words">
+        <span className="wrap-break-word">
           Version created {formatDate(banner.dateCreated, 'MMMM dd, y HH:ss')} is{' '}
           <strong>Published</strong>
         </span>
@@ -70,15 +77,16 @@ function StatusBannerRow({ banner }: StatusBannerRowProps) {
     );
   }
 
+  const tone = getStatusBannerTone(banner.status);
+
   return (
     <div
-      className="flex flex-wrap gap-x-2 gap-y-1 items-center px-4 py-3 text-sm border-b bg-warning/10 border-border text-foreground md:px-6"
+      className={cn(
+        'flex flex-wrap gap-x-2 gap-y-1 items-center px-4 py-3 text-sm border-b border-border text-foreground md:px-6',
+        tone === 'pending' ? 'bg-warning/10' : 'bg-muted/40',
+      )}
       title={`open preview for version ${formatDate(banner.dateCreated, 'MMMM dd, y HH:ss')}`}
     >
-      <Eye
-        className="inline-block w-4 h-4 stroke-[2px] stroke-warning shrink-0 align-text-bottom"
-        aria-hidden
-      />
       <span className="wrap-break-word">
         {formatDate(banner.dateCreated, 'MMMM dd, y HH:ss')} version is{' '}
         <strong className="capitalize">{banner.statusLabel}</strong>

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.utils.spec.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.utils.spec.ts
@@ -1,0 +1,173 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import {
+  SUBMISSION_DETAIL_FORM_ACTIONS,
+  SUBMISSION_DETAIL_FIELDS,
+  emptyDetailValue,
+  getEditableFields,
+  getStatusBanners,
+  getVisibleDetailFields,
+  versionCountLabel,
+} from './SubmissionDetails.utils.js';
+
+describe('versionCountLabel', () => {
+  it('uses singular form for one version', () => {
+    expect(versionCountLabel(1)).toBe('1 version');
+  });
+
+  it('uses plural form for multiple versions', () => {
+    expect(versionCountLabel(2)).toBe('2 versions');
+    expect(versionCountLabel(5)).toBe('5 versions');
+  });
+});
+
+describe('emptyDetailValue', () => {
+  it('returns the standard empty placeholder', () => {
+    expect(emptyDetailValue()).toBe('Not assigned');
+  });
+});
+
+describe('getVisibleDetailFields', () => {
+  it('lists the submission detail fields without mystProjectKey', () => {
+    expect(getVisibleDetailFields()).toEqual([
+      'publicationDate',
+      'collection',
+      'kind',
+      'slug',
+      'doi',
+    ]);
+    expect(getVisibleDetailFields()).not.toContain('mystProjectKey');
+  });
+});
+
+describe('getEditableFields', () => {
+  it('returns no editable fields when updates are not allowed', () => {
+    expect(getEditableFields(false)).toEqual([]);
+  });
+
+  it('returns editable fields when updates are allowed', () => {
+    expect(getEditableFields(true)).toEqual(['publicationDate', 'collection', 'kind', 'slug']);
+    expect(getEditableFields(true)).not.toContain('doi');
+    expect(getEditableFields(true)).not.toContain('mystProjectKey');
+  });
+});
+
+describe('SUBMISSION_DETAIL_FORM_ACTIONS', () => {
+  it('preserves the edit action contract', () => {
+    expect(SUBMISSION_DETAIL_FORM_ACTIONS).toEqual({
+      setDatePublished: 'set-date-published',
+      setCollection: 'set-collection',
+      setKind: 'set-kind',
+      slugAdd: 'slug-add',
+      slugRemove: 'slug-remove',
+      slugSetPrimary: 'slug-set-primary',
+    });
+  });
+});
+
+describe('SUBMISSION_DETAIL_FIELDS', () => {
+  it('exposes field keys used by the detail card', () => {
+    expect(SUBMISSION_DETAIL_FIELDS.publicationDate).toBe('publicationDate');
+    expect(SUBMISSION_DETAIL_FIELDS.doi).toBe('doi');
+    expect(SUBMISSION_DETAIL_FIELDS).not.toHaveProperty('mystProjectKey');
+  });
+});
+
+describe('getStatusBanners', () => {
+  const baseUrl = 'https://example.com';
+  const signature = 'sig-123';
+  const activeVersion = {
+    id: 'version-active',
+    date_created: '2022-05-20T14:00:00.000Z',
+    status: 'IN_REVIEW',
+  };
+  const publishedVersion = {
+    id: 'version-published',
+    date_created: '2022-05-11T01:00:00.000Z',
+    site_work: { id: 'work-published' },
+  };
+
+  it('returns only a published banner when the active version is published', () => {
+    const result = getStatusBanners({
+      baseUrl,
+      signature,
+      activeVersion: { ...activeVersion, status: 'PUBLISHED' },
+      activeStatusLabel: 'PUBLISHED',
+      hasActiveNotPublished: false,
+      publishedVersion,
+      submissionSlug: 'nn00000',
+    });
+
+    expect(result).toEqual([
+      {
+        kind: 'published',
+        dateCreated: '2022-05-11T01:00:00.000Z',
+        href: 'https://example.com/articles/nn00000',
+      },
+    ]);
+  });
+
+  it('returns only a preview banner when the active version is not published', () => {
+    const result = getStatusBanners({
+      baseUrl,
+      signature,
+      activeVersion,
+      activeStatusLabel: 'In Review',
+      hasActiveNotPublished: true,
+      publishedVersion: undefined,
+      submissionSlug: undefined,
+    });
+
+    expect(result).toEqual([
+      {
+        kind: 'preview',
+        dateCreated: '2022-05-20T14:00:00.000Z',
+        statusLabel: 'In Review',
+        href: 'https://example.com/previews/version-active?preview=sig-123',
+      },
+    ]);
+  });
+
+  it('returns published then preview when both states apply', () => {
+    const result = getStatusBanners({
+      baseUrl,
+      signature,
+      activeVersion,
+      activeStatusLabel: 'In Review',
+      hasActiveNotPublished: true,
+      publishedVersion,
+      submissionSlug: 'nn00000',
+    });
+
+    expect(result).toEqual([
+      {
+        kind: 'published',
+        dateCreated: '2022-05-11T01:00:00.000Z',
+        href: 'https://example.com/articles/nn00000',
+      },
+      {
+        kind: 'preview',
+        dateCreated: '2022-05-20T14:00:00.000Z',
+        statusLabel: 'In Review',
+        href: 'https://example.com/previews/version-active?preview=sig-123',
+      },
+    ]);
+  });
+
+  it('falls back to the published work id when no slug is set', () => {
+    const result = getStatusBanners({
+      baseUrl,
+      signature,
+      activeVersion: { ...activeVersion, status: 'PUBLISHED' },
+      activeStatusLabel: 'PUBLISHED',
+      hasActiveNotPublished: false,
+      publishedVersion,
+      submissionSlug: undefined,
+    });
+
+    expect(result[0]).toMatchObject({
+      kind: 'published',
+      href: 'https://example.com/articles/work-published',
+    });
+  });
+});

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.utils.spec.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.utils.spec.ts
@@ -122,6 +122,7 @@ describe('getStatusBanners', () => {
       {
         kind: 'preview',
         dateCreated: '2022-05-20T14:00:00.000Z',
+        status: 'IN_REVIEW',
         statusLabel: 'In Review',
         href: 'https://example.com/previews/version-active?preview=sig-123',
       },
@@ -148,6 +149,7 @@ describe('getStatusBanners', () => {
       {
         kind: 'preview',
         dateCreated: '2022-05-20T14:00:00.000Z',
+        status: 'IN_REVIEW',
         statusLabel: 'In Review',
         href: 'https://example.com/previews/version-active?preview=sig-123',
       },

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.utils.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.utils.ts
@@ -29,6 +29,7 @@ export type StatusBanner =
   | {
       kind: 'preview';
       dateCreated: string;
+      status: string;
       statusLabel: string;
       href: string;
     };
@@ -102,6 +103,7 @@ export function getStatusBanners({
     banners.push({
       kind: 'preview',
       dateCreated: activeVersion.date_created,
+      status: activeVersion.status,
       statusLabel: activeStatusLabel,
       href: `${baseUrl}/previews/${activeVersion.id}?preview=${signature}`,
     });

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.utils.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionDetails.utils.ts
@@ -1,0 +1,111 @@
+export const SUBMISSION_DETAIL_FORM_ACTIONS = {
+  setDatePublished: 'set-date-published',
+  setCollection: 'set-collection',
+  setKind: 'set-kind',
+  slugAdd: 'slug-add',
+  slugRemove: 'slug-remove',
+  slugSetPrimary: 'slug-set-primary',
+} as const;
+
+export const SUBMISSION_DETAIL_FIELDS = {
+  publicationDate: 'publicationDate',
+  collection: 'collection',
+  kind: 'kind',
+  slug: 'slug',
+  doi: 'doi',
+} as const;
+
+export type SubmissionDetailFieldKey =
+  (typeof SUBMISSION_DETAIL_FIELDS)[keyof typeof SUBMISSION_DETAIL_FIELDS];
+
+export type SubmissionDetailEditableFieldKey = Exclude<SubmissionDetailFieldKey, 'doi'>;
+
+export type StatusBanner =
+  | {
+      kind: 'published';
+      dateCreated: string;
+      href: string;
+    }
+  | {
+      kind: 'preview';
+      dateCreated: string;
+      statusLabel: string;
+      href: string;
+    };
+
+type StatusBannerInput = {
+  baseUrl?: string;
+  signature: string;
+  activeVersion: {
+    id: string;
+    date_created: string;
+    status: string;
+  };
+  activeStatusLabel: string;
+  hasActiveNotPublished: boolean;
+  publishedVersion?: {
+    id: string;
+    date_created: string;
+    site_work: { id: string };
+  };
+  submissionSlug?: string;
+};
+
+export function versionCountLabel(count: number): string {
+  return count === 1 ? '1 version' : `${count} versions`;
+}
+
+export function emptyDetailValue(): string {
+  return 'Not assigned';
+}
+
+export function getVisibleDetailFields(): SubmissionDetailFieldKey[] {
+  return [
+    SUBMISSION_DETAIL_FIELDS.publicationDate,
+    SUBMISSION_DETAIL_FIELDS.collection,
+    SUBMISSION_DETAIL_FIELDS.kind,
+    SUBMISSION_DETAIL_FIELDS.slug,
+    SUBMISSION_DETAIL_FIELDS.doi,
+  ];
+}
+
+export function getEditableFields(canUpdate: boolean): SubmissionDetailEditableFieldKey[] {
+  if (!canUpdate) return [];
+  return [
+    SUBMISSION_DETAIL_FIELDS.publicationDate,
+    SUBMISSION_DETAIL_FIELDS.collection,
+    SUBMISSION_DETAIL_FIELDS.kind,
+    SUBMISSION_DETAIL_FIELDS.slug,
+  ];
+}
+
+export function getStatusBanners({
+  baseUrl,
+  signature,
+  activeVersion,
+  activeStatusLabel,
+  hasActiveNotPublished,
+  publishedVersion,
+  submissionSlug,
+}: StatusBannerInput): StatusBanner[] {
+  const banners: StatusBanner[] = [];
+
+  if (publishedVersion) {
+    banners.push({
+      kind: 'published',
+      dateCreated: publishedVersion.date_created,
+      href: `${baseUrl}/articles/${submissionSlug ?? publishedVersion.site_work.id}`,
+    });
+  }
+
+  if (hasActiveNotPublished) {
+    banners.push({
+      kind: 'preview',
+      dateCreated: activeVersion.date_created,
+      statusLabel: activeStatusLabel,
+      href: `${baseUrl}/previews/${activeVersion.id}?preview=${signature}`,
+    });
+  }
+
+  return banners;
+}

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionSummaryCard.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionSummaryCard.tsx
@@ -58,21 +58,24 @@ export function SubmissionSummaryCard({
           </div>
         ) : null}
 
-        <div className="flex flex-wrap gap-x-4 gap-y-1 items-center text-sm text-foreground">
-          {doi && doiHref ? (
-            <a
-              href={doiHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex gap-1 items-center hover:text-foreground hover:underline"
-            >
-              DOI {doi}
-              <ExternalLink className="w-3.5 h-3.5 shrink-0" aria-hidden />
-            </a>
-          ) : null}
-          {publishedOn ? (
+        <div className="flex flex-wrap gap-x-2 gap-y-1 items-baseline text-sm">
+          {doi && doiHref && (
+            <>
+              <span className="text-xs text-muted-foreground">DOI</span>
+              <a
+                href={doiHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs inline-flex gap-1 items-center font-mono text-muted-foreground hover:text-foreground hover:underline"
+              >
+                {doi}
+                <ExternalLink className="w-3 h-3 shrink-0" aria-hidden />
+              </a>
+            </>
+          )}
+          {publishedOn && (
             <div className="ml-auto text-xs text-muted-foreground">{publishedOn}</div>
-          ) : null}
+          )}
         </div>
       </div>
     </primitives.Card>

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionSummaryCard.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionSummaryCard.tsx
@@ -1,0 +1,83 @@
+import { ExternalLink } from 'lucide-react';
+import { primitives, ui } from '@curvenote/scms-core';
+import { authorInitials, getDoiHref, getNamedAuthors } from './SubmissionSummaryCard.utils.js';
+
+export type SubmissionSummaryCardProps = {
+  title: string;
+  description: string | undefined;
+  authors: { name: string }[];
+  publishedOn: string | undefined;
+  doi: string | undefined;
+};
+
+export function SubmissionSummaryCard({
+  title,
+  description,
+  authors,
+  publishedOn,
+  doi,
+}: SubmissionSummaryCardProps) {
+  const namedAuthors = getNamedAuthors(authors);
+  const doiHref = getDoiHref(doi);
+
+  return (
+    <primitives.Card lift className="p-8 rounded-md">
+      <div className="space-y-5">
+        <h3 title="submission title" className="text-2xl font-bold tracking-tight text-foreground">
+          {title}
+        </h3>
+
+        {namedAuthors.length > 0 ? (
+          <ul className="flex flex-wrap gap-x-4 gap-y-2">
+            {namedAuthors.map((author, index) => {
+              const initials = authorInitials(author.name);
+              return (
+                <li key={`${author.name}-${index}`} className="flex gap-2 items-center min-w-0">
+                  {initials ? (
+                    <ui.Avatar className="w-6 h-6">
+                      <ui.AvatarFallback className="text-[10px] font-medium text-muted-foreground">
+                        {initials}
+                      </ui.AvatarFallback>
+                    </ui.Avatar>
+                  ) : null}
+                  <span className="text-sm truncate text-foreground">{author.name}</span>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+
+        {description ? (
+          <div className="space-y-1.5">
+            <div className="text-xs font-semibold tracking-wide uppercase text-foreground">
+              Description
+            </div>
+            <p
+              title="submission description"
+              className="text-sm text-muted-foreground line-clamp-5 [mask-image:linear-gradient(to_bottom,black_65%,transparent)]"
+            >
+              {description}
+            </p>
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap gap-x-4 gap-y-1 items-center text-sm text-foreground">
+          {doi && doiHref ? (
+            <a
+              href={doiHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex gap-1 items-center hover:text-foreground hover:underline"
+            >
+              DOI {doi}
+              <ExternalLink className="w-3.5 h-3.5 shrink-0" aria-hidden />
+            </a>
+          ) : null}
+          {publishedOn ? (
+            <div className="ml-auto text-xs text-muted-foreground">{publishedOn}</div>
+          ) : null}
+        </div>
+      </div>
+    </primitives.Card>
+  );
+}

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionSummaryCard.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionSummaryCard.tsx
@@ -52,10 +52,7 @@ export function SubmissionSummaryCard({
             <div className="text-xs font-semibold tracking-wide uppercase text-foreground">
               Description
             </div>
-            <p
-              title="submission description"
-              className="text-sm text-muted-foreground line-clamp-5 [mask-image:linear-gradient(to_bottom,black_65%,transparent)]"
-            >
+            <p title="submission description" className="text-sm text-muted-foreground">
               {description}
             </p>
           </div>

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionSummaryCard.utils.spec.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionSummaryCard.utils.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, expect, it } from 'vitest';
 import { authorInitials, getDoiHref, getNamedAuthors } from './SubmissionSummaryCard.utils.js';
 

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionSummaryCard.utils.spec.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionSummaryCard.utils.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { authorInitials, getDoiHref, getNamedAuthors } from './SubmissionSummaryCard.utils.js';
+
+describe('authorInitials', () => {
+  it('uses first and last name initials for multi-word names', () => {
+    expect(authorInitials('Ada Lovelace')).toBe('AL');
+  });
+
+  it('uses the first two characters for single-word names', () => {
+    expect(authorInitials('Ada')).toBe('AD');
+  });
+
+  it('returns an empty string for whitespace-only names', () => {
+    expect(authorInitials('   ')).toBe('');
+  });
+
+  it('ignores extra whitespace between name parts', () => {
+    expect(authorInitials('  Grace   Hopper  ')).toBe('GH');
+  });
+});
+
+describe('getNamedAuthors', () => {
+  it('drops authors with empty or whitespace-only names', () => {
+    expect(
+      getNamedAuthors([
+        { name: 'Ada Lovelace' },
+        { name: '  ' },
+        { name: '' },
+        { name: 'Grace Hopper' },
+      ]),
+    ).toEqual([{ name: 'Ada Lovelace' }, { name: 'Grace Hopper' }]);
+  });
+
+  it('returns an empty array when authors is undefined', () => {
+    expect(getNamedAuthors(undefined)).toEqual([]);
+  });
+});
+
+describe('getDoiHref', () => {
+  it('builds a resolver URL when a DOI is provided', () => {
+    expect(getDoiHref('10.1234/example')).toBe('https://doi.org/10.1234/example');
+  });
+
+  it('returns undefined when no DOI is provided', () => {
+    expect(getDoiHref(undefined)).toBeUndefined();
+  });
+});

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionSummaryCard.utils.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionSummaryCard.utils.ts
@@ -1,0 +1,20 @@
+import { buildUrl } from 'doi-utils';
+
+export function authorInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) {
+    return '';
+  }
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase();
+  }
+  return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+}
+
+export function getNamedAuthors(authors: { name: string }[] | undefined): { name: string }[] {
+  return authors?.filter((author) => author.name.trim().length > 0) ?? [];
+}
+
+export function getDoiHref(doi: string | undefined): string | undefined {
+  return doi ? buildUrl(doi) : undefined;
+}

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionVersionTimeline.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/SubmissionVersionTimeline.tsx
@@ -275,11 +275,7 @@ function SubmissionVersionTimelineInner({
   }
 
   return (
-    <Timeline
-      title="TIMELINE"
-      titleClassName="text-sm font-medium uppercase tracking-wide"
-      headerAction={<TimelineActivitiesToggle />}
-    >
+    <Timeline title="TIMELINE" headerAction={<TimelineActivitiesToggle />}>
       {timelineSections.map((section) => {
         if (section.kind === 'submission-activity') {
           return (

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/route.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/route.tsx
@@ -4,7 +4,6 @@ import {
   clientCheckSiteScopes,
   error401,
   error404,
-  formatDate,
   PageFrame,
   useRevalidateOnInterval,
   useDeploymentConfig,
@@ -14,6 +13,7 @@ import {
   scopes,
 } from '@curvenote/scms-core';
 import { withAppSiteContext, userHasScope, assertUserDefined } from '@curvenote/scms-server';
+import { formatPublicationDate } from '../../publicationDateCalendar.js';
 import { loadSubmissionDetailPage } from './loader.server.js';
 import type { SubmissionDetailPageData } from './loader.server.js';
 import {
@@ -168,7 +168,7 @@ export default function SubmissionDetailRoute({
   ];
 
   const publishedOn = date_published
-    ? `Published on ${formatDate(date_published, 'd MMMM yyyy')}`
+    ? `Published on ${formatPublicationDate(date_published)}`
     : undefined;
 
   return (

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/route.tsx
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/route.tsx
@@ -1,14 +1,12 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
 import { data } from 'react-router';
 import {
-  primitives,
   clientCheckSiteScopes,
   error401,
   error404,
   formatDate,
   PageFrame,
   useRevalidateOnInterval,
-  SectionWithHeading,
   useDeploymentConfig,
   getBrandingFromMetaMatches,
   joinPageTitle,
@@ -35,7 +33,7 @@ import {
 import { useEffect, useState } from 'react';
 import { SubmissionDetails } from './SubmissionDetails.js';
 import { MagicLinks } from './MagicLinks.js';
-import { Info, MonitorPlay } from 'lucide-react';
+import { SubmissionSummaryCard } from './SubmissionSummaryCard.js';
 import { SubmissionVersionTimeline } from './SubmissionVersionTimeline.js';
 
 export const loader = async (args: LoaderFunctionArgs): Promise<SubmissionDetailPageData> => {
@@ -144,12 +142,11 @@ export default function SubmissionDetailRoute({
     workflow,
     poll,
     activeVersion,
-    activeVersionNumber,
     checkServiceRunsByWorkVersionId,
   } = loaderData;
 
-  const { kind, submitted_by, date_created, date_published } = submission;
-  const { title, description, authors } = activeVersion.site_work;
+  const { date_published } = submission;
+  const { title, description, authors, doi } = activeVersion.site_work;
 
   const [enabled, setEnabled] = useState(poll);
   useRevalidateOnInterval({ enabled, interval: 1000 });
@@ -170,62 +167,20 @@ export default function SubmissionDetailRoute({
     { label: title || submission.id, isCurrentPage: true },
   ];
 
+  const publishedOn = date_published
+    ? `Published on ${formatDate(date_published, 'd MMMM yyyy')}`
+    : undefined;
+
   return (
-    <PageFrame
-      title={
-        <>
-          Submission: <strong>{title}</strong>
-        </>
-      }
-      subtitle={`Manage the details for the submission to ${site.title}`}
-      breadcrumbs={breadcrumbs}
-    >
+    <PageFrame breadcrumbs={breadcrumbs}>
       <div className="mt-4 space-y-6 md:space-y-12">
-        <SectionWithHeading className="" heading="Social Media Card" icon={MonitorPlay}>
-          <primitives.Card lift className="p-8">
-            <div className="space-y-1">
-              <div className="flex relative flex-col pt-2 space-x-4 space-y-2 md:flex-row md:space-y-0">
-                <div>
-                  <primitives.Thumbnail
-                    className="min-w-[300px] min-h-[220px]"
-                    src={activeVersion.site_work.links.thumbnail}
-                    alt={title ?? ''}
-                  />
-                </div>
-                <div className="flex flex-col">
-                  <div className="font-light small-caps" title="kind">
-                    {kind.content.title ?? kind.name}
-                  </div>
-                  <h3 title="submission title">{title}</h3>
-                  <p title="submission description" className="text-sm">
-                    {description}
-                  </p>
-                  <div className="text-sm font-light pointer-events-none">
-                    {authors?.map((a) => a.name).join(', ') ?? ''}
-                  </div>
-                  <div className="text-sm font-light pointer-events-none">
-                    Publication Date: {date_published ? formatDate(date_published) : 'not set'}
-                  </div>
-                  <div className="grow"></div>
-                  <div className="absolute -top-4 -right-4">
-                    <primitives.HoverCardWrapper
-                      content={
-                        <p className="text-sm font-light text-gray-500">
-                          First submitted by {submitted_by.name} on{' '}
-                          {formatDate(date_created, 'MMMM dd, y')} at{' '}
-                          {formatDate(date_created, 'HH:mm')} - this summary is based on version #
-                          {activeVersionNumber}.
-                        </p>
-                      }
-                    >
-                      <Info className="w-4 h-4 text-gray-400" />
-                    </primitives.HoverCardWrapper>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </primitives.Card>
-        </SectionWithHeading>
+        <SubmissionSummaryCard
+          title={title}
+          description={description}
+          authors={authors}
+          publishedOn={publishedOn}
+          doi={doi}
+        />
         <SubmissionDetails baseUrl={config.renderServiceUrl ?? site.links.html} />
         <MagicLinks />
         <SubmissionVersionTimeline

--- a/ee/sites/src/routes/$siteName.submissions.$submissionId/useAttributeChangeDialog.ts
+++ b/ee/sites/src/routes/$siteName.submissions.$submissionId/useAttributeChangeDialog.ts
@@ -1,0 +1,62 @@
+import { useFetcher } from 'react-router';
+import { useState } from 'react';
+import {
+  type AttributeChangeFetcherOutcome,
+  getFetcherIdleDialogAction,
+} from './AttributeChangeDialog.utils.js';
+
+type UseAttributeChangeDialogOptions<TData> = {
+  resolveOutcome: (data: TData | undefined) => AttributeChangeFetcherOutcome;
+};
+
+type UseAttributeChangeDialogResult<TData> = {
+  open: boolean;
+  handleOpenChange: (nextOpen: boolean) => void;
+  beginSubmit: () => void;
+  fetcher: ReturnType<typeof useFetcher<TData>>;
+};
+
+export function useAttributeChangeDialog<TData>({
+  resolveOutcome,
+}: UseAttributeChangeDialogOptions<TData>): UseAttributeChangeDialogResult<TData> {
+  const fetcher = useFetcher<TData>();
+  const [open, setOpen] = useState(false);
+  const [awaitingResult, setAwaitingResult] = useState(false);
+  const [prevFetcherState, setPrevFetcherState] = useState(fetcher.state);
+
+  if (fetcher.state !== prevFetcherState) {
+    const action = getFetcherIdleDialogAction(
+      awaitingResult,
+      prevFetcherState,
+      fetcher.state,
+      resolveOutcome(fetcher.data as TData | undefined),
+    );
+
+    setPrevFetcherState(fetcher.state);
+
+    if (action?.closeDialog) {
+      setOpen(false);
+    }
+    if (action?.clearAwaiting) {
+      setAwaitingResult(false);
+    }
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setAwaitingResult(false);
+    }
+  };
+
+  const beginSubmit = () => {
+    setAwaitingResult(true);
+  };
+
+  return {
+    open,
+    handleOpenChange,
+    beginSubmit,
+    fetcher,
+  };
+}

--- a/ee/sites/src/routes/$siteName.submissions._index/SubmissionListingDates.tsx
+++ b/ee/sites/src/routes/$siteName.submissions._index/SubmissionListingDates.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { Calendar, Clock, Send } from 'lucide-react';
 import { formatDate, formatDatetime, formatToNow } from '@curvenote/scms-core';
+import { formatPublicationDate } from '../../publicationDateCalendar.js';
 
 function DateMetaSeparator() {
   return (
@@ -45,7 +46,7 @@ export function SubmissionListingDates({
       <DateMetaItem
         icon={<Calendar className="size-3.5" aria-hidden />}
         label="Publication Date:"
-        value={datePublished ? formatDate(datePublished) : 'n/a'}
+        value={datePublished ? formatPublicationDate(datePublished) : 'n/a'}
       />
       <DateMetaSeparator />
       <DateMetaItem

--- a/packages/scms-core/src/components/primitives/PopoverWrapper.tsx
+++ b/packages/scms-core/src/components/primitives/PopoverWrapper.tsx
@@ -3,14 +3,21 @@ import * as Popover from '@radix-ui/react-popover';
 import { X } from 'lucide-react';
 import classNames from 'classnames';
 
-export interface PopoverActions {
+export type PopoverActions = {
   closePopover: () => void;
-}
+};
+
+type PopoverWrapperProps = {
+  className?: string;
+  content: React.ReactNode;
+  skip?: boolean;
+  contentAlign?: 'start' | 'center' | 'end';
+};
 
 export const PopoverWrapper = React.forwardRef<
   PopoverActions,
-  React.PropsWithChildren<{ className?: string; content: React.ReactNode; skip?: boolean }>
->(({ className, content, children, skip }, ref) => {
+  React.PropsWithChildren<PopoverWrapperProps>
+>(({ className, content, children, skip, contentAlign = 'end' }, ref) => {
   const closeRef = useRef<HTMLButtonElement>(null);
   useImperativeHandle(ref, () => ({
     closePopover: () => {
@@ -27,6 +34,7 @@ export const PopoverWrapper = React.forwardRef<
             'rounded bg-white shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)] focus:shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)] will-change-[transform,opacity] data-[state=open]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[side=bottom]:animate-slideUpAndFade data-[state=open]:data-[side=left]:animate-slideRightAndFade',
             className,
           )}
+          align={contentAlign}
           sideOffset={5}
           onOpenAutoFocus={(e) => e.preventDefault()}
         >

--- a/packages/scms-core/src/components/timeline/Timeline.tsx
+++ b/packages/scms-core/src/components/timeline/Timeline.tsx
@@ -36,7 +36,7 @@ export function Timeline({
       {(title != null || headerAction != null) && (
         <div className="flex justify-between items-center mb-3">
           {title != null && (
-            <span className={cn('text-sm font-normal text-muted-foreground', titleClassName)}>
+            <span className={cn('text-xs font-medium text-muted-foreground uppercase tracking-wide', titleClassName)}>
               {title}
             </span>
           )}
@@ -45,7 +45,7 @@ export function Timeline({
       )}
       <div className="relative">
         <div
-          className={cn('absolute left-0 w-[2px] bg-foreground/20', lineTop, lineBottom)}
+          className={cn('absolute left-0 w-0.5 bg-foreground/20', lineTop, lineBottom)}
           aria-hidden
         />
         <div className={cn('space-y-6', nested && 'pt-5')}>{children}</div>

--- a/packages/scms-core/src/components/timeline/Timeline.tsx
+++ b/packages/scms-core/src/components/timeline/Timeline.tsx
@@ -36,7 +36,12 @@ export function Timeline({
       {(title != null || headerAction != null) && (
         <div className="flex justify-between items-center mb-3">
           {title != null && (
-            <span className={cn('text-xs font-medium text-muted-foreground uppercase tracking-wide', titleClassName)}>
+            <span
+              className={cn(
+                'text-xs font-medium text-muted-foreground uppercase tracking-wide',
+                titleClassName,
+              )}
+            >
               {title}
             </span>
           )}

--- a/packages/scms-core/src/utils/status.spec.ts
+++ b/packages/scms-core/src/utils/status.spec.ts
@@ -1,0 +1,22 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, it } from 'vitest';
+import { getStatusBannerTone } from './status.js';
+
+describe('getStatusBannerTone', () => {
+  it('treats pending as pending regardless of case', () => {
+    expect(getStatusBannerTone('PENDING')).toBe('pending');
+    expect(getStatusBannerTone('pending')).toBe('pending');
+  });
+
+  it('treats published as published regardless of case', () => {
+    expect(getStatusBannerTone('PUBLISHED')).toBe('published');
+    expect(getStatusBannerTone('Published')).toBe('published');
+  });
+
+  it('treats other statuses as neutral', () => {
+    expect(getStatusBannerTone('UNPUBLISHED')).toBe('neutral');
+    expect(getStatusBannerTone('IN_REVIEW')).toBe('neutral');
+    expect(getStatusBannerTone('REJECTED')).toBe('neutral');
+    expect(getStatusBannerTone(undefined)).toBe('neutral');
+  });
+});

--- a/packages/scms-core/src/utils/status.ts
+++ b/packages/scms-core/src/utils/status.ts
@@ -29,6 +29,18 @@ export function getStatusButtonClasses(status: string | undefined) {
   }
 }
 
+/** Semantic banner tone. Pending and published keep accent; other states are muted. */
+export function getStatusBannerTone(status: string | undefined) {
+  const normalized = status?.toUpperCase();
+  if (normalized === 'PENDING') {
+    return 'pending';
+  }
+  if (normalized === 'PUBLISHED') {
+    return 'published';
+  }
+  return 'neutral';
+}
+
 export function getStatusDotClasses(status: JobStatus | string) {
   switch (status) {
     case 'INCOMPLETE':


### PR DESCRIPTION
## Summary

Refreshes the site-admin submission details view ([CN-2417](https://linear.app/curvenote/issue/CN-2417/submission-details-page-refresh-site-admin-view)).

Site admins now get a dedicated summary card (title, authors, description, DOI, published date) and a cleaner details card for publication date, collection, kind, slug, and DOI. Inline popover/table editors are replaced with explicit edit actions and confirmable dialogs, so changing collection, kind, or slugs is harder to do by accident and easier to understand.

Business logic for banners, field contracts, attribute changes, and slug validation lives in `*.utils.ts` files next to the UI so those rules can be unit-tested without mounting React.

## What changed

### Summary card
The work title, authors (with initials), full description, DOI, and published date sit in their own card at the top of the page. This used to be mixed into the details layout; splitting it makes the admin view scannable and keeps bibliographic content separate from operational metadata.

### Details card
`SUBMISSION DETAILS` is now a labeled row layout (publication date, collection, kind, slug, DOI) with status banners for published / unpublished-preview versions. DOI stays read-only. Editable rows share `DetailFieldEditor` (value + pencil trigger) so the chrome is consistent.

Status banners keep **pending** orange and **published** green (with the check). Other states, including unpublished, use a muted row. The preview eye is gone: it sat in the same slot as the check but meant “you can preview”, not status. The preview link still covers that action.

### Collection and kind
Changing collection or kind opens a dialog instead of a popover table. Collection changes show a warning because the workflow/kind may no longer apply; kind changes use an informational callout. Confirm is disabled until a different option is selected.

### Slugs
Slug management is a dedicated dialog: list primary/other slugs, set primary, remove, and add. Remove and set-primary require a second confirmation that explains the URL impact. The work-id fallback slug is shown as default and is not removable.

### Publication date
The date editor is a calendar popover with Cancel/Save, aligned with the same pencil-trigger pattern as the other fields.

### Testing
Helpers were extracted so the rules can be tested independently of the UI:

- `SubmissionDetails.utils.ts` — visible/editable fields, version labels, status banner hrefs
- `SubmissionSummaryCard.utils.ts` — author initials, named authors, DOI href
- `AttributeChangeDialog.utils.ts` — option labels, optimistic titles, fetcher success/error
- `SlugManagerDialog.utils.ts` — display slug, add validation, confirm copy, mutation outcomes
- `getStatusBannerTone` — pending / published / muted (case-insensitive); classes stay in the component

Local verification: `bunx vitest run` on the submission-detail specs plus `packages/scms-core/src/utils/status.spec.ts`. Lint/format/compile for `@curvenote/scms-sites-ext` also passed (3 pre-existing unused-var warnings elsewhere in the package).

`@curvenote/scms-sites-ext` still has no `test` script, so these specs are not picked up by root `bun run test` / CI yet. They are in the tree and were run locally.

## Screenshots

### Overview — summary card + details card
Bibliographic content (title, authors, description, published date) is split from operational metadata. The details card uses labeled rows with pencil edit actions; DOI stays read-only. Status banners sit at the top of the details card.

<img width="1494" height="826" alt="Captura de pantalla 2026-08-26 a las 15 28 55" src="https://github.com/user-attachments/assets/d6369732-8bef-4ab9-8d82-8ec1fa67f658" />


### Change collection
Replaces the old popover table. The warning explains that a collection change can change the workflow and invalidate the current kind. Confirm stays disabled until another collection is selected.

<img width="1512" height="827" alt="Captura de pantalla 2026-08-26 a las 15 29 41" src="https://github.com/user-attachments/assets/392530b6-b73e-4fcb-8a96-79137ed47e54" />

### Change kind
Same dialog pattern with an informational callout. Confirm is disabled until a different kind is selected.

<img width="1512" height="829" alt="Captura de pantalla 2026-08-26 a las 15 29 49" src="https://github.com/user-attachments/assets/6eba1781-5d0f-4e86-bbd2-507fa445c0c9" />

### Manage slugs
Primary / other slugs, set-primary, remove, and add. The work-id fallback is shown as Default and is not removable.

<img width="1512" height="827" alt="Captura de pantalla 2026-08-26 a las 15 29 57" src="https://github.com/user-attachments/assets/a4a5-4a3b-8b45-a6e0c96e8c4c" />

### Remove slug confirmation
Destructive slug actions require a second confirm that explains the public-URL impact.

<img width="1510" height="828" alt="Captura de pantalla 2026-08-26 a las 15 30 08" src="https://github.com/user-attachments/assets/a0b836bc-b0d5-4e33-a210-946ca99ca820" />

## Test plan

- [x] Open a submission as a site admin: summary card shows title, authors, description, and published date
- [ ] Unpublished banner is muted (not pending orange); pending banner stays orange; published stays green with the check and no preview eye
- [x] Edit publication date via calendar → Save updates the row; Cancel leaves it unchanged
- [x] Change collection: warning callout, confirm disabled until another collection is selected, success closes the dialog
- [x] Change kind: info callout, same confirm/success behavior
- [x] Manage slugs: add a valid slug, reject invalid/short/duplicate, set primary, cancel a remove
- [x] DOI remains read-only
- [ ] User without `site.submissions.update` does not see edit triggers
- [x] If the current collection is missing from the available list, the details page still renders (kind row is read-only)


Made with [Cursor](https://cursor.com)