### PR TITLE
⚙️ enables deployers to specify a dashboard task order

### DIFF
--- a/.app-config.schema.yml
+++ b/.app-config.schema.yml
@@ -591,6 +591,14 @@ properties:
                       items:
                         type: string
                         pattern: '^[a-z0-9][a-z0-9 _-]*$'
+                    tasks:
+                      type: array
+                      description: >-
+                        Optional ordered list of task ids for explicit card order within this section
+                        (cross-category). Unlisted tasks that match categories append after, sorted by id.
+                      items:
+                        type: string
+                        minLength: 1
       renderServiceUrl:
         type: string
       workVersionPreviewUrl:

--- a/.changeset/dashboard-task-ordering.md
+++ b/.changeset/dashboard-task-ordering.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-core': minor
+'@curvenote/scms': minor
+---
+
+Add configurable dashboard task section ordering via deploy config, export shared `TaskCardNewBadge` for task cards, and align Check My Work NEW badge positioning.

--- a/packages/scms-core/src/modules/builtinTasks/AutomatedChecksTaskCard.tsx
+++ b/packages/scms-core/src/modules/builtinTasks/AutomatedChecksTaskCard.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router';
 import { Card } from '../../components/primitives/Card.js';
 import checksIllustration from './checks-illustration.svg';
+import { TaskCardNewBadge, TASK_CARD_TITLE_BADGE_PADDING } from './TaskCardNewBadge.js';
 
 export function AutomatedChecksTaskCard() {
   const navigate = useNavigate();
@@ -29,13 +30,9 @@ export function AutomatedChecksTaskCard() {
               height={73}
             />
           </div>
-          <div className="flex-1 text-left">
-            <h3 className="flex gap-1 items-center text-lg font-normal">
-              Check My Work{' '}
-              <span className="rounded-md bg-green-600 px-1.5 py-1 mb-1 text-[10px] font-medium leading-none text-white dark:bg-green-600">
-                NEW
-              </span>
-            </h3>
+          <div className={`relative flex-1 min-w-0 text-left ${TASK_CARD_TITLE_BADGE_PADDING}`}>
+            <TaskCardNewBadge className="absolute top-0 right-0" />
+            <h3 className="text-lg font-normal">Check My Work</h3>
             <p className="text-sm text-muted-foreground">
               Upload a draft and get automatic checks on its structure, text and figures.
             </p>

--- a/packages/scms-core/src/modules/builtinTasks/TaskCardNewBadge.tsx
+++ b/packages/scms-core/src/modules/builtinTasks/TaskCardNewBadge.tsx
@@ -1,0 +1,9 @@
+const badgeClassName =
+  'inline-flex shrink-0 items-center rounded-md bg-green-600 px-1.5 py-1 text-[10px] font-medium leading-none text-white dark:bg-green-600';
+
+export function TaskCardNewBadge({ className }: { className?: string }) {
+  return <span className={className ? `${badgeClassName} ${className}` : badgeClassName}>NEW</span>;
+}
+
+/** Reserve space for an absolutely positioned NEW badge in the top-right of the title block. */
+export const TASK_CARD_TITLE_BADGE_PADDING = 'pr-11';

--- a/packages/scms-core/src/modules/builtinTasks/index.ts
+++ b/packages/scms-core/src/modules/builtinTasks/index.ts
@@ -1,3 +1,4 @@
 export { BUILTIN_TASK_IDS } from './ids.js';
 export { BUILTIN_TASK_META, getAllowedBuiltinTaskIds } from './metadata.js';
 export { getBuiltinTasksWithComponents } from './registry.js';
+export { TaskCardNewBadge, TASK_CARD_TITLE_BADGE_PADDING } from './TaskCardNewBadge.js';

--- a/packages/scms-core/src/providers/DeploymentProvider.tsx
+++ b/packages/scms-core/src/providers/DeploymentProvider.tsx
@@ -27,10 +27,14 @@ export type WelcomeContent = {
 export type DashboardTaskSection = {
   title: string;
   categories: string[];
+  /** Explicit task card order within this section (cross-category). Unlisted eligible tasks append after, sorted by id. */
+  tasks?: string[];
 };
 
 export type DashboardTasksConfig = {
   enabled?: boolean;
+  /** Built-in dashboard task ids to enable (e.g. automated-checks). */
+  builtins?: string[];
   sections?: DashboardTaskSection[];
 };
 

--- a/platform/scms/app/root.tsx
+++ b/platform/scms/app/root.tsx
@@ -417,6 +417,8 @@ export const loader = async (args: Route.LoaderArgs) => {
     'dashboard.tasks.sections.*.title',
     'dashboard.tasks.sections.*.categories',
     'dashboard.tasks.sections.*.categories.*',
+    'dashboard.tasks.sections.*.tasks',
+    'dashboard.tasks.sections.*.tasks.*',
     'statusBar.reportProblem.email',
     'statusBar.reportProblem.subject',
     'statusBar.items',

--- a/platform/scms/app/routes/app/dashboard/route.tsx
+++ b/platform/scms/app/routes/app/dashboard/route.tsx
@@ -59,6 +59,62 @@ function sortTasks(tasks: TaskWithComponent[]): TaskWithComponent[] {
   return [...tasks].sort((a, b) => a.id.localeCompare(b.id) || a.name.localeCompare(b.name));
 }
 
+function collectSectionEligibleTasks(
+  categories: string[] | undefined,
+  tasksByCategory: Map<string, TaskWithComponent[]>,
+): TaskWithComponent[] {
+  const eligible: TaskWithComponent[] = [];
+  const seen = new Set<string>();
+
+  for (const rawCategory of categories ?? []) {
+    const normalizedCategory = normalizeCategory(rawCategory);
+    if (!normalizedCategory) continue;
+
+    for (const task of tasksByCategory.get(normalizedCategory) ?? []) {
+      if (seen.has(task.id)) continue;
+      seen.add(task.id);
+      eligible.push(task);
+    }
+  }
+
+  return eligible;
+}
+
+function orderSectionTasks(
+  eligibleTasks: TaskWithComponent[],
+  configuredTaskIds: string[] | undefined,
+): TaskWithComponent[] {
+  if (!configuredTaskIds || configuredTaskIds.length === 0) {
+    return sortTasks(eligibleTasks);
+  }
+
+  const tasksById = new Map(eligibleTasks.map((task) => [task.id, task]));
+  const ordered: TaskWithComponent[] = [];
+  const used = new Set<string>();
+
+  for (const taskId of configuredTaskIds) {
+    const task = tasksById.get(taskId);
+    if (!task || used.has(task.id)) continue;
+    used.add(task.id);
+    ordered.push(task);
+  }
+
+  const unlisted = eligibleTasks.filter((task) => !used.has(task.id));
+  return [...ordered, ...sortTasks(unlisted)];
+}
+
+function appendUniqueSectionTasks(
+  sectionTasks: TaskWithComponent[],
+  tasks: TaskWithComponent[],
+  usedTaskIds: Set<string>,
+): void {
+  for (const task of tasks) {
+    if (usedTaskIds.has(task.id)) continue;
+    usedTaskIds.add(task.id);
+    sectionTasks.push(task);
+  }
+}
+
 function normalizeCategory(value?: string): string | undefined {
   if (!value) return undefined;
   const normalized = value.trim().toLowerCase();
@@ -147,14 +203,21 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
   // Render configured sections first, honoring the configured section/category order.
   for (const section of configuredSections) {
     const sectionTasks: TaskWithComponent[] = [];
-    for (const rawCategory of section.categories ?? []) {
-      const normalizedCategory = normalizeCategory(rawCategory);
-      if (!normalizedCategory) continue;
-      const categoryTasks = tasksByCategory.get(normalizedCategory) ?? [];
-      for (const task of categoryTasks) {
-        if (usedTaskIds.has(task.id)) continue;
-        usedTaskIds.add(task.id);
-        sectionTasks.push(task);
+    const configuredTaskIds = section.tasks;
+
+    if (configuredTaskIds && configuredTaskIds.length > 0) {
+      const eligibleTasks = collectSectionEligibleTasks(section.categories, tasksByCategory);
+      appendUniqueSectionTasks(
+        sectionTasks,
+        orderSectionTasks(eligibleTasks, configuredTaskIds),
+        usedTaskIds,
+      );
+    } else {
+      for (const rawCategory of section.categories ?? []) {
+        const normalizedCategory = normalizeCategory(rawCategory);
+        if (!normalizedCategory) continue;
+        const categoryTasks = tasksByCategory.get(normalizedCategory) ?? [];
+        appendUniqueSectionTasks(sectionTasks, categoryTasks, usedTaskIds);
       }
     }
 

--- a/platform/scms/docs/create-work-flows.md
+++ b/platform/scms/docs/create-work-flows.md
@@ -131,12 +131,34 @@ Dashboard tasks and My Works dropdown use **different** flags today. PMC task ca
 
 The dashboard loader builds a map of allowed task ids per extension (`task: true` + scopes) and allowed built-in task ids from `dashboard.tasks.builtins`.
 
-Each task renders `task.component` — the component **owns its own click handler**:
+Section layout is configured under `dashboard.tasks.sections`. Each section may include:
 
-| Task | Component | Navigates to |
-|------|-----------|--------------|
-| Check My Work | `AutomatedChecksTaskCard` | `/app/works/new` |
-| PMC Deposit | `PMCDepositTaskCard` | `/app/works/pmc` |
+| Field | Purpose |
+|-------|---------|
+| `title` | Section heading |
+| `categories` | Membership filter — only tasks in these categories appear in the section |
+| `tasks` | Optional ordered list of task **ids** for explicit card order (cross-category). Unlisted eligible tasks append after, sorted alphabetically by id |
+
+Example:
+
+```yaml
+dashboard:
+  tasks:
+    enabled: true
+    builtins:
+      - automated-checks
+    sections:
+      - title: 'Improve and publish your work'
+        categories: [check, publish]
+        tasks:
+          - my-publish-task
+          - automated-checks
+          - my-format-task
+```
+
+Task ids come from each extension's `getTasks()` return value (and from built-in task ids listed in `dashboard.tasks.builtins`). Use the `id` field on `ExtensionTask`, not the display `name`. When adding a new task card, register it in the extension's `getTasks()` and reference that id in app-config.
+
+Each task renders `task.component` — the component **owns its own click handler** (navigation is hardcoded in the card, not derived from `WorkCreateOption.startPath`).
 
 The dashboard does **not** read `WorkCreateOption` or `startPath`.
 


### PR DESCRIPTION
* dashboard task order can be influenced on a paper section basis, falling back to default sort for unlisted card ids
* tweak: changes to (new) positioning on built in card

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard presentation and deploy-time layout config only; no changes to auth, data, or work-creation routing.
> 
> **Overview**
> Deployers can set **explicit task card order** within each dashboard section by adding an optional `tasks` list (task **ids**) under `dashboard.tasks.sections` in app-config. Sections still filter membership via `categories`; when `tasks` is set, cards follow that order (cross-category), and any eligible tasks not listed still appear afterward, sorted by id. When `tasks` is omitted, behavior stays **category order** as before.
> 
> Types, JSON schema, client config allowlisting (`root.tsx`), and **create-work-flows** docs are updated to describe `tasks`, `builtins`, and the section layout fields.
> 
> A shared **`TaskCardNewBadge`** (exported from scms-core) replaces inline styling on the Check My Work built-in card; the NEW badge is **top-right** in the title block with reserved padding so layout stays consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa29f16b52da38e74b8344287325d31c3845cfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->