### PR TITLE
Add Cursor rule to wrap Tailwind class constants in cn()

### DIFF
--- a/.cursor/rules/tailwind-class-constants.mdc
+++ b/.cursor/rules/tailwind-class-constants.mdc
@@ -1,0 +1,24 @@
+---
+description: Wrap Tailwind class constants in cn() so class linters can see them
+globs: "**/*.{ts,tsx}"
+alwaysApply: false
+---
+
+# Tailwind Class Constants
+
+When Tailwind classes live in a constant (or any variable, not a JSX `className` literal), wrap them with `cn()` from `@curvenote/scms-core`.
+
+A future Tailwind class linter can inspect `cn()` (and JSX `className`) but will miss a plain string constant.
+
+```tsx
+// ❌ BAD — linter cannot see these classes
+const DESTRUCTIVE_SOFT_BUTTON_CLASS =
+  'bg-destructive/10 text-red-800 shadow-xs hover:bg-destructive/15';
+
+// ✅ GOOD
+const DESTRUCTIVE_SOFT_BUTTON_CLASS = cn(
+  'bg-destructive/10 text-red-800 shadow-xs hover:bg-destructive/15',
+);
+```
+
+Inline `className="..."` and `className={cn(...)}` in JSX are already visible to the linter; do not extract them only to wrap `cn()`. Extract + `cn()` when the class list is reused or too long for the JSX.


### PR DESCRIPTION
## Summary
- Adds a Cursor project rule so extracted Tailwind class strings are wrapped in `cn()`.
- Auto-attaches on `*.ts` / `*.tsx` (`alwaysApply: false` + globs), not on every conversation.

## Why
We do not use `eslint-plugin-tailwindcss` yet. This convention is so we can adopt it later without first having to wrap every class constant: the plugin can sort and organize class lists, catch conflicts, and flag invalid utilities, but it inspects JSX `className` and known helpers like `cn()`, not plain string constants.

## Test plan
- [ ] Confirm the rule appears under `.cursor/rules/tailwind-class-constants.mdc`
- [ ] In a TS/TSX edit, confirm the agent prefers `cn('...')` for class constants rather than a bare string