### PR TITLE
Enable extensions registered jobs to be PATCHed

### DIFF
--- a/.changeset/job-on-job-patch.md
+++ b/.changeset/job-on-job-patch.md
@@ -1,0 +1,6 @@
+---
+'@curvenote/scms-core': patch
+'@curvenote/scms-server': patch
+---
+
+Add optional `JobRegistration.onJobPatch` hook invoked after `PATCH /api/v1/jobs/:jobId` so extension jobs can map worker updates onto metadata.

--- a/packages/scms-core/src/modules/extensions/types.ts
+++ b/packages/scms-core/src/modules/extensions/types.ts
@@ -593,6 +593,23 @@ export type JobRegistration = {
   jobType: string;
   handler: (ctx: Context, data: CreateJob, storageBackend?: StorageBackend) => Promise<any>;
   requiresStorageBackend?: boolean;
+  /**
+   * Optional hook invoked after a successful `PATCH /api/v1/jobs/:jobId` for this job type.
+   * Used by external workers (e.g. Foundry) to drive extension metadata from job updates.
+   */
+  onJobPatch?: (args: {
+    ctx: Context;
+    job: {
+      id: string;
+      job_type: string;
+      status: string;
+      payload: unknown;
+      results: unknown;
+      messages: unknown;
+    };
+    priorStatus: string;
+    update: { status: string; message?: string; results?: Record<string, any> };
+  }) => Promise<void>;
 };
 
 export interface InboundEmail {

--- a/packages/scms-server/src/backend/loaders/jobs/update.server.ts
+++ b/packages/scms-server/src/backend/loaders/jobs/update.server.ts
@@ -21,17 +21,43 @@ export default async function (
   ctx: Context,
   jobId: string,
   data: UpdateJob,
-  _extensionJobs?: JobRegistration[],
+  extensionJobs?: JobRegistration[],
 ) {
   const prisma = await getPrismaClient();
   const prior = await prisma.job.findUnique({
     where: { id: jobId },
-    select: { status: true },
+    select: { status: true, job_type: true },
   });
   if (!prior) throw error404();
 
   const dbo = await dbUpdateJob(jobId, data);
   if (!dbo) throw error404();
+
+  const registration = (extensionJobs ?? []).find((j) => j.jobType === dbo.job_type);
+  if (registration?.onJobPatch) {
+    try {
+      await registration.onJobPatch({
+        ctx,
+        job: {
+          id: dbo.id,
+          job_type: dbo.job_type,
+          status: dbo.status,
+          payload: dbo.payload,
+          results: dbo.results,
+          messages: dbo.messages,
+        },
+        priorStatus: prior.status,
+        update: data,
+      });
+    } catch (err) {
+      console.error('[jobs.update] onJobPatch failed', {
+        jobId,
+        job_type: dbo.job_type,
+        err,
+      });
+      throw err;
+    }
+  }
 
   if (isTerminalStatus(dbo.status) && !isTerminalStatus(prior.status)) {
     await onJobTerminal(jobId, dbo.status);

--- a/packages/scms-server/tests/jobs/updateJob.test.ts
+++ b/packages/scms-server/tests/jobs/updateJob.test.ts
@@ -36,6 +36,9 @@ vi.mock('../../src/backend/loaders/jobs/get.server.js', () => ({
 
 import updateJob from '../../src/backend/loaders/jobs/update.server.js';
 
+const EXT_JOB = 'ACME_WORKER';
+const OTHER_JOB = 'WIDGET_TASK';
+
 describe('updateJob terminal handling', () => {
   beforeEach(() => {
     mockFindUnique.mockReset();
@@ -49,7 +52,7 @@ describe('updateJob terminal handling', () => {
   });
 
   test('runs onJobTerminal only on the first transition to a terminal status', async () => {
-    mockFindUnique.mockResolvedValue({ status: JobStatus.FAILED });
+    mockFindUnique.mockResolvedValue({ status: JobStatus.FAILED, job_type: 'PUBLISH' });
     mockDbUpdateJob.mockResolvedValue({
       id: 'job-1',
       status: JobStatus.FAILED,
@@ -63,7 +66,7 @@ describe('updateJob terminal handling', () => {
   });
 
   test('invokes onJobTerminal when status newly becomes terminal', async () => {
-    mockFindUnique.mockResolvedValue({ status: JobStatus.RUNNING });
+    mockFindUnique.mockResolvedValue({ status: JobStatus.RUNNING, job_type: 'PUBLISH' });
     const dbo = {
       id: 'job-1',
       status: JobStatus.FAILED,
@@ -79,7 +82,10 @@ describe('updateJob terminal handling', () => {
   });
 
   test('invokes onJobTerminal when status newly becomes CANCELLED', async () => {
-    mockFindUnique.mockResolvedValue({ status: JobStatus.RUNNING });
+    mockFindUnique.mockResolvedValue({
+      status: JobStatus.RUNNING,
+      job_type: KnownJobTypes.CONVERTER_TASK,
+    });
     const dbo = {
       id: 'job-1',
       status: JobStatus.CANCELLED,
@@ -92,5 +98,104 @@ describe('updateJob terminal handling', () => {
     expect(mockOnJobTerminal).toHaveBeenCalledOnce();
     expect(mockOnJobTerminal).toHaveBeenCalledWith('job-1', JobStatus.CANCELLED);
     expect(mockRecordConverterTaskTerminalActivity).toHaveBeenCalledOnce();
+  });
+});
+
+describe('updateJob onJobPatch', () => {
+  const onJobPatch = vi.fn(async () => undefined);
+
+  beforeEach(() => {
+    mockFindUnique.mockReset();
+    mockDbUpdateJob.mockReset();
+    mockOnJobTerminal.mockReset();
+    mockRecordConverterTaskTerminalActivity.mockReset();
+    mockFormatJobDTO.mockReset();
+    onJobPatch.mockReset();
+    onJobPatch.mockResolvedValue(undefined);
+    mockOnJobTerminal.mockResolvedValue(undefined);
+    mockRecordConverterTaskTerminalActivity.mockResolvedValue(undefined);
+    mockFormatJobDTO.mockReturnValue({ id: 'job-1' });
+  });
+
+  test('invokes matching extension onJobPatch after db update', async () => {
+    mockFindUnique.mockResolvedValue({ status: JobStatus.RUNNING, job_type: EXT_JOB });
+    const dbo = {
+      id: 'job-1',
+      job_type: EXT_JOB,
+      status: JobStatus.RUNNING,
+      payload: { work_id: 'w1' },
+      results: { phase: 'readyForReview' },
+      messages: [],
+    };
+    mockDbUpdateJob.mockResolvedValue(dbo);
+    const update = {
+      status: JobStatus.RUNNING,
+      results: { phase: 'readyForReview' },
+    };
+
+    await updateJob({} as never, 'job-1', update, [
+      {
+        jobType: EXT_JOB,
+        handler: vi.fn() as never,
+        onJobPatch,
+      },
+      {
+        jobType: OTHER_JOB,
+        handler: vi.fn() as never,
+        onJobPatch: vi.fn(),
+      },
+    ]);
+
+    expect(onJobPatch).toHaveBeenCalledOnce();
+    expect(onJobPatch).toHaveBeenCalledWith({
+      ctx: expect.anything(),
+      job: {
+        id: 'job-1',
+        job_type: EXT_JOB,
+        status: JobStatus.RUNNING,
+        payload: { work_id: 'w1' },
+        results: { phase: 'readyForReview' },
+        messages: [],
+      },
+      priorStatus: JobStatus.RUNNING,
+      update,
+    });
+  });
+
+  test('skips onJobPatch when job type has no registration', async () => {
+    mockFindUnique.mockResolvedValue({ status: JobStatus.RUNNING, job_type: EXT_JOB });
+    mockDbUpdateJob.mockResolvedValue({
+      id: 'job-1',
+      job_type: EXT_JOB,
+      status: JobStatus.RUNNING,
+      payload: {},
+      results: null,
+      messages: [],
+    });
+
+    await updateJob({} as never, 'job-1', { status: JobStatus.RUNNING }, [
+      { jobType: OTHER_JOB, handler: vi.fn() as never, onJobPatch },
+    ]);
+
+    expect(onJobPatch).not.toHaveBeenCalled();
+  });
+
+  test('rethrows when onJobPatch fails', async () => {
+    mockFindUnique.mockResolvedValue({ status: JobStatus.RUNNING, job_type: EXT_JOB });
+    mockDbUpdateJob.mockResolvedValue({
+      id: 'job-1',
+      job_type: EXT_JOB,
+      status: JobStatus.RUNNING,
+      payload: {},
+      results: null,
+      messages: [],
+    });
+    onJobPatch.mockRejectedValue(new Error('hook blew up'));
+
+    await expect(
+      updateJob({} as never, 'job-1', { status: JobStatus.RUNNING }, [
+        { jobType: EXT_JOB, handler: vi.fn() as never, onJobPatch },
+      ]),
+    ).rejects.toThrow('hook blew up');
   });
 });


### PR DESCRIPTION
- **✨ Add JobRegistration.onJobPatch for Foundry jobStatus callbacks**
- **✅ Cover JobRegistration.onJobPatch in updateJob tests**
