### PR TITLE
🔜 change redirect to submission listing

### DIFF
--- a/.changeset/sites-default-submissions-redirect.md
+++ b/.changeset/sites-default-submissions-redirect.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-sites-ext': patch
+'@curvenote/scms': patch
+---
+
+Default site landing redirect now sends users to the submissions listing instead of the inbox placeholder.

--- a/ee/sites/src/routes/$siteName._index.tsx
+++ b/ee/sites/src/routes/$siteName._index.tsx
@@ -1,7 +1,8 @@
 import { redirect } from 'react-router';
+import type { LoaderFunctionArgs } from 'react-router';
 
-export function loader() {
-  throw redirect('/app');
+export function loader({ params }: LoaderFunctionArgs) {
+  throw redirect(`/app/sites/${params.siteName}/submissions`);
 }
 
 // TODO is this still needed?

--- a/ee/sites/src/routes/$siteName/route.tsx
+++ b/ee/sites/src/routes/$siteName/route.tsx
@@ -27,7 +27,7 @@ export async function loader(args: LoaderFunctionArgs): Promise<LoaderData | Res
 
   const pathname = new URL(args.request.url).pathname.replace(/\/$/, '');
   if (pathname === `/app/sites/${ctx.site.name}`) {
-    return redirect(`/app/sites/${ctx.site.name}/inbox`);
+    return redirect(`/app/sites/${ctx.site.name}/submissions`);
   }
 
   const menu = await buildMenu(ctx);


### PR DESCRIPTION
We do not yet have an updates Sites > Site > Inbox design, yet the default route is still the inbox. This PR changes the default route to the submissions listing until we have the updated inbox in place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only redirect changes with no auth, data, or API behavior changes.
> 
> **Overview**
> **Default site URLs now land on submissions** instead of the inbox placeholder or generic `/app`, until an updated inbox is ready.
> 
> The site index route loader redirects `/app/sites/:siteName` to **`/app/sites/:siteName/submissions`** (using `siteName` from route params). The parent site layout loader applies the same target when the pathname is exactly the site root (trailing slash normalized), replacing the previous redirect to **`inbox`**.
> 
> A changeset records patch bumps for `@curvenote/scms-sites-ext` and `@curvenote/scms`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5a05963f35689ac4c2f01afd3475eeee119bf3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->