### PR TITLE
🐛 Allow job handshakes to update submission status without explicit site scopes

### DIFF
--- a/.changeset/pmc-deposit-status-callback.md
+++ b/.changeset/pmc-deposit-status-callback.md
@@ -1,0 +1,5 @@
+---
+'@curvenote/scms-server': patch
+---
+
+Allow job handshake tokens to call submission status APIs without site scopes (fixes PMC deposit status callbacks).

--- a/packages/scms-server/src/backend/context.submission.handshake.spec.ts
+++ b/packages/scms-server/src/backend/context.submission.handshake.spec.ts
@@ -4,6 +4,7 @@
  */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { SiteRole } from '@curvenote/scms-db';
 import { Context } from './context.server.js';
 
 const withContext = vi.fn();
@@ -53,6 +54,7 @@ const siteRow = {
 
 const submissionRow = {
   id: 'sub-1',
+  site_id: 'site-1',
   work_id: 'work-1',
   versions: [],
 };
@@ -68,15 +70,28 @@ function makeArgs() {
   } as any;
 }
 
-function makeHandshakeContext(request: Request, handshake: boolean) {
+function makeContext(
+  request: Request,
+  opts: {
+    handshake?: boolean;
+    curvenote?: boolean;
+    user?: Record<string, unknown> | null;
+  } = {},
+) {
   const ctx = new Context({ api: {}, app: {} } as any, {} as any, {} as any, request);
-  ctx.user = {
-    id: 'sa-1',
-    system_role: null,
-    site_roles: [],
-    work_roles: [],
-  } as any;
-  if (handshake) {
+  if (opts.user === null) {
+    ctx.user = undefined;
+  } else if (opts.user !== undefined) {
+    ctx.user = opts.user as any;
+  } else {
+    ctx.user = {
+      id: 'sa-1',
+      system_role: null,
+      site_roles: [],
+      work_roles: [],
+    } as any;
+  }
+  if (opts.handshake) {
     (ctx as any).$verifiedHandshakeToken = 'handshake-token';
     (ctx as any).$handshakeClaims = {
       audience: 'jobs',
@@ -84,7 +99,23 @@ function makeHandshakeContext(request: Request, handshake: boolean) {
       jobId: 'job-1',
     };
   }
+  if (opts.curvenote) {
+    (ctx as any).$verifiedCurvenoteToken = 'curvenote-token';
+  }
   return ctx;
+}
+
+function userWithSiteAdmin(siteId = 'site-1') {
+  return {
+    id: 'user-1',
+    system_role: null,
+    site_roles: [{ site_id: siteId, site: { name: 'pmc', id: siteId }, role: SiteRole.ADMIN }],
+    work_roles: [],
+    roles: [],
+    disabled: false,
+    pending: false,
+    ready_for_approval: false,
+  };
 }
 
 describe('withAPISubmissionContext handshake', () => {
@@ -97,7 +128,7 @@ describe('withAPISubmissionContext handshake', () => {
 
   test('allows handshake without site scopes when allowHandshake is true', async () => {
     const args = makeArgs();
-    withContext.mockResolvedValue(makeHandshakeContext(args.request, true));
+    withContext.mockResolvedValue(makeContext(args.request, { handshake: true }));
 
     const ctx = await withAPISubmissionContext(args, [site.submissions.update], {
       allowHandshake: true,
@@ -105,21 +136,24 @@ describe('withAPISubmissionContext handshake', () => {
 
     expect(ctx.submission.id).toBe('sub-1');
     expect(ctx.site.name).toBe('pmc');
+    expect(withContext).toHaveBeenCalledTimes(1);
   });
 
   test('rejects handshake when allowHandshake is not set', async () => {
     const args = makeArgs();
-    withContext.mockResolvedValue(makeHandshakeContext(args.request, true));
+    withContext.mockResolvedValue(makeContext(args.request, { handshake: true }));
 
     // Falls through to withAppSubmissionContext; SA has no site scopes → 404
     await expect(withAPISubmissionContext(args, [site.submissions.update])).rejects.toMatchObject({
       status: 404,
     });
+    // Outer withContext skipped when allowHandshake is unset — only app path resolves once
+    expect(withContext).toHaveBeenCalledTimes(1);
   });
 
   test('still 404s when submission is missing even with handshake', async () => {
     const args = makeArgs();
-    withContext.mockResolvedValue(makeHandshakeContext(args.request, true));
+    withContext.mockResolvedValue(makeContext(args.request, { handshake: true }));
     dbGetSubmission.mockResolvedValue(null);
 
     await expect(
@@ -127,5 +161,55 @@ describe('withAPISubmissionContext handshake', () => {
         allowHandshake: true,
       }),
     ).rejects.toMatchObject({ status: 404 });
+  });
+
+  test('404 when submission belongs to a different site', async () => {
+    const args = makeArgs();
+    withContext.mockResolvedValue(makeContext(args.request, { handshake: true }));
+    dbGetSubmission.mockResolvedValue({ ...submissionRow, site_id: 'other-site' });
+
+    await expect(
+      withAPISubmissionContext(args, [site.submissions.update], {
+        allowHandshake: true,
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('withAPISubmissionContext user auth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbGetSite.mockResolvedValue(siteRow);
+    dbGetSubmission.mockResolvedValue(submissionRow);
+    dbGetWork.mockResolvedValue(workRow);
+  });
+
+  test('succeeds for curvenote-authorized user with matching site scope', async () => {
+    const args = makeArgs();
+    withContext.mockResolvedValue(
+      makeContext(args.request, {
+        curvenote: true,
+        user: userWithSiteAdmin(),
+      }),
+    );
+
+    const ctx = await withAPISubmissionContext(args, [site.submissions.update]);
+    expect(ctx.submission.id).toBe('sub-1');
+    expect(ctx.site.id).toBe('site-1');
+    expect(withContext).toHaveBeenCalledTimes(1);
+  });
+
+  test('401 when curvenote token is missing', async () => {
+    const args = makeArgs();
+    withContext.mockResolvedValue(
+      makeContext(args.request, {
+        curvenote: false,
+        user: userWithSiteAdmin(),
+      }),
+    );
+
+    await expect(withAPISubmissionContext(args, [site.submissions.update])).rejects.toMatchObject({
+      status: 401,
+    });
   });
 });

--- a/packages/scms-server/src/backend/context.submission.handshake.spec.ts
+++ b/packages/scms-server/src/backend/context.submission.handshake.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * Handshake tokens must be able to update submission status (job callbacks)
+ * without holding site:submissions:update on the site — matching withAPISiteContext.
+ */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { Context } from './context.server.js';
+
+const withContext = vi.fn();
+const dbGetSite = vi.fn();
+const dbGetSubmission = vi.fn();
+const dbGetWork = vi.fn();
+
+vi.mock('./context.server.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    withContext: (...args: unknown[]) => withContext(...args),
+  };
+});
+
+vi.mock('./loaders/sites/get.server.js', () => ({
+  dbGetSite: (...args: unknown[]) => dbGetSite(...args),
+  dbGetUserSiteRoles: vi.fn(),
+}));
+
+vi.mock('./loaders/sites/submissions/get.server.js', () => ({
+  dbGetSubmission: (...args: unknown[]) => dbGetSubmission(...args),
+  formatSubmissionDTO: vi.fn(),
+}));
+
+vi.mock('./loaders/works/get.server.js', () => ({
+  dbGetWork: (...args: unknown[]) => dbGetWork(...args),
+  dbGetUserWorkRoles: vi.fn(),
+  formatWorkDTO: vi.fn(),
+  getCanonicalOrLatestVersion: vi.fn(),
+}));
+
+vi.mock('./loaders/sites/submissions/versions/get.server.js', () => ({
+  formatSubmissionVersionDTO: vi.fn(),
+}));
+
+import { withAPISubmissionContext } from './context.submission.server.js';
+import { site } from '@curvenote/scms-core';
+
+const siteRow = {
+  id: 'site-1',
+  name: 'pmc',
+  private: true,
+  restricted: true,
+  metadata: { title: 'PMC' },
+};
+
+const submissionRow = {
+  id: 'sub-1',
+  work_id: 'work-1',
+  versions: [],
+};
+
+const workRow = { id: 'work-1', versions: [] };
+
+function makeArgs() {
+  return {
+    params: { siteName: 'pmc', submissionId: 'sub-1' },
+    request: new Request('https://example.com/v1/sites/pmc/submissions/sub-1/status', {
+      method: 'PUT',
+    }),
+  } as any;
+}
+
+function makeHandshakeContext(request: Request, handshake: boolean) {
+  const ctx = new Context({ api: {}, app: {} } as any, {} as any, {} as any, request);
+  ctx.user = {
+    id: 'sa-1',
+    system_role: null,
+    site_roles: [],
+    work_roles: [],
+  } as any;
+  if (handshake) {
+    (ctx as any).$verifiedHandshakeToken = 'handshake-token';
+    (ctx as any).$handshakeClaims = {
+      audience: 'jobs',
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      jobId: 'job-1',
+    };
+  }
+  return ctx;
+}
+
+describe('withAPISubmissionContext handshake', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbGetSite.mockResolvedValue(siteRow);
+    dbGetSubmission.mockResolvedValue(submissionRow);
+    dbGetWork.mockResolvedValue(workRow);
+  });
+
+  test('allows handshake without site scopes when allowHandshake is true', async () => {
+    const args = makeArgs();
+    withContext.mockResolvedValue(makeHandshakeContext(args.request, true));
+
+    const ctx = await withAPISubmissionContext(args, [site.submissions.update], {
+      allowHandshake: true,
+    });
+
+    expect(ctx.submission.id).toBe('sub-1');
+    expect(ctx.site.name).toBe('pmc');
+  });
+
+  test('rejects handshake when allowHandshake is not set', async () => {
+    const args = makeArgs();
+    withContext.mockResolvedValue(makeHandshakeContext(args.request, true));
+
+    // Falls through to withAppSubmissionContext; SA has no site scopes → 404
+    await expect(withAPISubmissionContext(args, [site.submissions.update])).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  test('still 404s when submission is missing even with handshake', async () => {
+    const args = makeArgs();
+    withContext.mockResolvedValue(makeHandshakeContext(args.request, true));
+    dbGetSubmission.mockResolvedValue(null);
+
+    await expect(
+      withAPISubmissionContext(args, [site.submissions.update], {
+        allowHandshake: true,
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/packages/scms-server/src/backend/context.submission.server.ts
+++ b/packages/scms-server/src/backend/context.submission.server.ts
@@ -210,22 +210,27 @@ export async function withAPISubmissionContext<T extends LoaderFunctionArgs | Ac
   scopes: string[],
   opts?: { allowHandshake?: boolean },
 ): Promise<SubmissionContext> {
-  const ctx = await withContext(args);
+  // Only resolve context here when the handshake shortcut is possible — otherwise
+  // withAppSubmissionContext would call withContext a second time (JWT + DB + provision).
+  if (opts?.allowHandshake) {
+    const ctx = await withContext(args);
+    if (ctx.authorized.handshake) {
+      const { siteName, submissionId } = args.params;
+      if (!siteName) throw httpError(400, 'Missing site name');
+      if (!submissionId) throw httpError(400, 'Missing submission ID');
 
-  if (opts?.allowHandshake && ctx.authorized.handshake) {
-    const { siteName, submissionId } = args.params;
-    if (!siteName) throw httpError(400, 'Missing site name');
-    if (!submissionId) throw httpError(400, 'Missing submission ID');
+      const site = await dbGetSite(siteName);
+      const submission = await dbGetSubmission({ id: submissionId });
+      if (!site || !site.metadata || !submission) throw error404();
+      // URL site must own the submission — prevents cross-site context via handshake
+      if (submission.site_id !== site.id) throw error404();
 
-    const site = await dbGetSite(siteName);
-    const submission = await dbGetSubmission({ id: submissionId });
-    if (!site || !site.metadata || !submission) throw error404();
+      const workId = submission.work_id ?? submission.versions[0]?.work_version?.work_id;
+      const work = await dbGetWork(workId);
+      if (!work) throw error404();
 
-    const workId = submission.work_id ?? submission.versions[0]?.work_version?.work_id;
-    const work = await dbGetWork(workId);
-    if (!work) throw error404();
-
-    return new SubmissionContext(ctx, site, work, submission);
+      return new SubmissionContext(ctx, site, work, submission);
+    }
   }
 
   const submissionCtx = await withAppSubmissionContext(args, scopes, { redirect: false });

--- a/packages/scms-server/src/backend/context.submission.server.ts
+++ b/packages/scms-server/src/backend/context.submission.server.ts
@@ -201,14 +201,34 @@ export async function withAppSubmissionContext<T extends LoaderFunctionArgs | Ac
  *
  * Validates the user is defined and has correctly scoped access to the submission, either
  * via the site or the work.
+ *
+ * When `allowHandshake` is true, a valid job handshake token may act without site scopes
+ * (same pattern as `withAPISiteContext`) so workers can call status callbacks.
  */
 export async function withAPISubmissionContext<T extends LoaderFunctionArgs | ActionFunctionArgs>(
   args: T,
   scopes: string[],
   opts?: { allowHandshake?: boolean },
 ): Promise<SubmissionContext> {
-  const ctx = await withAppSubmissionContext(args, scopes, { redirect: false });
-  const authorizedByHandshake = opts?.allowHandshake && ctx.authorized.handshake;
-  if (!authorizedByHandshake && !ctx.authorized.curvenote) throw error401();
-  return ctx;
+  const ctx = await withContext(args);
+
+  if (opts?.allowHandshake && ctx.authorized.handshake) {
+    const { siteName, submissionId } = args.params;
+    if (!siteName) throw httpError(400, 'Missing site name');
+    if (!submissionId) throw httpError(400, 'Missing submission ID');
+
+    const site = await dbGetSite(siteName);
+    const submission = await dbGetSubmission({ id: submissionId });
+    if (!site || !site.metadata || !submission) throw error404();
+
+    const workId = submission.work_id ?? submission.versions[0]?.work_version?.work_id;
+    const work = await dbGetWork(workId);
+    if (!work) throw error404();
+
+    return new SubmissionContext(ctx, site, work, submission);
+  }
+
+  const submissionCtx = await withAppSubmissionContext(args, scopes, { redirect: false });
+  if (!submissionCtx.authorized.curvenote) throw error401();
+  return submissionCtx;
 }


### PR DESCRIPTION
handshakes remain scoped to sites and jobId over their limited time window

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes API authorization for submission endpoints when `allowHandshake` is enabled; mitigated by opt-in per route, handshake token constraints, and submission–site binding checks.
> 
> **Overview**
> Fixes **PMC deposit status callbacks** where job workers use handshake tokens but lack `site:submissions:update` on the site.
> 
> `withAPISubmissionContext` now mirrors `withAPISiteContext`: when callers pass **`allowHandshake: true`**, a valid job handshake can build submission context **without** site-scope checks. The handshake path still loads site, submission, and work from the URL and returns **404** if the submission is missing or its `site_id` does not match the site in the path (blocks cross-site use). User/Curvenote auth is unchanged: without the handshake shortcut, the handler still goes through `withAppSubmissionContext` and requires a Curvenote token (**401** if missing).
> 
> A changeset and **Vitest** coverage document allow/reject behavior, missing submission, cross-site mismatch, and normal user auth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce6a11df9bf994ea4d9252027dc318aa7ffba26e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->